### PR TITLE
Implement script view endpoint

### DIFF
--- a/lib/storybox_web/controllers/api_controller.ex
+++ b/lib/storybox_web/controllers/api_controller.ex
@@ -100,6 +100,201 @@ defmodule StoryboxWeb.ApiController do
     })
   end
 
+  def script_view(conn, params) do
+    story = conn.assigns.current_story
+
+    case parse_script_mode(params) do
+      {:error, reason} ->
+        conn |> put_status(400) |> json(%{error: reason})
+
+      {:ok, mode, snapshot_id} ->
+        sequences =
+          Storybox.Stories.SequencePiece
+          |> Ash.Query.filter(story_id == ^story.id)
+          |> Ash.Query.sort(position: :asc)
+          |> Ash.read!(authorize?: false)
+
+        sequence_ids = Enum.map(sequences, & &1.id)
+
+        scene_pieces =
+          Storybox.Stories.ScenePiece
+          |> Ash.Query.filter(sequence_piece_id in ^sequence_ids)
+          |> Ash.Query.sort(position: :asc)
+          |> Ash.read!(authorize?: false)
+
+        scenes_by_sequence = Enum.group_by(scene_pieces, & &1.sequence_piece_id)
+        scene_piece_ids = Enum.map(scene_pieces, & &1.id)
+
+        case resolve_script_versions(mode, snapshot_id, story.id, scene_pieces, scene_piece_ids) do
+          {:error, :snapshot_not_found} ->
+            conn |> put_status(404) |> json(%{error: "snapshot not found"})
+
+          {:ok, versions_map} ->
+            case build_script_scenes(scene_pieces, versions_map) do
+              {:error, :content_unavailable} ->
+                conn |> put_status(503) |> json(%{error: "content unavailable"})
+
+              {:ok, scenes_with_content} ->
+                result =
+                  sequences
+                  |> Enum.map(fn seq ->
+                    scenes =
+                      scenes_by_sequence
+                      |> Map.get(seq.id, [])
+                      |> Enum.map(&scenes_with_content[&1.id])
+
+                    %{
+                      id: seq.id,
+                      title: seq.title,
+                      act: seq.act,
+                      position: seq.position,
+                      scenes: scenes
+                    }
+                  end)
+
+                json(conn, %{
+                  story_id: story.id,
+                  mode: mode,
+                  snapshot_id: snapshot_id,
+                  sequences: result
+                })
+            end
+        end
+    end
+  end
+
+  defp parse_script_mode(%{"mode" => mode} = params)
+       when mode in ["latest", "approved", "snapshot"] do
+    if mode == "snapshot" do
+      case params do
+        %{"snapshot_id" => id} -> {:ok, mode, id}
+        _ -> {:error, "snapshot_id is required when mode is snapshot"}
+      end
+    else
+      {:ok, mode, nil}
+    end
+  end
+
+  defp parse_script_mode(%{"mode" => _}),
+    do: {:error, "mode must be latest, approved, or snapshot"}
+
+  defp parse_script_mode(_), do: {:error, "mode is required"}
+
+  defp resolve_script_versions("latest", _snapshot_id, _story_id, _scene_pieces, scene_piece_ids) do
+    all_versions =
+      Storybox.Stories.SceneVersion
+      |> Ash.Query.filter(scene_piece_id in ^scene_piece_ids)
+      |> Ash.read!(authorize?: false)
+
+    versions_map =
+      all_versions
+      |> Enum.group_by(& &1.scene_piece_id)
+      |> Map.new(fn {id, vs} -> {id, Enum.max_by(vs, & &1.version_number)} end)
+
+    {:ok, versions_map}
+  end
+
+  defp resolve_script_versions(
+         "approved",
+         _snapshot_id,
+         _story_id,
+         scene_pieces,
+         _scene_piece_ids
+       ) do
+    approved_ids =
+      scene_pieces
+      |> Enum.map(& &1.approved_version_id)
+      |> Enum.reject(&is_nil/1)
+
+    versions_by_id =
+      case approved_ids do
+        [] ->
+          %{}
+
+        ids ->
+          Storybox.Stories.SceneVersion
+          |> Ash.Query.filter(id in ^ids)
+          |> Ash.read!(authorize?: false)
+          |> Map.new(&{&1.id, &1})
+      end
+
+    versions_map =
+      Map.new(scene_pieces, fn piece ->
+        {piece.id, versions_by_id[piece.approved_version_id]}
+      end)
+
+    {:ok, versions_map}
+  end
+
+  defp resolve_script_versions("snapshot", snapshot_id, story_id, scene_pieces, _scene_piece_ids) do
+    result =
+      Storybox.Stories.ScriptSnapshot
+      |> Ash.Query.filter(id == ^snapshot_id and story_id == ^story_id)
+      |> Ash.read_one(authorize?: false)
+
+    case result do
+      {:ok, nil} ->
+        {:error, :snapshot_not_found}
+
+      {:ok, snapshot} ->
+        version_ids = Map.values(snapshot.entries)
+
+        versions_by_id =
+          case version_ids do
+            [] ->
+              %{}
+
+            ids ->
+              Storybox.Stories.SceneVersion
+              |> Ash.Query.filter(id in ^ids)
+              |> Ash.read!(authorize?: false)
+              |> Map.new(&{to_string(&1.id), &1})
+          end
+
+        versions_map =
+          Map.new(scene_pieces, fn piece ->
+            version_id = snapshot.entries[to_string(piece.id)]
+            {piece.id, versions_by_id[version_id]}
+          end)
+
+        {:ok, versions_map}
+
+      {:error, _} ->
+        {:error, :snapshot_not_found}
+    end
+  end
+
+  defp build_script_scenes(scene_pieces, versions_map) do
+    Enum.reduce_while(scene_pieces, {:ok, %{}}, fn piece, {:ok, acc} ->
+      version = versions_map[piece.id]
+
+      case fetch_scene_content(version) do
+        {:error, :content_unavailable} ->
+          {:halt, {:error, :content_unavailable}}
+
+        {:ok, content} ->
+          scene = %{
+            id: piece.id,
+            title: piece.title,
+            position: piece.position,
+            version: format_version(version),
+            content: content
+          }
+
+          {:cont, {:ok, Map.put(acc, piece.id, scene)}}
+      end
+    end)
+  end
+
+  defp fetch_scene_content(nil), do: {:ok, nil}
+
+  defp fetch_scene_content(version) do
+    case Storybox.Storage.get_content(version.content_uri) do
+      {:ok, content} -> {:ok, content}
+      {:error, _} -> {:error, :content_unavailable}
+    end
+  end
+
   def sequence_detail(conn, %{"id" => id}) do
     story = conn.assigns.current_story
 

--- a/lib/storybox_web/controllers/api_controller.ex
+++ b/lib/storybox_web/controllers/api_controller.ex
@@ -45,4 +45,157 @@ defmodule StoryboxWeb.ApiController do
         |> json(%{error: "internal error"})
     end
   end
+
+  def treatment_view(conn, _params) do
+    story = conn.assigns.current_story
+
+    pieces =
+      Storybox.Stories.SequencePiece
+      |> Ash.Query.filter(story_id == ^story.id)
+      |> Ash.Query.sort(position: :asc)
+      |> Ash.read!(authorize?: false)
+
+    approved_ids =
+      pieces
+      |> Enum.map(& &1.approved_version_id)
+      |> Enum.reject(&is_nil/1)
+
+    versions_by_id =
+      case approved_ids do
+        [] ->
+          %{}
+
+        ids ->
+          Storybox.Stories.SequenceVersion
+          |> Ash.Query.filter(id in ^ids)
+          |> Ash.read!(authorize?: false)
+          |> Map.new(&{&1.id, &1})
+      end
+
+    acts =
+      pieces
+      |> Enum.group_by(& &1.act)
+      |> Enum.sort_by(fn {act, _} -> {is_nil(act), act} end)
+      |> Enum.map(fn {act, seqs} ->
+        %{
+          act: act,
+          sequences:
+            Enum.map(seqs, fn piece ->
+              version = versions_by_id[piece.approved_version_id]
+
+              %{
+                id: piece.id,
+                title: piece.title,
+                position: piece.position,
+                approved_version: format_version(version)
+              }
+            end)
+        }
+      end)
+
+    json(conn, %{
+      story_id: story.id,
+      through_lines: story.through_lines,
+      acts: acts
+    })
+  end
+
+  def sequence_detail(conn, %{"id" => id}) do
+    story = conn.assigns.current_story
+
+    case Storybox.Stories.SequencePiece
+         |> Ash.Query.filter(id == ^id and story_id == ^story.id)
+         |> Ash.read_one(authorize?: false) do
+      {:ok, nil} ->
+        conn |> put_status(404) |> json(%{error: "not found"})
+
+      {:ok, piece} ->
+        version_query =
+          if piece.approved_version_id do
+            Storybox.Stories.SequenceVersion
+            |> Ash.Query.filter(id == ^piece.approved_version_id)
+            |> Ash.read_one(authorize?: false)
+          else
+            Storybox.Stories.SequenceVersion
+            |> Ash.Query.filter(sequence_piece_id == ^piece.id)
+            |> Ash.Query.sort(version_number: :desc)
+            |> Ash.Query.limit(1)
+            |> Ash.read_one(authorize?: false)
+          end
+
+        case version_query do
+          {:ok, nil} ->
+            conn |> put_status(404) |> json(%{error: "no version available"})
+
+          {:ok, version} ->
+            case Storybox.Storage.get_content(version.content_uri) do
+              {:ok, content} ->
+                characters =
+                  Storybox.Stories.Character
+                  |> Ash.Query.filter(story_id == ^story.id)
+                  |> Ash.read!(authorize?: false)
+
+                world =
+                  Storybox.Stories.World
+                  |> Ash.Query.filter(story_id == ^story.id)
+                  |> Ash.read_one!(authorize?: false)
+
+                json(conn, %{
+                  id: piece.id,
+                  title: piece.title,
+                  act: piece.act,
+                  position: piece.position,
+                  version: format_version(version),
+                  content: content,
+                  context: %{
+                    world: format_world(world),
+                    characters: Enum.map(characters, &format_character/1)
+                  }
+                })
+
+              {:error, _} ->
+                conn |> put_status(503) |> json(%{error: "content unavailable"})
+            end
+
+          {:error, _} ->
+            conn |> put_status(500) |> json(%{error: "internal error"})
+        end
+
+      {:error, _} ->
+        conn |> put_status(500) |> json(%{error: "internal error"})
+    end
+  end
+
+  defp format_version(nil), do: nil
+
+  defp format_version(version) do
+    %{
+      id: version.id,
+      version_number: version.version_number,
+      upstream_status: version.upstream_status,
+      weights: version.weights,
+      inserted_at: version.inserted_at
+    }
+  end
+
+  defp format_world(nil), do: nil
+
+  defp format_world(world) do
+    %{
+      id: world.id,
+      history: world.history,
+      rules: world.rules,
+      subtext: world.subtext
+    }
+  end
+
+  defp format_character(char) do
+    %{
+      id: char.id,
+      name: char.name,
+      essence: char.essence,
+      contradictions: char.contradictions,
+      voice: char.voice
+    }
+  end
 end

--- a/lib/storybox_web/router.ex
+++ b/lib/storybox_web/router.ex
@@ -36,6 +36,8 @@ defmodule StoryboxWeb.Router do
 
     get "/stories/:story_id/ping", ApiController, :ping
     get "/stories/:story_id/views/synopsis", ApiController, :synopsis_view
+    get "/stories/:story_id/views/treatment", ApiController, :treatment_view
+    get "/stories/:story_id/sequences/:id", ApiController, :sequence_detail
   end
 
   # Enable LiveDashboard and Swoosh mailbox preview in development

--- a/lib/storybox_web/router.ex
+++ b/lib/storybox_web/router.ex
@@ -37,6 +37,7 @@ defmodule StoryboxWeb.Router do
     get "/stories/:story_id/ping", ApiController, :ping
     get "/stories/:story_id/views/synopsis", ApiController, :synopsis_view
     get "/stories/:story_id/views/treatment", ApiController, :treatment_view
+    get "/stories/:story_id/views/script", ApiController, :script_view
     get "/stories/:story_id/sequences/:id", ApiController, :sequence_detail
   end
 

--- a/test/storybox_web/controllers/script_view_test.exs
+++ b/test/storybox_web/controllers/script_view_test.exs
@@ -1,0 +1,417 @@
+defmodule StoryboxWeb.ScriptViewTest do
+  use StoryboxWeb.ConnCase
+
+  alias Storybox.Accounts.ApiToken
+
+  # Shared setup creates the following structure (see plan for diagram):
+  #
+  #   story → seq_1 (Act I) → scene_1 → v1 (EXT. PARK...), v2 (INT. OFFICE...) ★ approved
+  #                          → scene_2 → v3 (EXT. STREET...)   no approved version
+  #         → seq_2 (Act II) → scene_3 → v4 (INT. KITCHEN...) ★ approved
+  #                           → scene_4   (no versions)
+  #   snapshot: entries = {scene_1 → v1}  (pins scene_1 to old v1; others not listed)
+  #   other_story: for token isolation tests
+
+  setup do
+    {:ok, user} =
+      Storybox.Accounts.User
+      |> Ash.Changeset.for_create(:register_with_password, %{
+        email: "script_view_test@example.com",
+        password: "password123!",
+        password_confirmation: "password123!"
+      })
+      |> Ash.create()
+
+    {:ok, story} =
+      Storybox.Stories.Story
+      |> Ash.Changeset.for_create(:create, %{
+        title: "Script Test Story",
+        through_lines: ["tension"],
+        user_id: user.id
+      })
+      |> Ash.create()
+
+    {:ok, other_story} =
+      Storybox.Stories.Story
+      |> Ash.Changeset.for_create(:create, %{title: "Other Story", user_id: user.id})
+      |> Ash.create()
+
+    {:ok, raw_token, _} = ApiToken.generate(%{story_id: story.id, user_id: user.id})
+
+    {:ok, seq_1} =
+      Storybox.Stories.SequencePiece
+      |> Ash.Changeset.for_create(:create, %{
+        title: "Opening",
+        act: "Act I",
+        position: 1,
+        story_id: story.id
+      })
+      |> Ash.create(authorize?: false)
+
+    {:ok, seq_2} =
+      Storybox.Stories.SequencePiece
+      |> Ash.Changeset.for_create(:create, %{
+        title: "Confrontation",
+        act: "Act II",
+        position: 1,
+        story_id: story.id
+      })
+      |> Ash.create(authorize?: false)
+
+    {:ok, scene_1} =
+      Storybox.Stories.ScenePiece
+      |> Ash.Changeset.for_create(:create, %{
+        title: "Cold open",
+        position: 1,
+        sequence_piece_id: seq_1.id
+      })
+      |> Ash.create(authorize?: false)
+
+    {:ok, scene_2} =
+      Storybox.Stories.ScenePiece
+      |> Ash.Changeset.for_create(:create, %{
+        title: "Inciting incident",
+        position: 2,
+        sequence_piece_id: seq_1.id
+      })
+      |> Ash.create(authorize?: false)
+
+    {:ok, scene_3} =
+      Storybox.Stories.ScenePiece
+      |> Ash.Changeset.for_create(:create, %{
+        title: "The argument",
+        position: 1,
+        sequence_piece_id: seq_2.id
+      })
+      |> Ash.create(authorize?: false)
+
+    {:ok, scene_4} =
+      Storybox.Stories.ScenePiece
+      |> Ash.Changeset.for_create(:create, %{
+        title: "Aftermath",
+        position: 2,
+        sequence_piece_id: seq_2.id
+      })
+      |> Ash.create(authorize?: false)
+
+    {:ok, v1} =
+      Storybox.Stories.ScenePiece
+      |> Ash.ActionInput.for_action(:create_version, %{
+        scene_piece_id: scene_1.id,
+        content: "EXT. PARK - DAY\n\nFirst draft."
+      })
+      |> Ash.run_action(authorize?: false)
+
+    {:ok, v2} =
+      Storybox.Stories.ScenePiece
+      |> Ash.ActionInput.for_action(:create_version, %{
+        scene_piece_id: scene_1.id,
+        content: "INT. OFFICE - NIGHT\n\nRevised."
+      })
+      |> Ash.run_action(authorize?: false)
+
+    {:ok, scene_1} =
+      scene_1
+      |> Ash.Changeset.for_update(:approve_version, %{version_id: v2.id})
+      |> Ash.update(authorize?: false)
+
+    {:ok, v3} =
+      Storybox.Stories.ScenePiece
+      |> Ash.ActionInput.for_action(:create_version, %{
+        scene_piece_id: scene_2.id,
+        content: "EXT. STREET - DAY\n\nSomething happens."
+      })
+      |> Ash.run_action(authorize?: false)
+
+    {:ok, v4} =
+      Storybox.Stories.ScenePiece
+      |> Ash.ActionInput.for_action(:create_version, %{
+        scene_piece_id: scene_3.id,
+        content: "INT. KITCHEN - DAY\n\nThey argue."
+      })
+      |> Ash.run_action(authorize?: false)
+
+    {:ok, scene_3} =
+      scene_3
+      |> Ash.Changeset.for_update(:approve_version, %{version_id: v4.id})
+      |> Ash.update(authorize?: false)
+
+    # Snapshot pins scene_1 to v1 (its old version, not the currently approved v2)
+    {:ok, snapshot} =
+      Storybox.Stories.ScriptSnapshot
+      |> Ash.Changeset.for_create(:create, %{
+        name: "Test snapshot",
+        story_id: story.id,
+        entries: %{to_string(scene_1.id) => to_string(v1.id)}
+      })
+      |> Ash.create(authorize?: false)
+
+    %{
+      story: story,
+      other_story: other_story,
+      raw_token: raw_token,
+      seq_1: seq_1,
+      seq_2: seq_2,
+      scene_1: scene_1,
+      scene_2: scene_2,
+      scene_3: scene_3,
+      scene_4: scene_4,
+      v1: v1,
+      v2: v2,
+      v3: v3,
+      v4: v4,
+      snapshot: snapshot
+    }
+  end
+
+  defp authed(conn, raw_token), do: put_req_header(conn, "authorization", "Bearer #{raw_token}")
+
+  defp get_script(conn, story, raw_token, params) do
+    query = URI.encode_query(params)
+    conn |> authed(raw_token) |> get("/api/stories/#{story.id}/views/script?#{query}")
+  end
+
+  defp find_sequence(body, title), do: Enum.find(body["sequences"], &(&1["title"] == title))
+  defp find_scene(sequence, title), do: Enum.find(sequence["scenes"], &(&1["title"] == title))
+
+  # ── mode=latest ─────────────────────────────────────────────────────────────
+
+  describe "GET /api/stories/:story_id/views/script?mode=latest" do
+    test "returns all sequences with each scene resolved to its highest-numbered version and content",
+         %{
+           conn: conn,
+           story: story,
+           raw_token: raw_token
+         } do
+      conn = get_script(conn, story, raw_token, %{mode: "latest"})
+      body = json_response(conn, 200)
+
+      assert body["story_id"] == story.id
+      assert body["mode"] == "latest"
+      assert body["snapshot_id"] == nil
+      assert length(body["sequences"]) == 2
+
+      opening = find_sequence(body, "Opening")
+      cold_open = find_scene(opening, "Cold open")
+      assert cold_open["version"]["version_number"] == 2
+      assert cold_open["content"] == "INT. OFFICE - NIGHT\n\nRevised."
+
+      inciting = find_scene(opening, "Inciting incident")
+      assert inciting["version"]["version_number"] == 1
+      assert inciting["content"] == "EXT. STREET - DAY\n\nSomething happens."
+    end
+
+    test "scenes within a sequence are ordered by position", %{
+      conn: conn,
+      story: story,
+      raw_token: raw_token
+    } do
+      conn = get_script(conn, story, raw_token, %{mode: "latest"})
+      opening = find_sequence(json_response(conn, 200), "Opening")
+
+      positions = Enum.map(opening["scenes"], & &1["position"])
+      assert positions == Enum.sort(positions)
+      assert hd(opening["scenes"])["title"] == "Cold open"
+    end
+
+    test "scene with no versions returns null version and null content without crashing", %{
+      conn: conn,
+      story: story,
+      raw_token: raw_token,
+      scene_4: scene_4
+    } do
+      conn = get_script(conn, story, raw_token, %{mode: "latest"})
+      confrontation = find_sequence(json_response(conn, 200), "Confrontation")
+      aftermath = find_scene(confrontation, "Aftermath")
+
+      assert aftermath["id"] == scene_4.id
+      assert aftermath["version"] == nil
+      assert aftermath["content"] == nil
+    end
+  end
+
+  # ── mode=approved ────────────────────────────────────────────────────────────
+
+  describe "GET /api/stories/:story_id/views/script?mode=approved" do
+    test "scenes with an approved version return that version's content", %{
+      conn: conn,
+      story: story,
+      raw_token: raw_token
+    } do
+      conn = get_script(conn, story, raw_token, %{mode: "approved"})
+      body = json_response(conn, 200)
+
+      cold_open = body |> find_sequence("Opening") |> find_scene("Cold open")
+      assert cold_open["version"]["version_number"] == 2
+      assert cold_open["content"] == "INT. OFFICE - NIGHT\n\nRevised."
+
+      argument = body |> find_sequence("Confrontation") |> find_scene("The argument")
+      assert argument["version"]["version_number"] == 1
+      assert argument["content"] == "INT. KITCHEN - DAY\n\nThey argue."
+    end
+
+    test "scene with no approved version returns null version and null content", %{
+      conn: conn,
+      story: story,
+      raw_token: raw_token
+    } do
+      conn = get_script(conn, story, raw_token, %{mode: "approved"})
+      body = json_response(conn, 200)
+
+      inciting = body |> find_sequence("Opening") |> find_scene("Inciting incident")
+      assert inciting["version"] == nil
+      assert inciting["content"] == nil
+
+      aftermath = body |> find_sequence("Confrontation") |> find_scene("Aftermath")
+      assert aftermath["version"] == nil
+      assert aftermath["content"] == nil
+    end
+  end
+
+  # ── mode=snapshot ────────────────────────────────────────────────────────────
+
+  describe "GET /api/stories/:story_id/views/script?mode=snapshot" do
+    test "resolves scene_1 to v1 via the snapshot entries map, not the current approved v2", %{
+      conn: conn,
+      story: story,
+      raw_token: raw_token,
+      snapshot: snapshot
+    } do
+      conn = get_script(conn, story, raw_token, %{mode: "snapshot", snapshot_id: snapshot.id})
+      body = json_response(conn, 200)
+
+      assert body["snapshot_id"] == snapshot.id
+
+      cold_open = body |> find_sequence("Opening") |> find_scene("Cold open")
+      assert cold_open["version"]["version_number"] == 1
+      assert cold_open["content"] == "EXT. PARK - DAY\n\nFirst draft."
+    end
+
+    test "scenes not listed in the snapshot entries return null version and null content", %{
+      conn: conn,
+      story: story,
+      raw_token: raw_token,
+      snapshot: snapshot
+    } do
+      conn = get_script(conn, story, raw_token, %{mode: "snapshot", snapshot_id: snapshot.id})
+      body = json_response(conn, 200)
+
+      # scene_2, scene_3, scene_4 are not in the snapshot
+      inciting = body |> find_sequence("Opening") |> find_scene("Inciting incident")
+      assert inciting["version"] == nil
+      assert inciting["content"] == nil
+
+      argument = body |> find_sequence("Confrontation") |> find_scene("The argument")
+      assert argument["version"] == nil
+      assert argument["content"] == nil
+
+      aftermath = body |> find_sequence("Confrontation") |> find_scene("Aftermath")
+      assert aftermath["version"] == nil
+      assert aftermath["content"] == nil
+    end
+
+    test "snapshot belonging to a different story returns 404", %{
+      conn: conn,
+      story: story,
+      other_story: other_story,
+      raw_token: raw_token
+    } do
+      {:ok, other_snapshot} =
+        Storybox.Stories.ScriptSnapshot
+        |> Ash.Changeset.for_create(:create, %{
+          name: "Other",
+          story_id: other_story.id,
+          entries: %{}
+        })
+        |> Ash.create(authorize?: false)
+
+      conn =
+        get_script(conn, story, raw_token, %{mode: "snapshot", snapshot_id: other_snapshot.id})
+
+      assert json_response(conn, 404)["error"] == "snapshot not found"
+    end
+  end
+
+  # ── parameter validation ─────────────────────────────────────────────────────
+
+  describe "parameter validation" do
+    test "missing mode param returns 400", %{conn: conn, story: story, raw_token: raw_token} do
+      conn = conn |> authed(raw_token) |> get("/api/stories/#{story.id}/views/script")
+      assert json_response(conn, 400)["error"] == "mode is required"
+    end
+
+    test "unrecognised mode value returns 400", %{conn: conn, story: story, raw_token: raw_token} do
+      conn = get_script(conn, story, raw_token, %{mode: "draft"})
+      assert json_response(conn, 400)["error"] == "mode must be latest, approved, or snapshot"
+    end
+
+    test "mode=snapshot without snapshot_id returns 400", %{
+      conn: conn,
+      story: story,
+      raw_token: raw_token
+    } do
+      conn = get_script(conn, story, raw_token, %{mode: "snapshot"})
+      assert json_response(conn, 400)["error"] == "snapshot_id is required when mode is snapshot"
+    end
+  end
+
+  # ── auth & content guard ─────────────────────────────────────────────────────
+
+  describe "auth and content guards" do
+    test "token scoped to a different story returns 403", %{
+      conn: conn,
+      other_story: other_story,
+      raw_token: raw_token
+    } do
+      conn =
+        conn
+        |> authed(raw_token)
+        |> get("/api/stories/#{other_story.id}/views/script?mode=latest")
+
+      assert json_response(conn, 403)["error"] == "forbidden"
+    end
+
+    test "version with a missing MinIO object returns 503", %{
+      conn: conn,
+      story: story,
+      raw_token: raw_token,
+      scene_1: scene_1
+    } do
+      {:ok, bad_version} =
+        Storybox.Stories.SceneVersion
+        |> Ash.Changeset.for_create(:create, %{
+          scene_piece_id: scene_1.id,
+          content_uri:
+            "storybox://stories/#{story.id}/scenes/#{scene_1.id}/v999_nonexistent.fountain",
+          version_number: 99,
+          upstream_status: :current,
+          weights: %{}
+        })
+        |> Ash.create(authorize?: false)
+
+      scene_1
+      |> Ash.Changeset.for_update(:approve_version, %{version_id: bad_version.id})
+      |> Ash.update(authorize?: false)
+
+      conn = get_script(conn, story, raw_token, %{mode: "approved"})
+      assert json_response(conn, 503)["error"] == "content unavailable"
+    end
+
+    test "response does not expose content_uri in any version object", %{
+      conn: conn,
+      story: story,
+      raw_token: raw_token
+    } do
+      conn = get_script(conn, story, raw_token, %{mode: "latest"})
+      body = json_response(conn, 200)
+
+      body["sequences"]
+      |> Enum.flat_map(& &1["scenes"])
+      |> Enum.each(fn scene ->
+        if scene["version"] do
+          refute Map.has_key?(scene["version"], "content_uri")
+        end
+      end)
+    end
+  end
+end

--- a/test/storybox_web/controllers/treatment_view_test.exs
+++ b/test/storybox_web/controllers/treatment_view_test.exs
@@ -1,0 +1,338 @@
+defmodule StoryboxWeb.TreatmentViewTest do
+  use StoryboxWeb.ConnCase
+
+  alias Storybox.Accounts.ApiToken
+
+  setup do
+    {:ok, user} =
+      Storybox.Accounts.User
+      |> Ash.Changeset.for_create(:register_with_password, %{
+        email: "treatment_view_test@example.com",
+        password: "password123!",
+        password_confirmation: "password123!"
+      })
+      |> Ash.create()
+
+    {:ok, story} =
+      Storybox.Stories.Story
+      |> Ash.Changeset.for_create(:create, %{
+        title: "Treatment Test Story",
+        through_lines: ["preference", "tension"],
+        user_id: user.id
+      })
+      |> Ash.create()
+
+    {:ok, other_story} =
+      Storybox.Stories.Story
+      |> Ash.Changeset.for_create(:create, %{title: "Other Story", user_id: user.id})
+      |> Ash.create()
+
+    {:ok, raw_token, _} = ApiToken.generate(%{story_id: story.id, user_id: user.id})
+
+    %{user: user, story: story, other_story: other_story, raw_token: raw_token}
+  end
+
+  defp authed(conn, raw_token) do
+    put_req_header(conn, "authorization", "Bearer #{raw_token}")
+  end
+
+  defp create_piece(story, attrs) do
+    {:ok, piece} =
+      Storybox.Stories.SequencePiece
+      |> Ash.Changeset.for_create(:create, Map.put(attrs, :story_id, story.id))
+      |> Ash.create(authorize?: false)
+
+    piece
+  end
+
+  defp create_version(piece, content) do
+    {:ok, version} =
+      Storybox.Stories.SequencePiece
+      |> Ash.ActionInput.for_action(:create_version, %{
+        sequence_piece_id: piece.id,
+        content: content
+      })
+      |> Ash.run_action(authorize?: false)
+
+    version
+  end
+
+  defp approve_version(piece, version) do
+    {:ok, updated} =
+      piece
+      |> Ash.Changeset.for_update(:approve_version, %{version_id: version.id})
+      |> Ash.update(authorize?: false)
+
+    updated
+  end
+
+  # ── treatment view ──────────────────────────────────────────────────────────
+
+  describe "GET /api/stories/:story_id/views/treatment" do
+    test "returns empty acts list when story has no sequences", %{
+      conn: conn,
+      story: story,
+      raw_token: raw_token
+    } do
+      conn = conn |> authed(raw_token) |> get("/api/stories/#{story.id}/views/treatment")
+
+      body = json_response(conn, 200)
+      assert body["story_id"] == story.id
+      assert body["through_lines"] == ["preference", "tension"]
+      assert body["acts"] == []
+    end
+
+    test "returns sequences grouped by act with approved version metadata", %{
+      conn: conn,
+      story: story,
+      raw_token: raw_token
+    } do
+      p1 = create_piece(story, %{title: "Opening", act: "Act I", position: 1})
+      v1 = create_version(p1, "EXT. PARK - DAY\n\nThe story begins.")
+      approve_version(p1, v1)
+
+      # Second piece in Act I — no approved version
+      create_piece(story, %{title: "Complication", act: "Act I", position: 2})
+
+      # Piece in Act II — with approved version
+      p3 = create_piece(story, %{title: "Midpoint", act: "Act II", position: 1})
+      v3 = create_version(p3, "INT. ROOM - NIGHT\n\nThe midpoint shift.")
+      approve_version(p3, v3)
+
+      conn = conn |> authed(raw_token) |> get("/api/stories/#{story.id}/views/treatment")
+
+      body = json_response(conn, 200)
+      acts = body["acts"]
+
+      assert length(acts) == 2
+
+      act1 = Enum.find(acts, &(&1["act"] == "Act I"))
+      assert length(act1["sequences"]) == 2
+
+      opening = Enum.find(act1["sequences"], &(&1["title"] == "Opening"))
+      assert opening["approved_version"]["version_number"] == 1
+      assert opening["approved_version"]["upstream_status"] == "current"
+      assert is_map(opening["approved_version"]["weights"])
+
+      complication = Enum.find(act1["sequences"], &(&1["title"] == "Complication"))
+      assert complication["approved_version"] == nil
+
+      act2 = Enum.find(acts, &(&1["act"] == "Act II"))
+      assert length(act2["sequences"]) == 1
+      assert hd(act2["sequences"])["title"] == "Midpoint"
+      assert hd(act2["sequences"])["approved_version"]["version_number"] == 1
+    end
+
+    test "sequences without an act are grouped under null", %{
+      conn: conn,
+      story: story,
+      raw_token: raw_token
+    } do
+      create_piece(story, %{title: "Unassigned", act: nil, position: 1})
+      create_piece(story, %{title: "First Act", act: "Act I", position: 1})
+
+      conn = conn |> authed(raw_token) |> get("/api/stories/#{story.id}/views/treatment")
+
+      acts = json_response(conn, 200)["acts"]
+
+      # nil act sorts last
+      assert List.last(acts)["act"] == nil
+      assert hd(List.last(acts)["sequences"])["title"] == "Unassigned"
+    end
+
+    test "sequences within an act are sorted by position", %{
+      conn: conn,
+      story: story,
+      raw_token: raw_token
+    } do
+      create_piece(story, %{title: "Third", act: "Act I", position: 3})
+      create_piece(story, %{title: "First", act: "Act I", position: 1})
+      create_piece(story, %{title: "Second", act: "Act I", position: 2})
+
+      conn = conn |> authed(raw_token) |> get("/api/stories/#{story.id}/views/treatment")
+
+      sequences = json_response(conn, 200)["acts"] |> hd() |> Map.get("sequences")
+      assert Enum.map(sequences, & &1["title"]) == ["First", "Second", "Third"]
+    end
+
+    test "response does not expose content_uri", %{
+      conn: conn,
+      story: story,
+      raw_token: raw_token
+    } do
+      p = create_piece(story, %{title: "Scene", act: "Act I", position: 1})
+      v = create_version(p, "content")
+      approve_version(p, v)
+
+      conn = conn |> authed(raw_token) |> get("/api/stories/#{story.id}/views/treatment")
+
+      body = json_response(conn, 200)
+
+      version =
+        body["acts"] |> hd() |> Map.get("sequences") |> hd() |> Map.get("approved_version")
+
+      refute Map.has_key?(version, "content_uri")
+    end
+
+    test "returns 403 when token is scoped to a different story", %{
+      conn: conn,
+      other_story: other_story,
+      raw_token: raw_token
+    } do
+      conn = conn |> authed(raw_token) |> get("/api/stories/#{other_story.id}/views/treatment")
+      assert json_response(conn, 403)["error"] == "forbidden"
+    end
+  end
+
+  # ── sequence detail ──────────────────────────────────────────────────────────
+
+  describe "GET /api/stories/:story_id/sequences/:id" do
+    test "returns content and context for approved version", %{
+      conn: conn,
+      story: story,
+      raw_token: raw_token
+    } do
+      {:ok, character} =
+        Storybox.Stories.Character
+        |> Ash.Changeset.for_create(:create, %{
+          name: "Jane",
+          essence: "A reluctant hero",
+          contradictions: ["wants peace", "excels at violence"],
+          voice: "Laconic",
+          story_id: story.id
+        })
+        |> Ash.create(authorize?: false)
+
+      {:ok, world} =
+        Storybox.Stories.World
+        |> Ash.Changeset.for_create(:create, %{
+          history: "A world of fog",
+          rules: "Magic is forbidden",
+          subtext: "Power corrupts",
+          story_id: story.id
+        })
+        |> Ash.create(authorize?: false)
+
+      p = create_piece(story, %{title: "Opening", act: "Act I", position: 1})
+      v = create_version(p, "EXT. FOREST - DAY\n\nJane walks alone.")
+      approve_version(p, v)
+
+      conn =
+        conn
+        |> authed(raw_token)
+        |> get("/api/stories/#{story.id}/sequences/#{p.id}")
+
+      body = json_response(conn, 200)
+
+      assert body["id"] == p.id
+      assert body["title"] == "Opening"
+      assert body["act"] == "Act I"
+      assert body["position"] == 1
+      assert body["content"] == "EXT. FOREST - DAY\n\nJane walks alone."
+      assert body["version"]["version_number"] == 1
+      assert body["version"]["upstream_status"] == "current"
+
+      assert body["context"]["world"]["id"] == world.id
+      assert body["context"]["world"]["history"] == "A world of fog"
+
+      assert length(body["context"]["characters"]) == 1
+      char = hd(body["context"]["characters"])
+      assert char["id"] == character.id
+      assert char["name"] == "Jane"
+    end
+
+    test "falls back to latest version when no approved version is set", %{
+      conn: conn,
+      story: story,
+      raw_token: raw_token
+    } do
+      p = create_piece(story, %{title: "Draft", act: "Act I", position: 1})
+      create_version(p, "First draft content.")
+      create_version(p, "Second draft content.")
+
+      conn =
+        conn
+        |> authed(raw_token)
+        |> get("/api/stories/#{story.id}/sequences/#{p.id}")
+
+      body = json_response(conn, 200)
+      assert body["version"]["version_number"] == 2
+      assert body["content"] == "Second draft content."
+    end
+
+    test "returns 404 when sequence does not belong to the story", %{
+      conn: conn,
+      story: story,
+      other_story: other_story,
+      raw_token: raw_token
+    } do
+      other_piece = create_piece(other_story, %{title: "Foreign", act: nil, position: 1})
+
+      conn =
+        conn
+        |> authed(raw_token)
+        |> get("/api/stories/#{story.id}/sequences/#{other_piece.id}")
+
+      assert json_response(conn, 404)["error"] == "not found"
+    end
+
+    test "returns 404 when sequence exists but has no versions", %{
+      conn: conn,
+      story: story,
+      raw_token: raw_token
+    } do
+      p = create_piece(story, %{title: "Empty", act: nil, position: 1})
+
+      conn =
+        conn
+        |> authed(raw_token)
+        |> get("/api/stories/#{story.id}/sequences/#{p.id}")
+
+      assert json_response(conn, 404)["error"] == "no version available"
+    end
+
+    test "returns 503 when MinIO object is missing", %{
+      conn: conn,
+      story: story,
+      raw_token: raw_token
+    } do
+      p = create_piece(story, %{title: "Broken", act: nil, position: 1})
+
+      {:ok, bad_version} =
+        Storybox.Stories.SequenceVersion
+        |> Ash.Changeset.for_create(:create, %{
+          sequence_piece_id: p.id,
+          content_uri:
+            "storybox://stories/#{story.id}/sequences/#{p.id}/v999_nonexistent.fountain",
+          version_number: 1,
+          upstream_status: :current,
+          weights: %{}
+        })
+        |> Ash.create(authorize?: false)
+
+      p
+      |> Ash.Changeset.for_update(:approve_version, %{version_id: bad_version.id})
+      |> Ash.update(authorize?: false)
+
+      conn =
+        conn
+        |> authed(raw_token)
+        |> get("/api/stories/#{story.id}/sequences/#{p.id}")
+
+      assert json_response(conn, 503)["error"] == "content unavailable"
+    end
+
+    test "returns 404 for a completely unknown sequence id", %{
+      conn: conn,
+      story: story,
+      raw_token: raw_token
+    } do
+      conn =
+        conn
+        |> authed(raw_token)
+        |> get("/api/stories/#{story.id}/sequences/00000000-0000-0000-0000-000000000000")
+
+      assert json_response(conn, 404)["error"] == "not found"
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `GET /api/stories/:story_id/views/script?mode=latest|approved|snapshot` to the agentic API
- Resolves scene content from MinIO across three modes: `latest` (highest version number per scene), `approved` (approved version pointer), and `snapshot` (pinned versions from a `ScriptSnapshot` entries map)
- Response groups scenes by sequence/act, matching the structure of the treatment view
- Scenes with no resolved version in the given mode return `null` version and `null` content rather than being omitted

## Key decisions

- **Batch DB loading per mode** — all scene versions are loaded in a single query per mode (not N+1 per scene), then resolved in memory
- **Snapshot isolation** — snapshot is verified against `story_id` before use; a snapshot belonging to another story returns 404
- **Inline content** — MinIO content is fetched and included in the response; any MinIO failure short-circuits with 503
- **`content_uri` not exposed** — internal storage URIs are stripped from all version objects in the response

## Test plan

- [x] 118 tests, 0 failures (`mix precommit`)
- [x] `mode=latest` resolves highest-numbered version per scene with content
- [x] `mode=approved` resolves approved pointer; null for unapproved/versionless scenes
- [x] `mode=snapshot` resolves pinned version from entries map (verified against currently approved version to confirm entries take precedence)
- [x] Scenes not in snapshot / with no versions return null gracefully
- [x] Parameter validation: missing mode → 400, invalid mode → 400, snapshot without snapshot_id → 400
- [x] Snapshot from different story → 404
- [x] Wrong-story token → 403
- [x] Missing MinIO object → 503
- [x] `content_uri` not present in any response version object

closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)