### PR TITLE
Implement upstream change propagation

### DIFF
--- a/lib/storybox/stories/character.ex
+++ b/lib/storybox/stories/character.ex
@@ -1,7 +1,8 @@
 defmodule Storybox.Stories.Character do
   use Ash.Resource,
     domain: Storybox.Stories,
-    data_layer: AshPostgres.DataLayer
+    data_layer: AshPostgres.DataLayer,
+    notifiers: [Storybox.Stories.Notifiers.PropagateUpstreamChange]
 
   postgres do
     table "characters"

--- a/lib/storybox/stories/notifiers/propagate_upstream_change.ex
+++ b/lib/storybox/stories/notifiers/propagate_upstream_change.ex
@@ -1,0 +1,98 @@
+defmodule Storybox.Stories.Notifiers.PropagateUpstreamChange do
+  use Ash.Notifier
+
+  require Ash.Query
+
+  alias Storybox.Stories.{
+    ScenePiece,
+    SceneVersion,
+    SequencePiece,
+    SequenceVersion,
+    UpstreamChange
+  }
+
+  @impl true
+  def notify(%Ash.Notifier.Notification{
+        action: %{type: :update},
+        resource: resource,
+        data: record,
+        changeset: changeset
+      }) do
+    {story_id, component_type, component_id} = component_info(resource, record)
+    version_before = to_string(changeset.data.updated_at)
+    version_after = to_string(record.updated_at)
+
+    propagate(story_id, component_type, component_id, version_before, version_after)
+  end
+
+  def notify(_), do: :ok
+
+  defp component_info(Storybox.Stories.Story, record), do: {record.id, :story, record.id}
+
+  defp component_info(Storybox.Stories.Character, record),
+    do: {record.story_id, :character, record.id}
+
+  defp component_info(Storybox.Stories.World, record), do: {record.story_id, :world, record.id}
+
+  defp propagate(story_id, component_type, component_id, version_before, version_after) do
+    sequence_pieces =
+      SequencePiece
+      |> Ash.Query.filter(story_id == ^story_id)
+      |> Ash.read!()
+
+    for sp <- sequence_pieces do
+      sequence_versions =
+        SequenceVersion
+        |> Ash.Query.filter(sequence_piece_id == ^sp.id)
+        |> Ash.read!()
+
+      for sv <- sequence_versions do
+        sv
+        |> Ash.Changeset.for_update(:mark_stale, %{})
+        |> Ash.update!()
+
+        UpstreamChange
+        |> Ash.Changeset.for_create(:create, %{
+          piece_version_type: :sequence_version,
+          piece_version_id: sv.id,
+          component_type: component_type,
+          component_id: component_id,
+          version_before: version_before,
+          version_after: version_after
+        })
+        |> Ash.create!()
+      end
+
+      scene_pieces =
+        ScenePiece
+        |> Ash.Query.filter(sequence_piece_id == ^sp.id)
+        |> Ash.read!()
+
+      for scene_piece <- scene_pieces do
+        scene_versions =
+          SceneVersion
+          |> Ash.Query.filter(scene_piece_id == ^scene_piece.id)
+          |> Ash.read!()
+
+        for sv <- scene_versions do
+          sv
+          |> Ash.Changeset.for_update(:mark_stale, %{})
+          |> Ash.update!()
+
+          UpstreamChange
+          |> Ash.Changeset.for_create(:create, %{
+            piece_version_type: :scene_version,
+            piece_version_id: sv.id,
+            component_type: component_type,
+            component_id: component_id,
+            version_before: version_before,
+            version_after: version_after
+          })
+          |> Ash.create!()
+        end
+      end
+    end
+
+    :ok
+  end
+end

--- a/lib/storybox/stories/scene_version.ex
+++ b/lib/storybox/stories/scene_version.ex
@@ -34,5 +34,9 @@ defmodule Storybox.Stories.SceneVersion do
     create :create do
       accept [:scene_piece_id, :content_uri, :version_number, :upstream_status, :weights]
     end
+
+    update :mark_stale do
+      change set_attribute(:upstream_status, :stale)
+    end
   end
 end

--- a/lib/storybox/stories/sequence_version.ex
+++ b/lib/storybox/stories/sequence_version.ex
@@ -34,5 +34,9 @@ defmodule Storybox.Stories.SequenceVersion do
     create :create do
       accept [:sequence_piece_id, :content_uri, :version_number, :upstream_status, :weights]
     end
+
+    update :mark_stale do
+      change set_attribute(:upstream_status, :stale)
+    end
   end
 end

--- a/lib/storybox/stories/story.ex
+++ b/lib/storybox/stories/story.ex
@@ -1,7 +1,8 @@
 defmodule Storybox.Stories.Story do
   use Ash.Resource,
     domain: Storybox.Stories,
-    data_layer: AshPostgres.DataLayer
+    data_layer: AshPostgres.DataLayer,
+    notifiers: [Storybox.Stories.Notifiers.PropagateUpstreamChange]
 
   postgres do
     table "stories"

--- a/lib/storybox/stories/world.ex
+++ b/lib/storybox/stories/world.ex
@@ -1,7 +1,8 @@
 defmodule Storybox.Stories.World do
   use Ash.Resource,
     domain: Storybox.Stories,
-    data_layer: AshPostgres.DataLayer
+    data_layer: AshPostgres.DataLayer,
+    notifiers: [Storybox.Stories.Notifiers.PropagateUpstreamChange]
 
   postgres do
     table "worlds"

--- a/test/storybox/stories/upstream_change_propagation_test.exs
+++ b/test/storybox/stories/upstream_change_propagation_test.exs
@@ -1,0 +1,238 @@
+defmodule Storybox.Stories.UpstreamChangePropagationTest do
+  use Storybox.DataCase
+
+  require Ash.Query
+
+  alias Storybox.Stories.{
+    Character,
+    ScenePiece,
+    SceneVersion,
+    SequencePiece,
+    SequenceVersion,
+    Story,
+    UpstreamChange,
+    World
+  }
+
+  setup do
+    {:ok, user} =
+      Storybox.Accounts.User
+      |> Ash.Changeset.for_create(:register_with_password, %{
+        email: "test@example.com",
+        password: "password123!",
+        password_confirmation: "password123!"
+      })
+      |> Ash.create()
+
+    {:ok, story} =
+      Story
+      |> Ash.Changeset.for_create(:create, %{title: "Test Story", user_id: user.id})
+      |> Ash.create()
+
+    {:ok, character} =
+      Character
+      |> Ash.Changeset.for_create(:create, %{name: "Hero", story_id: story.id})
+      |> Ash.create()
+
+    {:ok, world} =
+      World
+      |> Ash.Changeset.for_create(:create, %{history: "Ancient times", story_id: story.id})
+      |> Ash.create()
+
+    {:ok, sequence} =
+      SequencePiece
+      |> Ash.Changeset.for_create(:create, %{title: "Act 1", position: 1, story_id: story.id})
+      |> Ash.create()
+
+    {:ok, sequence_version} =
+      SequenceVersion
+      |> Ash.Changeset.for_create(:create, %{
+        sequence_piece_id: sequence.id,
+        content_uri: "storybox://stories/#{story.id}/sequences/#{sequence.id}/v1",
+        version_number: 1
+      })
+      |> Ash.create()
+
+    {:ok, scene} =
+      ScenePiece
+      |> Ash.Changeset.for_create(:create, %{
+        title: "Scene 1",
+        position: 1,
+        sequence_piece_id: sequence.id
+      })
+      |> Ash.create()
+
+    {:ok, scene_version} =
+      SceneVersion
+      |> Ash.Changeset.for_create(:create, %{
+        scene_piece_id: scene.id,
+        content_uri: "storybox://stories/#{story.id}/scenes/#{scene.id}/v1",
+        version_number: 1
+      })
+      |> Ash.create()
+
+    %{
+      story: story,
+      character: character,
+      world: world,
+      sequence_version: sequence_version,
+      scene_version: scene_version
+    }
+  end
+
+  describe "story update propagation" do
+    test "marks all sequence_versions stale", %{story: story, sequence_version: sv} do
+      assert sv.upstream_status == :current
+
+      story
+      |> Ash.Changeset.for_update(:update, %{title: "Updated Title"})
+      |> Ash.update!()
+
+      updated = Ash.get!(SequenceVersion, sv.id)
+      assert updated.upstream_status == :stale
+    end
+
+    test "marks all scene_versions stale", %{story: story, scene_version: sv} do
+      assert sv.upstream_status == :current
+
+      story
+      |> Ash.Changeset.for_update(:update, %{title: "Updated Title"})
+      |> Ash.update!()
+
+      updated = Ash.get!(SceneVersion, sv.id)
+      assert updated.upstream_status == :stale
+    end
+
+    test "creates UpstreamChange for sequence_version with component_type :story", %{
+      story: story,
+      sequence_version: sv
+    } do
+      story
+      |> Ash.Changeset.for_update(:update, %{logline: "New logline"})
+      |> Ash.update!()
+
+      assert {:ok, [change]} =
+               UpstreamChange
+               |> Ash.Query.filter(
+                 piece_version_type == :sequence_version and piece_version_id == ^sv.id
+               )
+               |> Ash.read()
+
+      assert change.component_type == :story
+      assert change.component_id == story.id
+      assert change.acknowledged == false
+      assert is_binary(change.version_before)
+      assert is_binary(change.version_after)
+      assert change.version_before != change.version_after
+    end
+
+    test "creates UpstreamChange for scene_version with component_type :story", %{
+      story: story,
+      scene_version: sv
+    } do
+      story
+      |> Ash.Changeset.for_update(:update, %{logline: "New logline"})
+      |> Ash.update!()
+
+      assert {:ok, [change]} =
+               UpstreamChange
+               |> Ash.Query.filter(
+                 piece_version_type == :scene_version and piece_version_id == ^sv.id
+               )
+               |> Ash.read()
+
+      assert change.component_type == :story
+      assert change.component_id == story.id
+    end
+  end
+
+  describe "character update propagation" do
+    test "marks sequence_versions stale", %{character: character, sequence_version: sv} do
+      character
+      |> Ash.Changeset.for_update(:update, %{essence: "Brave"})
+      |> Ash.update!()
+
+      updated = Ash.get!(SequenceVersion, sv.id)
+      assert updated.upstream_status == :stale
+    end
+
+    test "marks scene_versions stale", %{character: character, scene_version: sv} do
+      character
+      |> Ash.Changeset.for_update(:update, %{essence: "Brave"})
+      |> Ash.update!()
+
+      updated = Ash.get!(SceneVersion, sv.id)
+      assert updated.upstream_status == :stale
+    end
+
+    test "creates UpstreamChange with component_type :character", %{
+      character: character,
+      sequence_version: sv
+    } do
+      character
+      |> Ash.Changeset.for_update(:update, %{essence: "Brave"})
+      |> Ash.update!()
+
+      assert {:ok, [change]} =
+               UpstreamChange
+               |> Ash.Query.filter(
+                 piece_version_type == :sequence_version and piece_version_id == ^sv.id
+               )
+               |> Ash.read()
+
+      assert change.component_type == :character
+      assert change.component_id == character.id
+    end
+  end
+
+  describe "world update propagation" do
+    test "marks sequence_versions stale", %{world: world, sequence_version: sv} do
+      world
+      |> Ash.Changeset.for_update(:update, %{rules: "Magic is real"})
+      |> Ash.update!()
+
+      updated = Ash.get!(SequenceVersion, sv.id)
+      assert updated.upstream_status == :stale
+    end
+
+    test "marks scene_versions stale", %{world: world, scene_version: sv} do
+      world
+      |> Ash.Changeset.for_update(:update, %{rules: "Magic is real"})
+      |> Ash.update!()
+
+      updated = Ash.get!(SceneVersion, sv.id)
+      assert updated.upstream_status == :stale
+    end
+
+    test "creates UpstreamChange with component_type :world", %{
+      world: world,
+      scene_version: sv
+    } do
+      world
+      |> Ash.Changeset.for_update(:update, %{rules: "Magic is real"})
+      |> Ash.update!()
+
+      assert {:ok, [change]} =
+               UpstreamChange
+               |> Ash.Query.filter(
+                 piece_version_type == :scene_version and piece_version_id == ^sv.id
+               )
+               |> Ash.read()
+
+      assert change.component_type == :world
+      assert change.component_id == world.id
+    end
+  end
+
+  describe "no propagation on create" do
+    test "creating a story does not create UpstreamChange records", %{story: story} do
+      # story was created in setup — confirm no changes were triggered
+      assert {:ok, changes} =
+               UpstreamChange
+               |> Ash.Query.filter(component_type == :story and component_id == ^story.id)
+               |> Ash.read()
+
+      assert changes == []
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `Storybox.Stories.Notifiers.PropagateUpstreamChange` — an Ash notifier attached to Story, Character, and World via the `notifiers:` use-option
- On any `:update` to those resources, the notifier walks the downstream graph (SequencePieces → SequenceVersions + ScenePieces → SceneVersions) and marks every version `:stale`
- Adds a `:mark_stale` update action to `SequenceVersion` and `SceneVersion` for this purpose
- Creates an `UpstreamChange` record per affected version capturing `component_type`, `component_id`, and `version_before`/`version_after` as ISO8601 `updated_at` timestamps

## Key decisions

- **`version_before`/`version_after` as timestamps** — Story/Character/World have no version counter; `updated_at` is the most meaningful before/after marker available without adding extra fields
- **Notifier fires on all updates, no field-level filtering** — simple and correct for MVP; overly aggressive but never incorrect
- **Synchronous execution** — Ash notifiers run in the same process after the transaction, so no async complexity needed

## Trade-offs / deferred

- If Story has many sequences and scenes, a single update triggers N×M DB writes; acceptable for MVP story sizes
- No UI surface — staleness rendering deferred to #21 (LiveView: treatment view)

closes #11

## Test plan

- [x] `mix precommit` passes (68 tests, 0 failures)
- [x] Story update → all SequenceVersions and SceneVersions marked `:stale`
- [x] Character update → propagates with `component_type: :character`
- [x] World update → propagates with `component_type: :world`
- [x] `UpstreamChange` records created with correct fields and `acknowledged: false`
- [x] No propagation triggered on `:create`

🤖 Generated with [Claude Code](https://claude.com/claude-code)