### PR TITLE
MinIO integration for piece content

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -53,6 +53,8 @@ config :ex_aws, :s3,
   host: "localhost",
   port: 9000
 
+config :storybox, minio_bucket: "storybox-pieces"
+
 # Ash formatter plugin
 config :ash, :formatter, extensions: [Ash.Formatter]
 

--- a/lib/storybox/storage.ex
+++ b/lib/storybox/storage.ex
@@ -1,0 +1,35 @@
+defmodule Storybox.Storage do
+  @bucket Application.compile_env(:storybox, :minio_bucket, "storybox-pieces")
+
+  def uri_for_sequence(story_id, piece_id, version_number) do
+    "storybox://stories/#{story_id}/sequences/#{piece_id}/v#{version_number}.fountain"
+  end
+
+  def uri_for_scene(story_id, piece_id, version_number) do
+    "storybox://stories/#{story_id}/scenes/#{piece_id}/v#{version_number}.fountain"
+  end
+
+  def uri_for_synopsis(story_id, version_number) do
+    "storybox://stories/#{story_id}/synopsis/v#{version_number}.fountain"
+  end
+
+  def uri_to_path("storybox://" <> path), do: path
+
+  def put_content(uri, content) do
+    path = uri_to_path(uri)
+
+    case ExAws.S3.put_object(@bucket, path, content) |> ExAws.request() do
+      {:ok, _} -> {:ok, uri}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  def get_content(uri) do
+    path = uri_to_path(uri)
+
+    case ExAws.S3.get_object(@bucket, path) |> ExAws.request() do
+      {:ok, %{body: body}} -> {:ok, body}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+end

--- a/lib/storybox/stories/scene_piece.ex
+++ b/lib/storybox/stories/scene_piece.ex
@@ -43,11 +43,21 @@ defmodule Storybox.Stories.ScenePiece do
 
     action :create_version, :struct do
       constraints instance_of: Storybox.Stories.SceneVersion
-      argument :content_uri, :string, allow_nil?: false
+      argument :content, :string, allow_nil?: false
       argument :scene_piece_id, :uuid, allow_nil?: false
 
       run fn input, _context ->
         piece_id = input.arguments.scene_piece_id
+
+        [piece] =
+          Storybox.Stories.ScenePiece
+          |> Ash.Query.filter(id == ^piece_id)
+          |> Ash.read!(authorize?: false)
+
+        [sequence] =
+          Storybox.Stories.SequencePiece
+          |> Ash.Query.filter(id == ^piece.sequence_piece_id)
+          |> Ash.read!(authorize?: false)
 
         existing_versions =
           Storybox.Stories.SceneVersion
@@ -60,15 +70,19 @@ defmodule Storybox.Stories.ScenePiece do
           |> Enum.max(fn -> 0 end)
           |> Kernel.+(1)
 
-        Storybox.Stories.SceneVersion
-        |> Ash.Changeset.for_create(:create, %{
-          scene_piece_id: input.arguments.scene_piece_id,
-          content_uri: input.arguments.content_uri,
-          version_number: next_version_number,
-          upstream_status: :current,
-          weights: %{}
-        })
-        |> Ash.create(authorize?: false)
+        uri = Storybox.Storage.uri_for_scene(sequence.story_id, piece_id, next_version_number)
+
+        with {:ok, _} <- Storybox.Storage.put_content(uri, input.arguments.content) do
+          Storybox.Stories.SceneVersion
+          |> Ash.Changeset.for_create(:create, %{
+            scene_piece_id: piece_id,
+            content_uri: uri,
+            version_number: next_version_number,
+            upstream_status: :current,
+            weights: %{}
+          })
+          |> Ash.create(authorize?: false)
+        end
       end
     end
   end

--- a/lib/storybox/stories/sequence_piece.ex
+++ b/lib/storybox/stories/sequence_piece.ex
@@ -44,11 +44,16 @@ defmodule Storybox.Stories.SequencePiece do
 
     action :create_version, :struct do
       constraints instance_of: Storybox.Stories.SequenceVersion
-      argument :content_uri, :string, allow_nil?: false
+      argument :content, :string, allow_nil?: false
       argument :sequence_piece_id, :uuid, allow_nil?: false
 
       run fn input, _context ->
         piece_id = input.arguments.sequence_piece_id
+
+        [piece] =
+          Storybox.Stories.SequencePiece
+          |> Ash.Query.filter(id == ^piece_id)
+          |> Ash.read!(authorize?: false)
 
         existing_versions =
           Storybox.Stories.SequenceVersion
@@ -61,15 +66,19 @@ defmodule Storybox.Stories.SequencePiece do
           |> Enum.max(fn -> 0 end)
           |> Kernel.+(1)
 
-        Storybox.Stories.SequenceVersion
-        |> Ash.Changeset.for_create(:create, %{
-          sequence_piece_id: input.arguments.sequence_piece_id,
-          content_uri: input.arguments.content_uri,
-          version_number: next_version_number,
-          upstream_status: :current,
-          weights: %{}
-        })
-        |> Ash.create(authorize?: false)
+        uri = Storybox.Storage.uri_for_sequence(piece.story_id, piece_id, next_version_number)
+
+        with {:ok, _} <- Storybox.Storage.put_content(uri, input.arguments.content) do
+          Storybox.Stories.SequenceVersion
+          |> Ash.Changeset.for_create(:create, %{
+            sequence_piece_id: piece_id,
+            content_uri: uri,
+            version_number: next_version_number,
+            upstream_status: :current,
+            weights: %{}
+          })
+          |> Ash.create(authorize?: false)
+        end
       end
     end
   end

--- a/lib/storybox/stories/synopsis_version.ex
+++ b/lib/storybox/stories/synopsis_version.ex
@@ -3,6 +3,8 @@ defmodule Storybox.Stories.SynopsisVersion do
     domain: Storybox.Stories,
     data_layer: AshPostgres.DataLayer
 
+  require Ash.Query
+
   postgres do
     table "synopsis_versions"
     repo Storybox.Repo
@@ -26,6 +28,39 @@ defmodule Storybox.Stories.SynopsisVersion do
 
     create :create do
       accept [:story_id, :content_uri, :version_number]
+    end
+
+    action :create_version, :struct do
+      constraints instance_of: Storybox.Stories.SynopsisVersion
+      argument :content, :string, allow_nil?: false
+      argument :story_id, :uuid, allow_nil?: false
+
+      run fn input, _context ->
+        story_id = input.arguments.story_id
+
+        existing_versions =
+          Storybox.Stories.SynopsisVersion
+          |> Ash.Query.filter(story_id == ^story_id)
+          |> Ash.read!(authorize?: false)
+
+        next_version_number =
+          existing_versions
+          |> Enum.map(& &1.version_number)
+          |> Enum.max(fn -> 0 end)
+          |> Kernel.+(1)
+
+        uri = Storybox.Storage.uri_for_synopsis(story_id, next_version_number)
+
+        with {:ok, _} <- Storybox.Storage.put_content(uri, input.arguments.content) do
+          Storybox.Stories.SynopsisVersion
+          |> Ash.Changeset.for_create(:create, %{
+            story_id: story_id,
+            content_uri: uri,
+            version_number: next_version_number
+          })
+          |> Ash.create(authorize?: false)
+        end
+      end
     end
   end
 end

--- a/test/storybox/storage_test.exs
+++ b/test/storybox/storage_test.exs
@@ -1,0 +1,46 @@
+defmodule Storybox.StorageTest do
+  use ExUnit.Case, async: true
+
+  alias Storybox.Storage
+
+  @story_id "11111111-1111-1111-1111-111111111111"
+  @piece_id "22222222-2222-2222-2222-222222222222"
+
+  describe "uri_for_sequence/3" do
+    test "builds correct URI" do
+      assert Storage.uri_for_sequence(@story_id, @piece_id, 1) ==
+               "storybox://stories/#{@story_id}/sequences/#{@piece_id}/v1.fountain"
+    end
+  end
+
+  describe "uri_for_scene/3" do
+    test "builds correct URI" do
+      assert Storage.uri_for_scene(@story_id, @piece_id, 2) ==
+               "storybox://stories/#{@story_id}/scenes/#{@piece_id}/v2.fountain"
+    end
+  end
+
+  describe "uri_for_synopsis/2" do
+    test "builds correct URI" do
+      assert Storage.uri_for_synopsis(@story_id, 3) ==
+               "storybox://stories/#{@story_id}/synopsis/v3.fountain"
+    end
+  end
+
+  describe "uri_to_path/1" do
+    test "strips storybox:// scheme" do
+      uri = "storybox://stories/#{@story_id}/sequences/#{@piece_id}/v1.fountain"
+      assert Storage.uri_to_path(uri) == "stories/#{@story_id}/sequences/#{@piece_id}/v1.fountain"
+    end
+  end
+
+  describe "put_content/2 and get_content/1" do
+    test "round-trips content through MinIO" do
+      uri = Storage.uri_for_sequence(@story_id, @piece_id, 99)
+      content = "INT. COFFEE SHOP - DAY\n\nA detective stares at a blank page."
+
+      assert {:ok, ^uri} = Storage.put_content(uri, content)
+      assert {:ok, ^content} = Storage.get_content(uri)
+    end
+  end
+end

--- a/test/storybox/stories/scene_piece_test.exs
+++ b/test/storybox/stories/scene_piece_test.exs
@@ -81,7 +81,7 @@ defmodule Storybox.Stories.ScenePieceTest do
                Storybox.Stories.ScenePiece
                |> Ash.ActionInput.for_action(:create_version, %{
                  scene_piece_id: piece.id,
-                 content_uri: "storybox://stories/#{story.id}/scenes/#{piece.id}/v1"
+                 content: "INT. COFFEE SHOP - DAY"
                })
                |> Ash.run_action()
 
@@ -89,9 +89,12 @@ defmodule Storybox.Stories.ScenePieceTest do
       assert version.upstream_status == :current
       assert version.weights == %{}
       assert version.scene_piece_id == piece.id
+
+      assert version.content_uri ==
+               Storybox.Storage.uri_for_scene(story.id, piece.id, 1)
     end
 
-    test "increments version_number for subsequent versions", %{story: story, sequence: sequence} do
+    test "increments version_number for subsequent versions", %{sequence: sequence} do
       {:ok, piece} =
         Storybox.Stories.ScenePiece
         |> Ash.Changeset.for_create(:create, %{
@@ -105,7 +108,7 @@ defmodule Storybox.Stories.ScenePieceTest do
         Storybox.Stories.ScenePiece
         |> Ash.ActionInput.for_action(:create_version, %{
           scene_piece_id: piece.id,
-          content_uri: "storybox://stories/#{story.id}/scenes/#{piece.id}/v1"
+          content: "Version one content"
         })
         |> Ash.run_action()
 
@@ -113,7 +116,7 @@ defmodule Storybox.Stories.ScenePieceTest do
                Storybox.Stories.ScenePiece
                |> Ash.ActionInput.for_action(:create_version, %{
                  scene_piece_id: piece.id,
-                 content_uri: "storybox://stories/#{story.id}/scenes/#{piece.id}/v2"
+                 content: "Version two content"
                })
                |> Ash.run_action()
 
@@ -122,7 +125,7 @@ defmodule Storybox.Stories.ScenePieceTest do
   end
 
   describe "approve_version action" do
-    test "sets approved_version_id on the piece", %{story: story, sequence: sequence} do
+    test "sets approved_version_id on the piece", %{sequence: sequence} do
       {:ok, piece} =
         Storybox.Stories.ScenePiece
         |> Ash.Changeset.for_create(:create, %{
@@ -136,7 +139,7 @@ defmodule Storybox.Stories.ScenePieceTest do
         Storybox.Stories.ScenePiece
         |> Ash.ActionInput.for_action(:create_version, %{
           scene_piece_id: piece.id,
-          content_uri: "storybox://stories/#{story.id}/scenes/#{piece.id}/v1"
+          content: "Approved content"
         })
         |> Ash.run_action()
 

--- a/test/storybox/stories/script_snapshot_test.exs
+++ b/test/storybox/stories/script_snapshot_test.exs
@@ -119,7 +119,7 @@ defmodule Storybox.Stories.ScriptSnapshotTest do
         Storybox.Stories.ScenePiece
         |> Ash.ActionInput.for_action(:create_version, %{
           scene_piece_id: piece1.id,
-          content_uri: "storybox://stories/#{story.id}/scenes/#{piece1.id}/v1"
+          content: "Scene one content"
         })
         |> Ash.run_action()
 
@@ -127,7 +127,7 @@ defmodule Storybox.Stories.ScriptSnapshotTest do
         Storybox.Stories.ScenePiece
         |> Ash.ActionInput.for_action(:create_version, %{
           scene_piece_id: piece2.id,
-          content_uri: "storybox://stories/#{story.id}/scenes/#{piece2.id}/v1"
+          content: "Scene two content"
         })
         |> Ash.run_action()
 
@@ -179,7 +179,7 @@ defmodule Storybox.Stories.ScriptSnapshotTest do
         Storybox.Stories.ScenePiece
         |> Ash.ActionInput.for_action(:create_version, %{
           scene_piece_id: piece_approved.id,
-          content_uri: "storybox://stories/#{story.id}/scenes/#{piece_approved.id}/v1"
+          content: "Approved scene content"
         })
         |> Ash.run_action()
 

--- a/test/storybox/stories/sequence_piece_test.exs
+++ b/test/storybox/stories/sequence_piece_test.exs
@@ -86,7 +86,7 @@ defmodule Storybox.Stories.SequencePieceTest do
                Storybox.Stories.SequencePiece
                |> Ash.ActionInput.for_action(:create_version, %{
                  sequence_piece_id: piece.id,
-                 content_uri: "storybox://stories/#{story.id}/sequences/#{piece.id}/v1"
+                 content: "INT. COFFEE SHOP - DAY"
                })
                |> Ash.run_action()
 
@@ -94,6 +94,9 @@ defmodule Storybox.Stories.SequencePieceTest do
       assert version.upstream_status == :current
       assert version.weights == %{}
       assert version.sequence_piece_id == piece.id
+
+      assert version.content_uri ==
+               Storybox.Storage.uri_for_sequence(story.id, piece.id, 1)
     end
 
     test "increments version_number for subsequent versions", %{story: story} do
@@ -110,7 +113,7 @@ defmodule Storybox.Stories.SequencePieceTest do
         Storybox.Stories.SequencePiece
         |> Ash.ActionInput.for_action(:create_version, %{
           sequence_piece_id: piece.id,
-          content_uri: "storybox://stories/#{story.id}/sequences/#{piece.id}/v1"
+          content: "Version one content"
         })
         |> Ash.run_action()
 
@@ -118,7 +121,7 @@ defmodule Storybox.Stories.SequencePieceTest do
                Storybox.Stories.SequencePiece
                |> Ash.ActionInput.for_action(:create_version, %{
                  sequence_piece_id: piece.id,
-                 content_uri: "storybox://stories/#{story.id}/sequences/#{piece.id}/v2"
+                 content: "Version two content"
                })
                |> Ash.run_action()
 
@@ -141,7 +144,7 @@ defmodule Storybox.Stories.SequencePieceTest do
         Storybox.Stories.SequencePiece
         |> Ash.ActionInput.for_action(:create_version, %{
           sequence_piece_id: piece.id,
-          content_uri: "storybox://stories/#{story.id}/sequences/#{piece.id}/v1"
+          content: "Approved content"
         })
         |> Ash.run_action()
 

--- a/test/storybox/stories/synopsis_version_test.exs
+++ b/test/storybox/stories/synopsis_version_test.exs
@@ -106,4 +106,40 @@ defmodule Storybox.Stories.SynopsisVersionTest do
       assert Enum.any?(versions, &(&1.id == version.id))
     end
   end
+
+  describe "create_version action" do
+    test "creates first version with version_number 1 and correct URI", %{story: story} do
+      assert {:ok, version} =
+               Storybox.Stories.SynopsisVersion
+               |> Ash.ActionInput.for_action(:create_version, %{
+                 story_id: story.id,
+                 content: "A detective story about memory."
+               })
+               |> Ash.run_action()
+
+      assert version.story_id == story.id
+      assert version.version_number == 1
+      assert version.content_uri == Storybox.Storage.uri_for_synopsis(story.id, 1)
+    end
+
+    test "increments version_number for subsequent versions", %{story: story} do
+      {:ok, _v1} =
+        Storybox.Stories.SynopsisVersion
+        |> Ash.ActionInput.for_action(:create_version, %{
+          story_id: story.id,
+          content: "First synopsis draft."
+        })
+        |> Ash.run_action()
+
+      assert {:ok, v2} =
+               Storybox.Stories.SynopsisVersion
+               |> Ash.ActionInput.for_action(:create_version, %{
+                 story_id: story.id,
+                 content: "Second synopsis draft."
+               })
+               |> Ash.run_action()
+
+      assert v2.version_number == 2
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- Adds `Storybox.Storage` module with `put_content/2`, `get_content/1`, and URI builders for sequences, scenes, and synopsis (`storybox://stories/{id}/...` scheme)
- Updates `create_version` on `SequencePiece` and `ScenePiece` to accept raw `content:` (string), store to MinIO, and derive the URI — callers no longer manage URIs directly
- Adds `create_version` action to `SynopsisVersion` with the same pattern
- Updates all existing tests that called `create_version` with `content_uri:` to use `content:` instead

## Key decisions

- **No Mox** — tests hit real MinIO in the Podman stack, consistent with the project's real-PostgreSQL approach
- **URI scheme** — `storybox://stories/{story_id}/{type}/{piece_id}/v{n}.fountain` maps 1:1 to MinIO object key (just strip the `storybox://` prefix)
- **`story_id` traversal** — `ScenePiece.create_version` loads scene→sequence to resolve `story_id` for the URI; `SequencePiece.create_version` loads the piece directly

## Test plan

- [x] `mix precommit` passes (75 tests, 0 failures)
- [x] Rebased onto main after #11 merged — no conflicts
- [x] MinIO round-trip verified manually via iex and confirmed in MinIO console

closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)