### PR TITLE
LiveView: story list — closes #19

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -55,6 +55,9 @@ config :ex_aws, :s3,
 
 config :storybox, minio_bucket: "storybox-pieces"
 
+# AshAuthentication.Phoenix — use verified routes instead of router helpers
+config :ash_authentication_phoenix, :auth_routes_prefix, "/"
+
 # Ash formatter plugin
 config :ash, :formatter, extensions: [Ash.Formatter]
 

--- a/lib/storybox/accounts/user.ex
+++ b/lib/storybox/accounts/user.ex
@@ -20,6 +20,7 @@ defmodule Storybox.Accounts.User do
     tokens do
       enabled?(true)
       token_resource(Storybox.Accounts.Token)
+      store_all_tokens?(true)
       require_token_presence_for_authentication?(true)
 
       signing_secret(fn _, _ ->

--- a/lib/storybox_web/components/layouts.ex
+++ b/lib/storybox_web/components/layouts.ex
@@ -26,10 +26,7 @@ defmodule StoryboxWeb.Layouts do
 
   """
   attr :flash, :map, required: true, doc: "the map of flash messages"
-
-  attr :current_scope, :map,
-    default: nil,
-    doc: "the current [scope](https://hexdocs.pm/phoenix/scopes.html)"
+  attr :current_user, :map, default: nil, doc: "the currently logged-in user, if any"
 
   slot :inner_block, required: true
 
@@ -37,30 +34,29 @@ defmodule StoryboxWeb.Layouts do
     ~H"""
     <header class="navbar px-4 sm:px-6 lg:px-8">
       <div class="flex-1">
-        <a href="/" class="flex-1 flex w-fit items-center gap-2">
+        <a href="/" class="flex w-fit items-center gap-2">
           <img src={~p"/images/logo.svg"} width="36" />
-          <span class="text-sm font-semibold">v{Application.spec(:phoenix, :vsn)}</span>
+          <span class="text-sm font-semibold">Storybox</span>
         </a>
       </div>
       <div class="flex-none">
-        <ul class="flex flex-column px-1 space-x-4 items-center">
-          <li>
-            <a href="https://phoenixframework.org/" class="btn btn-ghost">Website</a>
-          </li>
-          <li>
-            <a href="https://github.com/phoenixframework/phoenix" class="btn btn-ghost">GitHub</a>
-          </li>
-          <li>
-            <a href="https://hexdocs.pm/phoenix/overview.html" class="btn btn-primary">
-              Get Started <span aria-hidden="true">&rarr;</span>
-            </a>
-          </li>
+        <ul class="flex items-center px-1 space-x-4">
+          <%= if @current_user do %>
+            <li class="text-sm text-base-content/60">{@current_user.email}</li>
+            <li>
+              <a href={~p"/sign-out"} class="btn btn-ghost btn-sm">Sign out</a>
+            </li>
+          <% else %>
+            <li>
+              <a href={~p"/sign-in"} class="btn btn-primary btn-sm">Sign in</a>
+            </li>
+          <% end %>
         </ul>
       </div>
     </header>
 
-    <main class="px-4 py-20 sm:px-6 lg:px-8">
-      <div class="mx-auto max-w-2xl space-y-4">
+    <main class="px-4 py-10 sm:px-6 lg:px-8">
+      <div class="mx-auto max-w-3xl space-y-4">
         {render_slot(@inner_block)}
       </div>
     </main>

--- a/lib/storybox_web/live/story_list_live.ex
+++ b/lib/storybox_web/live/story_list_live.ex
@@ -1,0 +1,55 @@
+defmodule StoryboxWeb.StoryListLive do
+  use StoryboxWeb, :live_view
+
+  require Ash.Query
+
+  @impl true
+  def mount(_params, _session, socket) do
+    case socket.assigns[:current_user] do
+      nil ->
+        {:ok, redirect(socket, to: ~p"/sign-in")}
+
+      user ->
+        stories =
+          Storybox.Stories.Story
+          |> Ash.Query.filter(user_id == ^user.id)
+          |> Ash.Query.sort(inserted_at: :desc)
+          |> Ash.read!(authorize?: false)
+
+        {:ok, assign(socket, stories: stories, page_title: "My Stories")}
+    end
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <Layouts.app flash={@flash} current_user={@current_user}>
+      <div class="space-y-6">
+        <div class="flex items-center justify-between">
+          <h1 class="text-2xl font-bold">My Stories</h1>
+        </div>
+
+        <%= if @stories == [] do %>
+          <p class="text-base-content/60">No stories yet. Start writing your first story.</p>
+        <% else %>
+          <ul class="space-y-4">
+            <%= for story <- @stories do %>
+              <li class="card bg-base-200 shadow-sm">
+                <div class="card-body py-4">
+                  <h2 class="card-title text-lg">{story.title}</h2>
+                  <%= if story.logline do %>
+                    <p class="text-base-content/70 text-sm">{story.logline}</p>
+                  <% end %>
+                  <p class="text-base-content/40 text-xs">
+                    Created {Calendar.strftime(story.inserted_at, "%B %-d, %Y")}
+                  </p>
+                </div>
+              </li>
+            <% end %>
+          </ul>
+        <% end %>
+      </div>
+    </Layouts.app>
+    """
+  end
+end

--- a/lib/storybox_web/router.ex
+++ b/lib/storybox_web/router.ex
@@ -28,7 +28,10 @@ defmodule StoryboxWeb.Router do
     auth_routes(Storybox.Accounts.User, to: AuthController)
     reset_route([])
 
-    get "/", PageController, :home
+    live_session :authenticated,
+      on_mount: AshAuthentication.Phoenix.LiveSession do
+      live "/", StoryListLive
+    end
   end
 
   scope "/api", StoryboxWeb do

--- a/lib/storybox_web/router.ex
+++ b/lib/storybox_web/router.ex
@@ -23,10 +23,10 @@ defmodule StoryboxWeb.Router do
   scope "/", StoryboxWeb do
     pipe_through :browser
 
-    sign_in_route(register_path: "/register", reset_path: "/reset")
+    sign_in_route(register_path: "/register", reset_path: "/reset", auth_routes_prefix: "/auth")
     sign_out_route(AuthController)
-    auth_routes(Storybox.Accounts.User, to: AuthController)
-    reset_route([])
+    auth_routes(AuthController, Storybox.Accounts.User)
+    reset_route(auth_routes_prefix: "/auth")
 
     live_session :authenticated,
       on_mount: AshAuthentication.Phoenix.LiveSession do

--- a/priv/repo/migrations/20260411153340_rename_tokens_inserted_at_to_created_at.exs
+++ b/priv/repo/migrations/20260411153340_rename_tokens_inserted_at_to_created_at.exs
@@ -1,0 +1,7 @@
+defmodule Storybox.Repo.Migrations.RenameTokensInsertedAtToCreatedAt do
+  use Ecto.Migration
+
+  def change do
+    rename table(:tokens), :inserted_at, to: :created_at
+  end
+end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -1,11 +1,62 @@
-# Script for populating the database. You can run it as:
+require Ash.Query
+
+# ---------------------------------------------------------------------------
+# Dev seed data
 #
-#     mix run priv/repo/seeds.exs
-#
-# Inside the script, you can read and write to any of your
-# repositories directly:
-#
-#     Storybox.Repo.insert!(%Storybox.SomeSchema{})
-#
-# We recommend using the bang functions (`insert!`, `update!`
-# and so on) as they will fail if something goes wrong.
+# Test account — email: dev@storybox.test / password: Password1!
+# ---------------------------------------------------------------------------
+
+dev_user =
+  case Storybox.Accounts.User
+       |> Ash.Query.filter(email == "dev@storybox.test")
+       |> Ash.read_one!(authorize?: false) do
+    nil ->
+      Storybox.Accounts.User
+      |> Ash.Changeset.for_create(:register_with_password, %{
+        email: "dev@storybox.test",
+        password: "Password1!",
+        password_confirmation: "Password1!"
+      })
+      |> Ash.create!()
+
+    existing ->
+      existing
+  end
+
+IO.puts("Dev user ready: #{dev_user.email}")
+
+# Stories for the dev user
+existing_titles =
+  Storybox.Stories.Story
+  |> Ash.Query.filter(user_id == ^dev_user.id)
+  |> Ash.read!(authorize?: false)
+  |> Enum.map(& &1.title)
+
+stories = [
+  %{
+    title: "The Long Road Home",
+    logline: "A soldier returns from war to find his hometown unrecognisable.",
+    controlling_idea: "Redemption requires accepting what cannot be undone.",
+    through_lines: ["preference", "theme"]
+  },
+  %{
+    title: "Beneath the Surface",
+    logline: nil,
+    controlling_idea: nil,
+    through_lines: ["preference"]
+  },
+  %{
+    title: "Echo Chamber",
+    logline: "In a world of perfect information, one woman discovers the truth is still hidden.",
+    controlling_idea: nil,
+    through_lines: ["preference"]
+  }
+]
+
+for attrs <- stories, attrs.title not in existing_titles do
+  Storybox.Stories.Story
+  |> Ash.Changeset.for_create(:create, Map.put(attrs, :user_id, dev_user.id))
+  |> Ash.create!(authorize?: false)
+
+  IO.puts("  Created story: #{attrs.title}")
+end

--- a/test/storybox_web/controllers/page_controller_test.exs
+++ b/test/storybox_web/controllers/page_controller_test.exs
@@ -1,8 +1,8 @@
 defmodule StoryboxWeb.PageControllerTest do
   use StoryboxWeb.ConnCase
 
-  test "GET /", %{conn: conn} do
+  test "GET / redirects unauthenticated users to sign-in", %{conn: conn} do
     conn = get(conn, ~p"/")
-    assert html_response(conn, 200) =~ "Peace of mind from prototype to production"
+    assert redirected_to(conn) == ~p"/sign-in"
   end
 end

--- a/test/storybox_web/live/story_list_live_test.exs
+++ b/test/storybox_web/live/story_list_live_test.exs
@@ -1,0 +1,119 @@
+defmodule StoryboxWeb.StoryListLiveTest do
+  use StoryboxWeb.ConnCase
+
+  import Phoenix.LiveViewTest
+
+  setup do
+    {:ok, alice} =
+      Storybox.Accounts.User
+      |> Ash.Changeset.for_create(:register_with_password, %{
+        email: "alice@example.com",
+        password: "password123!",
+        password_confirmation: "password123!"
+      })
+      |> Ash.create()
+
+    {:ok, bob} =
+      Storybox.Accounts.User
+      |> Ash.Changeset.for_create(:register_with_password, %{
+        email: "bob@example.com",
+        password: "password123!",
+        password_confirmation: "password123!"
+      })
+      |> Ash.create()
+
+    {:ok, redemption_arc} =
+      Storybox.Stories.Story
+      |> Ash.Changeset.for_create(:create, %{
+        title: "Redemption Arc",
+        logline: "A man seeks redemption",
+        user_id: alice.id
+      })
+      |> Ash.create()
+
+    {:ok, the_heist} =
+      Storybox.Stories.Story
+      |> Ash.Changeset.for_create(:create, %{
+        title: "The Heist",
+        user_id: alice.id
+      })
+      |> Ash.create()
+
+    {:ok, _bobs_story} =
+      Storybox.Stories.Story
+      |> Ash.Changeset.for_create(:create, %{
+        title: "Bob's Story",
+        user_id: bob.id
+      })
+      |> Ash.create()
+
+    %{
+      alice: alice,
+      bob: bob,
+      redemption_arc: redemption_arc,
+      the_heist: the_heist
+    }
+  end
+
+  describe "unauthenticated access" do
+    test "redirects to sign-in when not logged in", %{conn: conn} do
+      assert {:error, {:redirect, %{to: "/sign-in"}}} = live(conn, "/")
+    end
+  end
+
+  describe "authenticated story list" do
+    test "shows Alice's story titles", %{conn: conn, alice: alice} do
+      conn = log_in_user(conn, alice)
+      {:ok, _view, html} = live(conn, "/")
+
+      assert html =~ "Redemption Arc"
+      assert html =~ "The Heist"
+    end
+
+    test "shows the logline for Redemption Arc", %{conn: conn, alice: alice} do
+      conn = log_in_user(conn, alice)
+      {:ok, _view, html} = live(conn, "/")
+
+      assert html =~ "A man seeks redemption"
+    end
+
+    test "does not show Bob's Story to Alice", %{conn: conn, alice: alice} do
+      conn = log_in_user(conn, alice)
+      {:ok, _view, html} = live(conn, "/")
+
+      refute html =~ "Bob&#39;s Story"
+      refute html =~ "Bob's Story"
+    end
+
+    test "shows empty state when user has no stories", %{conn: conn} do
+      # Bob has a story in setup but we create a fresh user with no stories
+      {:ok, empty_user} =
+        Storybox.Accounts.User
+        |> Ash.Changeset.for_create(:register_with_password, %{
+          email: "empty@example.com",
+          password: "password123!",
+          password_confirmation: "password123!"
+        })
+        |> Ash.create()
+
+      conn = log_in_user(conn, empty_user)
+      {:ok, _view, html} = live(conn, "/")
+
+      assert html =~ "No stories yet"
+    end
+
+    test "sign-out link is present in the layout", %{conn: conn, alice: alice} do
+      conn = log_in_user(conn, alice)
+      {:ok, _view, html} = live(conn, "/")
+
+      assert html =~ "/sign-out"
+    end
+
+    test "shows Alice's email in the layout", %{conn: conn, alice: alice} do
+      conn = log_in_user(conn, alice)
+      {:ok, _view, html} = live(conn, "/")
+
+      assert html =~ "alice@example.com"
+    end
+  end
+end

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -35,4 +35,25 @@ defmodule StoryboxWeb.ConnCase do
     Storybox.DataCase.setup_sandbox(tags)
     {:ok, conn: Phoenix.ConnTest.build_conn()}
   end
+
+  @doc """
+  Stores a user in the Plug session so that LiveView tests can mount
+  as an authenticated user via the AshAuthentication.Phoenix.LiveSession hook.
+  """
+  def log_in_user(conn, user) do
+    {:ok, token, _claims} = AshAuthentication.Jwt.token_for_user(user)
+
+    :ok =
+      AshAuthentication.TokenResource.Actions.store_token(
+        Storybox.Accounts.Token,
+        %{"token" => token, "purpose" => "user"},
+        context: %{private: %{ash_authentication?: true}}
+      )
+
+    user = %{user | __metadata__: Map.put(user.__metadata__, :token, token)}
+
+    conn
+    |> Plug.Test.init_test_session(%{})
+    |> AshAuthentication.Phoenix.Plug.store_in_session(user)
+  end
 end


### PR DESCRIPTION
## Summary

- Replaces \`PageController :home\` at \`/\` with \`StoryListLive\` — users land on their story list after login
- Unauthenticated requests redirect to \`/sign-in\` via the \`AshAuthentication.Phoenix.LiveSession\` on_mount hook
- Stories are filtered by \`user_id\` and sorted newest-first; each card shows title, logline (if present), and creation date
- \`Layouts.app\` updated: placeholder Phoenix nav links replaced with user email + sign-out link (or sign-in link for unauthenticated)
- \`ConnCase.log_in_user/2\` helper added for authenticating LiveView tests — generates a JWT, stores it in the token resource (needed because \`require_token_presence_for_authentication?: true\`), and seeds the session
- Dev seed data added: \`dev@storybox.test\` with three sample stories, idempotent, runs via \`mix setup\`

## Key decisions

**\`log_in_user/2\` must store the token in the DB.** The User resource has \`require_token_presence_for_authentication?: true\`, meaning the LiveSession hook does a DB lookup (\`get_token\`) in addition to JWT signature verification. Simply generating a JWT and storing it in the session is insufficient — the token record must exist in the \`tokens\` table. The helper calls \`AshAuthentication.TokenResource.Actions.store_token/3\` explicitly.

**\`store_all_tokens?: true\` required alongside \`require_token_presence_for_authentication?: true\`.** Without it, AshAuthentication issues JWTs on login/register but never writes them to the tokens table, so the LiveSession DB check always fails and loops back to sign-in.

**Tokens table schema fix included.** The existing \`tokens\` migration used Ecto's \`timestamps()\` which creates \`inserted_at\`, but the AshAuthentication snapshot expects \`created_at\`. A migration to rename the column is included.

**auth_routes argument order fixed.** The original router had \`auth_routes(User, to: Controller)\` which is backwards — correct signature is \`auth_routes(Controller, User)\`. \`sign_in_route\` and \`reset_route\` also need \`auth_routes_prefix: "/auth"\` so the LiveView form can build action URLs without router helpers (disabled by default in Phoenix 1.7+).

## Test plan

- [x] \`mix precommit\` passes — 150 tests, 0 failures
- [x] Unauthenticated \`GET /\` redirects to \`/sign-in\`
- [x] Alice sees "Redemption Arc" and "The Heist" in her story list
- [x] Alice sees the logline "A man seeks redemption" on the Redemption Arc card
- [x] Alice does not see "Bob's Story" (cross-user isolation)
- [x] A user with no stories sees the empty-state message
- [x] Sign-out link is present in the layout when authenticated
- [x] Alice's email is shown in the nav

### User validates
- [x] Story cards look reasonable — titles readable, dates formatted sensibly, layout not broken
- [x] Sign-out link works — clears session and redirects
- [x] Fresh session (incognito after sign-out) lands at \`/sign-in\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)