### PR TITLE
Implement synopsis view endpoint

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -20,6 +20,13 @@ if System.get_env("PHX_SERVER") do
   config :storybox, StoryboxWeb.Endpoint, server: true
 end
 
+# Bind to all interfaces when running inside a container (PHX_HOST is set in podman-compose.yml).
+# This overrides the loopback-only default in dev.exs so port-forwarding works.
+if System.get_env("PHX_HOST") && config_env() == :dev do
+  config :storybox, StoryboxWeb.Endpoint,
+    http: [ip: {0, 0, 0, 0}, port: String.to_integer(System.get_env("PORT") || "4000")]
+end
+
 # MinIO / ExAws — always read from env if present (dev container + prod)
 if minio_endpoint = System.get_env("MINIO_ENDPOINT") do
   uri = URI.parse(minio_endpoint)

--- a/lib/storybox_web/controllers/api_controller.ex
+++ b/lib/storybox_web/controllers/api_controller.ex
@@ -1,7 +1,48 @@
 defmodule StoryboxWeb.ApiController do
   use StoryboxWeb, :controller
 
+  require Ash.Query
+
   def ping(conn, %{"story_id" => story_id}) do
     json(conn, %{status: "ok", story_id: story_id})
+  end
+
+  def synopsis_view(conn, _params) do
+    story = conn.assigns.current_story
+
+    latest =
+      Storybox.Stories.SynopsisVersion
+      |> Ash.Query.filter(story_id == ^story.id)
+      |> Ash.Query.sort(version_number: :desc)
+      |> Ash.Query.limit(1)
+      |> Ash.read_one(authorize?: false)
+
+    case latest do
+      {:ok, nil} ->
+        conn
+        |> put_status(404)
+        |> json(%{error: "no synopsis found"})
+
+      {:ok, version} ->
+        case Storybox.Storage.get_content(version.content_uri) do
+          {:ok, content} ->
+            json(conn, %{
+              story_id: story.id,
+              version_number: version.version_number,
+              inserted_at: version.inserted_at,
+              content: content
+            })
+
+          {:error, _} ->
+            conn
+            |> put_status(503)
+            |> json(%{error: "content unavailable"})
+        end
+
+      {:error, _} ->
+        conn
+        |> put_status(500)
+        |> json(%{error: "internal error"})
+    end
   end
 end

--- a/lib/storybox_web/router.ex
+++ b/lib/storybox_web/router.ex
@@ -35,6 +35,7 @@ defmodule StoryboxWeb.Router do
     pipe_through [:api, :require_api_auth]
 
     get "/stories/:story_id/ping", ApiController, :ping
+    get "/stories/:story_id/views/synopsis", ApiController, :synopsis_view
   end
 
   # Enable LiveDashboard and Swoosh mailbox preview in development

--- a/test/storybox_web/controllers/synopsis_view_test.exs
+++ b/test/storybox_web/controllers/synopsis_view_test.exs
@@ -1,0 +1,122 @@
+defmodule StoryboxWeb.SynopsisViewTest do
+  use StoryboxWeb.ConnCase
+
+  alias Storybox.Accounts.ApiToken
+
+  setup do
+    {:ok, user} =
+      Storybox.Accounts.User
+      |> Ash.Changeset.for_create(:register_with_password, %{
+        email: "synopsis_view_test@example.com",
+        password: "password123!",
+        password_confirmation: "password123!"
+      })
+      |> Ash.create()
+
+    {:ok, story} =
+      Storybox.Stories.Story
+      |> Ash.Changeset.for_create(:create, %{title: "Synopsis Test Story", user_id: user.id})
+      |> Ash.create()
+
+    {:ok, other_story} =
+      Storybox.Stories.Story
+      |> Ash.Changeset.for_create(:create, %{title: "Other Story", user_id: user.id})
+      |> Ash.create()
+
+    {:ok, raw_token, _} = ApiToken.generate(%{story_id: story.id, user_id: user.id})
+
+    %{user: user, story: story, other_story: other_story, raw_token: raw_token}
+  end
+
+  defp authed(conn, raw_token) do
+    put_req_header(conn, "authorization", "Bearer #{raw_token}")
+  end
+
+  describe "GET /api/stories/:story_id/views/synopsis" do
+    test "returns 404 when no synopsis versions exist", %{
+      conn: conn,
+      story: story,
+      raw_token: raw_token
+    } do
+      conn =
+        conn
+        |> authed(raw_token)
+        |> get("/api/stories/#{story.id}/views/synopsis")
+
+      assert json_response(conn, 404)["error"] == "no synopsis found"
+    end
+
+    test "returns latest version with content when versions exist", %{
+      conn: conn,
+      story: story,
+      raw_token: raw_token
+    } do
+      {:ok, _v1} =
+        Storybox.Stories.SynopsisVersion
+        |> Ash.ActionInput.for_action(:create_version, %{
+          story_id: story.id,
+          content: "First synopsis draft."
+        })
+        |> Ash.run_action()
+
+      {:ok, _v2} =
+        Storybox.Stories.SynopsisVersion
+        |> Ash.ActionInput.for_action(:create_version, %{
+          story_id: story.id,
+          content: "Second synopsis draft."
+        })
+        |> Ash.run_action()
+
+      conn =
+        conn
+        |> authed(raw_token)
+        |> get("/api/stories/#{story.id}/views/synopsis")
+
+      assert %{
+               "story_id" => story_id,
+               "version_number" => version_number,
+               "inserted_at" => _inserted_at,
+               "content" => content
+             } = json_response(conn, 200)
+
+      assert story_id == story.id
+      assert version_number == 2
+      assert content == "Second synopsis draft."
+    end
+
+    test "returns 503 when content_uri points to a nonexistent MinIO object", %{
+      conn: conn,
+      story: story,
+      raw_token: raw_token
+    } do
+      {:ok, _version} =
+        Storybox.Stories.SynopsisVersion
+        |> Ash.Changeset.for_create(:create, %{
+          story_id: story.id,
+          content_uri: "storybox://stories/#{story.id}/synopsis/v999_nonexistent.fountain",
+          version_number: 1
+        })
+        |> Ash.create()
+
+      conn =
+        conn
+        |> authed(raw_token)
+        |> get("/api/stories/#{story.id}/views/synopsis")
+
+      assert json_response(conn, 503)["error"] == "content unavailable"
+    end
+
+    test "returns 403 when token is scoped to a different story", %{
+      conn: conn,
+      other_story: other_story,
+      raw_token: raw_token
+    } do
+      conn =
+        conn
+        |> authed(raw_token)
+        |> get("/api/stories/#{other_story.id}/views/synopsis")
+
+      assert json_response(conn, 403)["error"] == "forbidden"
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `GET /api/stories/:story_id/views/synopsis` — returns the latest `SynopsisVersion` (by `version_number`) with metadata and `.fountain` content fetched from MinIO
- 404 if no versions exist; 503 if MinIO fetch fails
- Auth and story-scope enforcement handled by the existing `ApiAuth` plug — controller just reads `conn.assigns.current_story`
- Fixes Phoenix not being reachable from the host when running in Podman

## Key decisions

- **"Latest" = highest `version_number`** rather than `inserted_at` — version numbers are the semantic ordering for synopsis versions
- **Raw fountain content** returned as a string — no parsing needed for an agentic API consumer
- **503 on MinIO failure** rather than 500 — signals a transient upstream issue the caller can retry

### Phoenix binding fix (`runtime.exs`)

By default `dev.exs` binds Phoenix to `127.0.0.1` (loopback only). Inside a Podman container that means Phoenix only accepts connections from within the container itself — port-forwarding from the host (`0.0.0.0:4000 -> 4000/tcp`) can't reach it.

The fix is to override the binding to `0.0.0.0`. The question is where to put it:

- **`dev.exs`** is processed at **compile time**. A change there doesn't take effect until the app is recompiled — a container restart isn't enough because the `_build` volume caches the compiled beam files.
- **`runtime.exs`** is evaluated at **application startup**, after compilation. A change there takes effect on the next restart with no recompile needed.

So the override lives in `runtime.exs`, gated on `PHX_HOST` being set (that env var is present in `podman-compose.yml` but not in a plain local dev setup), so it only applies inside the container and doesn't change behaviour for anyone running the app directly on their machine.

## Test plan

- [x] 404 when no synopsis versions exist
- [x] 200 with correct `version_number`, `story_id`, `inserted_at`, and `content` — verified with two versions that latest is returned
- [x] 503 when `content_uri` points to a nonexistent MinIO object
- [x] 403 when bearer token is scoped to a different story
- [x] `mix precommit` passes (92 tests, 0 failures)
- [x] Verified end-to-end with curl against running dev stack

closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)