### PR TITLE
Write new piece versions via API

### DIFF
--- a/lib/storybox_web/controllers/api_controller.ex
+++ b/lib/storybox_web/controllers/api_controller.ex
@@ -384,6 +384,78 @@ defmodule StoryboxWeb.ApiController do
     }
   end
 
+  def create_sequence_version(conn, %{"id" => id} = params) do
+    story = conn.assigns.current_story
+    content = params["content"]
+
+    if is_nil(content) || content == "" do
+      conn |> put_status(400) |> json(%{error: "content is required"})
+    else
+      piece =
+        Storybox.Stories.SequencePiece
+        |> Ash.Query.filter(id == ^id and story_id == ^story.id)
+        |> Ash.read!(authorize?: false)
+        |> List.first()
+
+      if piece do
+        case Storybox.Stories.SequencePiece
+             |> Ash.ActionInput.for_action(:create_version, %{
+               content: content,
+               sequence_piece_id: piece.id
+             })
+             |> Ash.run_action(authorize?: false) do
+          {:ok, version} ->
+            conn |> put_status(201) |> json(format_version(version))
+
+          {:error, _} ->
+            conn |> put_status(503) |> json(%{error: "storage error"})
+        end
+      else
+        conn |> put_status(404) |> json(%{error: "not found"})
+      end
+    end
+  end
+
+  def create_scene_version(conn, %{"id" => id} = params) do
+    story = conn.assigns.current_story
+    content = params["content"]
+
+    if is_nil(content) || content == "" do
+      conn |> put_status(400) |> json(%{error: "content is required"})
+    else
+      scene =
+        Storybox.Stories.ScenePiece
+        |> Ash.Query.filter(id == ^id)
+        |> Ash.read!(authorize?: false)
+        |> List.first()
+
+      owner =
+        if scene do
+          Storybox.Stories.SequencePiece
+          |> Ash.Query.filter(id == ^scene.sequence_piece_id and story_id == ^story.id)
+          |> Ash.read!(authorize?: false)
+          |> List.first()
+        end
+
+      if scene && owner do
+        case Storybox.Stories.ScenePiece
+             |> Ash.ActionInput.for_action(:create_version, %{
+               content: content,
+               scene_piece_id: scene.id
+             })
+             |> Ash.run_action(authorize?: false) do
+          {:ok, version} ->
+            conn |> put_status(201) |> json(format_version(version))
+
+          {:error, _} ->
+            conn |> put_status(503) |> json(%{error: "storage error"})
+        end
+      else
+        conn |> put_status(404) |> json(%{error: "not found"})
+      end
+    end
+  end
+
   defp format_character(char) do
     %{
       id: char.id,

--- a/lib/storybox_web/router.ex
+++ b/lib/storybox_web/router.ex
@@ -39,6 +39,8 @@ defmodule StoryboxWeb.Router do
     get "/stories/:story_id/views/treatment", ApiController, :treatment_view
     get "/stories/:story_id/views/script", ApiController, :script_view
     get "/stories/:story_id/sequences/:id", ApiController, :sequence_detail
+    post "/stories/:story_id/sequences/:id/versions", ApiController, :create_sequence_version
+    post "/stories/:story_id/scenes/:id/versions", ApiController, :create_scene_version
   end
 
   # Enable LiveDashboard and Swoosh mailbox preview in development

--- a/test/storybox_web/controllers/piece_versions_test.exs
+++ b/test/storybox_web/controllers/piece_versions_test.exs
@@ -1,0 +1,291 @@
+defmodule StoryboxWeb.PieceVersionsTest do
+  use StoryboxWeb.ConnCase
+
+  alias Storybox.Accounts.ApiToken
+
+  # Shared setup creates:
+  #
+  #   user ──── story ──── seq_1 ──── seq_v1 (v1, existing)
+  #          │              └───── scene_1 ── scene_v1 (v1, existing)
+  #          └── other_story ── other_seq ── other_scene
+  #
+  # raw_token is scoped to story. other_seq/other_scene are used for cross-story 404 tests.
+
+  setup do
+    {:ok, user} =
+      Storybox.Accounts.User
+      |> Ash.Changeset.for_create(:register_with_password, %{
+        email: "piece_versions_test@example.com",
+        password: "password123!",
+        password_confirmation: "password123!"
+      })
+      |> Ash.create()
+
+    {:ok, story} =
+      Storybox.Stories.Story
+      |> Ash.Changeset.for_create(:create, %{title: "Piece Versions Story", user_id: user.id})
+      |> Ash.create()
+
+    {:ok, other_story} =
+      Storybox.Stories.Story
+      |> Ash.Changeset.for_create(:create, %{title: "Other Story", user_id: user.id})
+      |> Ash.create()
+
+    {:ok, raw_token, _} = ApiToken.generate(%{story_id: story.id, user_id: user.id})
+
+    {:ok, seq_1} =
+      Storybox.Stories.SequencePiece
+      |> Ash.Changeset.for_create(:create, %{
+        title: "Seq",
+        act: "Act I",
+        position: 1,
+        story_id: story.id
+      })
+      |> Ash.create(authorize?: false)
+
+    {:ok, scene_1} =
+      Storybox.Stories.ScenePiece
+      |> Ash.Changeset.for_create(:create, %{
+        title: "Scene",
+        position: 1,
+        sequence_piece_id: seq_1.id
+      })
+      |> Ash.create(authorize?: false)
+
+    # Existing v1 records created directly (bypasses MinIO in setup)
+    {:ok, _seq_v1} =
+      Storybox.Stories.SequenceVersion
+      |> Ash.Changeset.for_create(:create, %{
+        sequence_piece_id: seq_1.id,
+        content_uri: "storybox://test/seq/v1.fountain",
+        version_number: 1,
+        upstream_status: :current,
+        weights: %{}
+      })
+      |> Ash.create(authorize?: false)
+
+    {:ok, _scene_v1} =
+      Storybox.Stories.SceneVersion
+      |> Ash.Changeset.for_create(:create, %{
+        scene_piece_id: scene_1.id,
+        content_uri: "storybox://test/scene/v1.fountain",
+        version_number: 1,
+        upstream_status: :current,
+        weights: %{}
+      })
+      |> Ash.create(authorize?: false)
+
+    {:ok, other_seq} =
+      Storybox.Stories.SequencePiece
+      |> Ash.Changeset.for_create(:create, %{
+        title: "Other Seq",
+        position: 1,
+        story_id: other_story.id
+      })
+      |> Ash.create(authorize?: false)
+
+    {:ok, other_scene} =
+      Storybox.Stories.ScenePiece
+      |> Ash.Changeset.for_create(:create, %{
+        title: "Other Scene",
+        position: 1,
+        sequence_piece_id: other_seq.id
+      })
+      |> Ash.create(authorize?: false)
+
+    %{
+      story: story,
+      seq_1: seq_1,
+      scene_1: scene_1,
+      other_seq: other_seq,
+      other_scene: other_scene,
+      raw_token: raw_token
+    }
+  end
+
+  describe "POST /api/stories/:story_id/sequences/:id/versions" do
+    test "creates a new version and returns 201", %{
+      conn: conn,
+      story: story,
+      seq_1: seq_1,
+      raw_token: raw_token
+    } do
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{raw_token}")
+        |> post("/api/stories/#{story.id}/sequences/#{seq_1.id}/versions", %{
+          "content" => "EXT. PARK - DAY\nSomething happens."
+        })
+
+      body = json_response(conn, 201)
+      assert body["version_number"]
+      assert body["upstream_status"] == "current"
+      assert body["weights"] == %{}
+      assert body["id"]
+    end
+
+    test "returns version_number 2 when a prior version already exists", %{
+      conn: conn,
+      story: story,
+      seq_1: seq_1,
+      raw_token: raw_token
+    } do
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{raw_token}")
+        |> post("/api/stories/#{story.id}/sequences/#{seq_1.id}/versions", %{
+          "content" => "EXT. PARK - DAY\nNew content."
+        })
+
+      assert json_response(conn, 201)["version_number"] == 2
+    end
+
+    test "returns 400 when content is missing", %{
+      conn: conn,
+      story: story,
+      seq_1: seq_1,
+      raw_token: raw_token
+    } do
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{raw_token}")
+        |> post("/api/stories/#{story.id}/sequences/#{seq_1.id}/versions", %{})
+
+      assert json_response(conn, 400)["error"] == "content is required"
+    end
+
+    test "returns 400 when content is empty string", %{
+      conn: conn,
+      story: story,
+      seq_1: seq_1,
+      raw_token: raw_token
+    } do
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{raw_token}")
+        |> post("/api/stories/#{story.id}/sequences/#{seq_1.id}/versions", %{"content" => ""})
+
+      assert json_response(conn, 400)["error"] == "content is required"
+    end
+
+    test "returns 404 when sequence belongs to a different story", %{
+      conn: conn,
+      story: story,
+      other_seq: other_seq,
+      raw_token: raw_token
+    } do
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{raw_token}")
+        |> post("/api/stories/#{story.id}/sequences/#{other_seq.id}/versions", %{
+          "content" => "Some content."
+        })
+
+      assert json_response(conn, 404)["error"] == "not found"
+    end
+
+    test "returns 404 for a non-existent sequence id", %{
+      conn: conn,
+      story: story,
+      raw_token: raw_token
+    } do
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{raw_token}")
+        |> post(
+          "/api/stories/#{story.id}/sequences/00000000-0000-0000-0000-000000000000/versions",
+          %{
+            "content" => "Some content."
+          }
+        )
+
+      assert json_response(conn, 404)["error"] == "not found"
+    end
+  end
+
+  describe "POST /api/stories/:story_id/scenes/:id/versions" do
+    test "creates a new scene version and returns 201", %{
+      conn: conn,
+      story: story,
+      scene_1: scene_1,
+      raw_token: raw_token
+    } do
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{raw_token}")
+        |> post("/api/stories/#{story.id}/scenes/#{scene_1.id}/versions", %{
+          "content" => "INT. OFFICE - NIGHT\nThey argue."
+        })
+
+      body = json_response(conn, 201)
+      assert body["version_number"]
+      assert body["upstream_status"] == "current"
+      assert body["weights"] == %{}
+      assert body["id"]
+    end
+
+    test "returns version_number 2 when a prior version already exists", %{
+      conn: conn,
+      story: story,
+      scene_1: scene_1,
+      raw_token: raw_token
+    } do
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{raw_token}")
+        |> post("/api/stories/#{story.id}/scenes/#{scene_1.id}/versions", %{
+          "content" => "INT. OFFICE - NIGHT\nNew content."
+        })
+
+      assert json_response(conn, 201)["version_number"] == 2
+    end
+
+    test "returns 400 when content is missing", %{
+      conn: conn,
+      story: story,
+      scene_1: scene_1,
+      raw_token: raw_token
+    } do
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{raw_token}")
+        |> post("/api/stories/#{story.id}/scenes/#{scene_1.id}/versions", %{})
+
+      assert json_response(conn, 400)["error"] == "content is required"
+    end
+
+    test "returns 404 when scene's parent sequence belongs to a different story", %{
+      conn: conn,
+      story: story,
+      other_scene: other_scene,
+      raw_token: raw_token
+    } do
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{raw_token}")
+        |> post("/api/stories/#{story.id}/scenes/#{other_scene.id}/versions", %{
+          "content" => "Some content."
+        })
+
+      assert json_response(conn, 404)["error"] == "not found"
+    end
+
+    test "returns 404 for a non-existent scene id", %{
+      conn: conn,
+      story: story,
+      raw_token: raw_token
+    } do
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{raw_token}")
+        |> post(
+          "/api/stories/#{story.id}/scenes/00000000-0000-0000-0000-000000000000/versions",
+          %{
+            "content" => "Some content."
+          }
+        )
+
+      assert json_response(conn, 404)["error"] == "not found"
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `POST /api/stories/:story_id/sequences/:id/versions` and `POST /api/stories/:story_id/scenes/:id/versions`
- Both endpoints accept `{"content": "..."}`, store the Fountain content to MinIO via the existing `:create_version` action on `SequencePiece`/`ScenePiece`, and return the new version record with 201
- Ownership verification: sequence pieces are checked directly by `story_id`; scene pieces are verified by walking up to the parent `SequencePiece` (two-query check, since `ScenePiece` has no direct `story_id`)

## Key decisions

- **No resource changes** — the `:create_version` generic actions already existed on both piece resources and handle version numbering, URI construction, and MinIO writes. This PR is purely HTTP wiring.
- **400 on blank content** — both missing key and empty string return `{"error": "content is required"}` before any DB or MinIO work is attempted.
- **503 on storage error** — MinIO failures surface as 503.

## Test plan

- [x] `mix precommit` passes (129 tests, 0 failures)
- [x] Creates v2 when a prior version already exists (version numbering via `:create_version`)
- [x] 400 on missing content key
- [x] 400 on empty string content
- [x] 404 when sequence belongs to a different story
- [x] 404 when scene's parent sequence belongs to a different story
- [x] 404 for non-existent IDs (both endpoints)

closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)