### PR TITLE
Implement synopsis diff endpoint

### DIFF
--- a/lib/storybox_web/controllers/api_controller.ex
+++ b/lib/storybox_web/controllers/api_controller.ex
@@ -361,6 +361,123 @@ defmodule StoryboxWeb.ApiController do
     end
   end
 
+  def treatment_diff(conn, params) do
+    story = conn.assigns.current_story
+
+    with {:params, %{"from" => from_str, "to" => to_str}} <- {:params, params},
+         {:parse_from, {from_num, ""}} <- {:parse_from, Integer.parse(from_str)},
+         {:parse_to, {to_num, ""}} <- {:parse_to, Integer.parse(to_str)},
+         {:from_sv, {:ok, from_sv}} when not is_nil(from_sv) <-
+           {:from_sv, load_synopsis_version(story.id, from_num)},
+         {:to_sv, {:ok, to_sv}} when not is_nil(to_sv) <-
+           {:to_sv, load_synopsis_version(story.id, to_num)},
+         {:from_content, {:ok, from_content}} <-
+           {:from_content, Storybox.Storage.get_content(from_sv.content_uri)},
+         {:to_content, {:ok, to_content}} <-
+           {:to_content, Storybox.Storage.get_content(to_sv.content_uri)} do
+      synopsis_diff =
+        List.myers_difference(
+          String.split(from_content, "\n"),
+          String.split(to_content, "\n")
+        )
+        |> Enum.map(fn
+          {:eq, lines} -> %{op: "eq", lines: lines}
+          {:ins, lines} -> %{op: "ins", lines: lines}
+          {:del, lines} -> %{op: "del", lines: lines}
+        end)
+
+      pieces =
+        Storybox.Stories.SequencePiece
+        |> Ash.Query.filter(story_id == ^story.id)
+        |> Ash.Query.sort(position: :asc)
+        |> Ash.read!(authorize?: false)
+
+      approved_ids =
+        pieces
+        |> Enum.map(& &1.approved_version_id)
+        |> Enum.reject(&is_nil/1)
+
+      versions_by_id =
+        case approved_ids do
+          [] ->
+            %{}
+
+          ids ->
+            Storybox.Stories.SequenceVersion
+            |> Ash.Query.filter(id in ^ids)
+            |> Ash.read!(authorize?: false)
+            |> Map.new(&{&1.id, &1})
+        end
+
+      {affected, unaffected, new} =
+        Enum.reduce(pieces, {[], [], []}, fn piece, {aff, unaff, new_acc} ->
+          version = versions_by_id[piece.approved_version_id]
+          formatted = format_piece(piece, version)
+
+          cond do
+            is_nil(piece.approved_version_id) -> {aff, unaff, [formatted | new_acc]}
+            version && version.upstream_status == :stale -> {[formatted | aff], unaff, new_acc}
+            true -> {aff, [formatted | unaff], new_acc}
+          end
+        end)
+
+      json(conn, %{
+        story_id: story.id,
+        from_version: from_num,
+        to_version: to_num,
+        synopsis_diff: synopsis_diff,
+        sequences: %{
+          affected: Enum.reverse(affected),
+          unaffected: Enum.reverse(unaffected),
+          new: Enum.reverse(new)
+        }
+      })
+    else
+      {:params, _} ->
+        conn |> put_status(400) |> json(%{error: "from and to version numbers are required"})
+
+      {:parse_from, _} ->
+        conn |> put_status(400) |> json(%{error: "from and to must be integers"})
+
+      {:parse_to, _} ->
+        conn |> put_status(400) |> json(%{error: "from and to must be integers"})
+
+      {:from_sv, {:ok, nil}} ->
+        conn |> put_status(404) |> json(%{error: "synopsis version not found"})
+
+      {:from_sv, _} ->
+        conn |> put_status(500) |> json(%{error: "internal error"})
+
+      {:to_sv, {:ok, nil}} ->
+        conn |> put_status(404) |> json(%{error: "synopsis version not found"})
+
+      {:to_sv, _} ->
+        conn |> put_status(500) |> json(%{error: "internal error"})
+
+      {:from_content, _} ->
+        conn |> put_status(503) |> json(%{error: "content unavailable"})
+
+      {:to_content, _} ->
+        conn |> put_status(503) |> json(%{error: "content unavailable"})
+    end
+  end
+
+  defp load_synopsis_version(story_id, version_number) do
+    Storybox.Stories.SynopsisVersion
+    |> Ash.Query.filter(story_id == ^story_id and version_number == ^version_number)
+    |> Ash.read_one(authorize?: false)
+  end
+
+  defp format_piece(piece, version) do
+    %{
+      id: piece.id,
+      title: piece.title,
+      act: piece.act,
+      position: piece.position,
+      approved_version: format_version(version)
+    }
+  end
+
   defp format_version(nil), do: nil
 
   defp format_version(version) do

--- a/lib/storybox_web/router.ex
+++ b/lib/storybox_web/router.ex
@@ -37,6 +37,7 @@ defmodule StoryboxWeb.Router do
     get "/stories/:story_id/ping", ApiController, :ping
     get "/stories/:story_id/views/synopsis", ApiController, :synopsis_view
     get "/stories/:story_id/views/treatment", ApiController, :treatment_view
+    get "/stories/:story_id/views/treatment/diff", ApiController, :treatment_diff
     get "/stories/:story_id/views/script", ApiController, :script_view
     get "/stories/:story_id/sequences/:id", ApiController, :sequence_detail
     post "/stories/:story_id/sequences/:id/versions", ApiController, :create_sequence_version

--- a/test/storybox_web/controllers/treatment_diff_test.exs
+++ b/test/storybox_web/controllers/treatment_diff_test.exs
@@ -1,0 +1,335 @@
+defmodule StoryboxWeb.TreatmentDiffTest do
+  use StoryboxWeb.ConnCase
+
+  alias Storybox.Accounts.ApiToken
+
+  setup do
+    {:ok, user} =
+      Storybox.Accounts.User
+      |> Ash.Changeset.for_create(:register_with_password, %{
+        email: "diff_test@example.com",
+        password: "password123!",
+        password_confirmation: "password123!"
+      })
+      |> Ash.create()
+
+    {:ok, story} =
+      Storybox.Stories.Story
+      |> Ash.Changeset.for_create(:create, %{
+        title: "Diff Test Story",
+        through_lines: ["courage"],
+        user_id: user.id
+      })
+      |> Ash.create()
+
+    {:ok, other_story} =
+      Storybox.Stories.Story
+      |> Ash.Changeset.for_create(:create, %{title: "Other Story", user_id: user.id})
+      |> Ash.create()
+
+    # v1 — "Act II: The conflict grows." will appear as a del
+    {:ok, _sv1} =
+      Storybox.Stories.SynopsisVersion
+      |> Ash.ActionInput.for_action(:create_version, %{
+        story_id: story.id,
+        content: "Act I: The hero begins.\nAct II: The conflict grows."
+      })
+      |> Ash.run_action()
+
+    # v2 — replaces the Act II line, adds Act III
+    {:ok, _sv2} =
+      Storybox.Stories.SynopsisVersion
+      |> Ash.ActionInput.for_action(:create_version, %{
+        story_id: story.id,
+        content: "Act I: The hero begins.\nAct II: The conflict escalates.\nAct III: Resolution."
+      })
+      |> Ash.run_action()
+
+    # "Opening" — has a current approved version (upstream_status: :current)
+    {:ok, opening} =
+      Storybox.Stories.SequencePiece
+      |> Ash.Changeset.for_create(:create, %{
+        title: "Opening",
+        act: "Act I",
+        position: 1,
+        story_id: story.id
+      })
+      |> Ash.create(authorize?: false)
+
+    {:ok, opening_v} =
+      Storybox.Stories.SequencePiece
+      |> Ash.ActionInput.for_action(:create_version, %{
+        sequence_piece_id: opening.id,
+        content: "EXT. PARK - DAY\n\nThe hero walks alone."
+      })
+      |> Ash.run_action(authorize?: false)
+
+    {:ok, _} =
+      opening
+      |> Ash.Changeset.for_update(:approve_version, %{version_id: opening_v.id})
+      |> Ash.update(authorize?: false)
+
+    # "Midpoint" — has a stale approved version (upstream_status: :stale)
+    {:ok, midpoint} =
+      Storybox.Stories.SequencePiece
+      |> Ash.Changeset.for_create(:create, %{
+        title: "Midpoint",
+        act: "Act II",
+        position: 1,
+        story_id: story.id
+      })
+      |> Ash.create(authorize?: false)
+
+    {:ok, stale_v} =
+      Storybox.Stories.SequenceVersion
+      |> Ash.Changeset.for_create(:create, %{
+        sequence_piece_id: midpoint.id,
+        content_uri: "storybox://stories/#{story.id}/sequences/#{midpoint.id}/v1.fountain",
+        version_number: 1,
+        upstream_status: :stale,
+        weights: %{}
+      })
+      |> Ash.create(authorize?: false)
+
+    {:ok, _} =
+      midpoint
+      |> Ash.Changeset.for_update(:approve_version, %{version_id: stale_v.id})
+      |> Ash.update(authorize?: false)
+
+    # "Draft" — no approved version
+    {:ok, _draft} =
+      Storybox.Stories.SequencePiece
+      |> Ash.Changeset.for_create(:create, %{
+        title: "Draft",
+        act: "Act I",
+        position: 2,
+        story_id: story.id
+      })
+      |> Ash.create(authorize?: false)
+
+    {:ok, raw_token, _} = ApiToken.generate(%{story_id: story.id, user_id: user.id})
+
+    %{user: user, story: story, other_story: other_story, raw_token: raw_token}
+  end
+
+  defp authed(conn, raw_token) do
+    put_req_header(conn, "authorization", "Bearer #{raw_token}")
+  end
+
+  describe "GET /api/stories/:story_id/views/treatment/diff" do
+    test "returns 200 with story_id, from_version, to_version", %{
+      conn: conn,
+      story: story,
+      raw_token: raw_token
+    } do
+      conn =
+        conn
+        |> authed(raw_token)
+        |> get("/api/stories/#{story.id}/views/treatment/diff?from=1&to=2")
+
+      body = json_response(conn, 200)
+      assert body["story_id"] == story.id
+      assert body["from_version"] == 1
+      assert body["to_version"] == 2
+    end
+
+    test "synopsis_diff eq entry contains unchanged first line", %{
+      conn: conn,
+      story: story,
+      raw_token: raw_token
+    } do
+      conn =
+        conn
+        |> authed(raw_token)
+        |> get("/api/stories/#{story.id}/views/treatment/diff?from=1&to=2")
+
+      diff = json_response(conn, 200)["synopsis_diff"]
+      eq_entry = Enum.find(diff, &(&1["op"] == "eq"))
+      assert eq_entry != nil
+      assert "Act I: The hero begins." in eq_entry["lines"]
+    end
+
+    test "synopsis_diff del entry contains removed line", %{
+      conn: conn,
+      story: story,
+      raw_token: raw_token
+    } do
+      conn =
+        conn
+        |> authed(raw_token)
+        |> get("/api/stories/#{story.id}/views/treatment/diff?from=1&to=2")
+
+      diff = json_response(conn, 200)["synopsis_diff"]
+      del_entry = Enum.find(diff, &(&1["op"] == "del"))
+      assert del_entry != nil
+      assert "Act II: The conflict grows." in del_entry["lines"]
+    end
+
+    test "synopsis_diff ins entries contain added lines", %{
+      conn: conn,
+      story: story,
+      raw_token: raw_token
+    } do
+      conn =
+        conn
+        |> authed(raw_token)
+        |> get("/api/stories/#{story.id}/views/treatment/diff?from=1&to=2")
+
+      diff = json_response(conn, 200)["synopsis_diff"]
+      ins_lines = diff |> Enum.filter(&(&1["op"] == "ins")) |> Enum.flat_map(& &1["lines"])
+      assert "Act II: The conflict escalates." in ins_lines
+      assert "Act III: Resolution." in ins_lines
+    end
+
+    test "sequences.unaffected contains Opening with upstream_status current", %{
+      conn: conn,
+      story: story,
+      raw_token: raw_token
+    } do
+      conn =
+        conn
+        |> authed(raw_token)
+        |> get("/api/stories/#{story.id}/views/treatment/diff?from=1&to=2")
+
+      unaffected = json_response(conn, 200)["sequences"]["unaffected"]
+      assert length(unaffected) == 1
+      opening = hd(unaffected)
+      assert opening["title"] == "Opening"
+      assert opening["approved_version"]["upstream_status"] == "current"
+    end
+
+    test "sequences.affected contains Midpoint with upstream_status stale", %{
+      conn: conn,
+      story: story,
+      raw_token: raw_token
+    } do
+      conn =
+        conn
+        |> authed(raw_token)
+        |> get("/api/stories/#{story.id}/views/treatment/diff?from=1&to=2")
+
+      affected = json_response(conn, 200)["sequences"]["affected"]
+      assert length(affected) == 1
+      midpoint = hd(affected)
+      assert midpoint["title"] == "Midpoint"
+      assert midpoint["approved_version"]["upstream_status"] == "stale"
+    end
+
+    test "sequences.new contains Draft with null approved_version", %{
+      conn: conn,
+      story: story,
+      raw_token: raw_token
+    } do
+      conn =
+        conn
+        |> authed(raw_token)
+        |> get("/api/stories/#{story.id}/views/treatment/diff?from=1&to=2")
+
+      new_seqs = json_response(conn, 200)["sequences"]["new"]
+      assert length(new_seqs) == 1
+      draft = hd(new_seqs)
+      assert draft["title"] == "Draft"
+      assert draft["approved_version"] == nil
+    end
+
+    test "sequence entries include id, title, act, position, approved_version fields", %{
+      conn: conn,
+      story: story,
+      raw_token: raw_token
+    } do
+      conn =
+        conn
+        |> authed(raw_token)
+        |> get("/api/stories/#{story.id}/views/treatment/diff?from=1&to=2")
+
+      sequences = json_response(conn, 200)["sequences"]
+      all = sequences["affected"] ++ sequences["unaffected"] ++ sequences["new"]
+
+      for seq <- all do
+        assert Map.has_key?(seq, "id")
+        assert Map.has_key?(seq, "title")
+        assert Map.has_key?(seq, "act")
+        assert Map.has_key?(seq, "position")
+        assert Map.has_key?(seq, "approved_version")
+      end
+    end
+
+    test "returns 400 when from param is missing", %{
+      conn: conn,
+      story: story,
+      raw_token: raw_token
+    } do
+      conn =
+        conn
+        |> authed(raw_token)
+        |> get("/api/stories/#{story.id}/views/treatment/diff?to=2")
+
+      assert json_response(conn, 400)["error"] == "from and to version numbers are required"
+    end
+
+    test "returns 400 when to param is missing", %{
+      conn: conn,
+      story: story,
+      raw_token: raw_token
+    } do
+      conn =
+        conn
+        |> authed(raw_token)
+        |> get("/api/stories/#{story.id}/views/treatment/diff?from=1")
+
+      assert json_response(conn, 400)["error"] == "from and to version numbers are required"
+    end
+
+    test "returns 400 when from is not a valid integer", %{
+      conn: conn,
+      story: story,
+      raw_token: raw_token
+    } do
+      conn =
+        conn
+        |> authed(raw_token)
+        |> get("/api/stories/#{story.id}/views/treatment/diff?from=abc&to=2")
+
+      assert json_response(conn, 400)["error"] == "from and to must be integers"
+    end
+
+    test "returns 404 when from version does not exist", %{
+      conn: conn,
+      story: story,
+      raw_token: raw_token
+    } do
+      conn =
+        conn
+        |> authed(raw_token)
+        |> get("/api/stories/#{story.id}/views/treatment/diff?from=999&to=2")
+
+      assert json_response(conn, 404)["error"] == "synopsis version not found"
+    end
+
+    test "returns 404 when to version does not exist", %{
+      conn: conn,
+      story: story,
+      raw_token: raw_token
+    } do
+      conn =
+        conn
+        |> authed(raw_token)
+        |> get("/api/stories/#{story.id}/views/treatment/diff?from=1&to=999")
+
+      assert json_response(conn, 404)["error"] == "synopsis version not found"
+    end
+
+    test "returns 403 when token is scoped to a different story", %{
+      conn: conn,
+      other_story: other_story,
+      raw_token: raw_token
+    } do
+      conn =
+        conn
+        |> authed(raw_token)
+        |> get("/api/stories/#{other_story.id}/views/treatment/diff?from=1&to=2")
+
+      assert json_response(conn, 403)["error"] == "forbidden"
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `GET /api/stories/:story_id/views/treatment/diff?from=<n>&to=<m>` endpoint
- `from` and `to` are `SynopsisVersion` version numbers — the endpoint fetches both, computes a line-by-line Myers diff of their content, and categorises all treatment sequences as **affected** (stale approved version), **unaffected** (current approved version), or **new** (no approved version)
- Uses `List.myers_difference/2` from Elixir's standard library — no new dependencies

## Key decisions

- **Myers diff over synopsis content, not sequences**: the diff parameters reference synopsis versions, not sequence versions. The sequence categorisation reflects their current `upstream_status`, giving an agent a clear scope of work after a synopsis change.
- **No "removed" category**: sequences are never hard-deleted in the current data model, so the category is omitted rather than returning a meaningless empty array.
- **Guard-based `with` pipeline**: each step in the `with` chain is tagged (e.g. `{:from_sv, ...}`) so the `else` clause can return a precise error status for each failure mode without nested `case` blocks.

## Test plan

- [x] `mix precommit` passes — 143 tests, 0 failures
- [x] Returns correct `synopsis_diff` with `eq`/`del`/`ins` entries referencing the actual changed lines
- [x] `sequences.unaffected` / `.affected` / `.new` correctly categorise the three seed sequences
- [x] All sequence entries include `id`, `title`, `act`, `position`, `approved_version`
- [x] Returns 400 when `from` or `to` is missing
- [x] Returns 400 when `from` is not a valid integer
- [x] Returns 404 when either synopsis version does not exist
- [x] Returns 403 when token is scoped to a different story

closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)