### PR TITLE
LiveView: treatment view

### DIFF
--- a/lib/storybox_web/live/treatment_live.ex
+++ b/lib/storybox_web/live/treatment_live.ex
@@ -1,0 +1,189 @@
+defmodule StoryboxWeb.TreatmentLive do
+  use StoryboxWeb, :live_view
+
+  require Ash.Query
+
+  @impl true
+  def mount(%{"story_id" => story_id}, _session, socket) do
+    case socket.assigns[:current_user] do
+      nil ->
+        {:ok, redirect(socket, to: ~p"/sign-in")}
+
+      user ->
+        story =
+          Storybox.Stories.Story
+          |> Ash.Query.filter(id == ^story_id and user_id == ^user.id)
+          |> Ash.read_one!(authorize?: false)
+
+        case story do
+          nil ->
+            {:ok,
+             socket
+             |> put_flash(:error, "Story not found.")
+             |> redirect(to: ~p"/")}
+
+          story ->
+            {:ok,
+             socket
+             |> assign(:story, story)
+             |> assign(:acts, load_acts(story))
+             |> assign(:page_title, "#{story.title} — Treatment")}
+        end
+    end
+  end
+
+  @impl true
+  def handle_event(
+        "approve_version",
+        %{"piece-id" => piece_id, "version-id" => version_id},
+        socket
+      ) do
+    piece =
+      Storybox.Stories.SequencePiece
+      |> Ash.Query.filter(id == ^piece_id)
+      |> Ash.read_one!(authorize?: false)
+
+    piece
+    |> Ash.Changeset.for_update(:approve_version, %{version_id: version_id})
+    |> Ash.update!(authorize?: false)
+
+    {:noreply, assign(socket, :acts, load_acts(socket.assigns.story))}
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <Layouts.app flash={@flash} current_user={@current_user}>
+      <div class="space-y-8">
+        <.link
+          navigate={~p"/stories/#{@story.id}"}
+          class="text-sm text-base-content/60 hover:text-base-content"
+        >
+          ← Back to overview
+        </.link>
+
+        <div class="space-y-1">
+          <h1 class="text-3xl font-bold">{@story.title}</h1>
+          <p class="text-base-content/60 text-sm">Treatment</p>
+        </div>
+
+        <%= if @acts == [] do %>
+          <p class="text-base-content/60 text-sm">No sequences yet.</p>
+        <% else %>
+          <%= for {act_label, pieces_with_versions} <- @acts do %>
+            <section class="space-y-3">
+              <h2 class="text-lg font-semibold text-base-content/80 border-b border-base-300 pb-1">
+                {act_label || "No act"}
+              </h2>
+              <div class="space-y-3">
+                <%= for {piece, versions} <- pieces_with_versions do %>
+                  <div class="card bg-base-200 shadow-sm">
+                    <div class="card-body py-4 space-y-3">
+                      <div class="flex items-center gap-2">
+                        <span class="badge badge-outline badge-sm font-mono">#{piece.position}</span>
+                        <h3 class="font-semibold">{piece.title}</h3>
+                      </div>
+
+                      <%= if versions == [] do %>
+                        <p class="text-base-content/50 text-sm">No versions yet.</p>
+                      <% else %>
+                        <div class="space-y-2">
+                          <%= for version <- versions do %>
+                            <div class={[
+                              "flex flex-wrap items-center gap-2 rounded p-2 text-sm",
+                              if(version.id == piece.approved_version_id, do: "bg-base-300", else: "")
+                            ]}>
+                              <span class="font-mono font-semibold">v{version.version_number}</span>
+
+                              <%= if version.id == piece.approved_version_id do %>
+                                <span class="badge badge-success badge-sm">Approved</span>
+                              <% end %>
+
+                              <span class={[
+                                "badge badge-sm",
+                                if(version.upstream_status == :stale,
+                                  do: "badge-warning",
+                                  else: "badge-ghost"
+                                )
+                              ]}>
+                                {version.upstream_status}
+                              </span>
+
+                              <span class={[
+                                "badge badge-sm",
+                                case review_status(version.weights, @story.through_lines) do
+                                  :reviewed -> "badge-info"
+                                  :partial -> "badge-warning"
+                                  :unreviewed -> "badge-ghost"
+                                end
+                              ]}>
+                                {review_status(version.weights, @story.through_lines)}
+                              </span>
+
+                              <%= if version.id != piece.approved_version_id do %>
+                                <button
+                                  class="btn btn-xs btn-outline ml-auto"
+                                  phx-click="approve_version"
+                                  phx-value-piece-id={piece.id}
+                                  phx-value-version-id={version.id}
+                                >
+                                  Approve
+                                </button>
+                              <% end %>
+                            </div>
+                          <% end %>
+                        </div>
+                      <% end %>
+                    </div>
+                  </div>
+                <% end %>
+              </div>
+            </section>
+          <% end %>
+        <% end %>
+      </div>
+    </Layouts.app>
+    """
+  end
+
+  defp load_acts(story) do
+    pieces =
+      Storybox.Stories.SequencePiece
+      |> Ash.Query.filter(story_id == ^story.id)
+      |> Ash.Query.sort(position: :asc)
+      |> Ash.read!(authorize?: false)
+
+    piece_ids = Enum.map(pieces, & &1.id)
+
+    versions_by_piece =
+      case piece_ids do
+        [] ->
+          %{}
+
+        ids ->
+          Storybox.Stories.SequenceVersion
+          |> Ash.Query.filter(sequence_piece_id in ^ids)
+          |> Ash.Query.sort(version_number: :desc)
+          |> Ash.read!(authorize?: false)
+          |> Enum.group_by(& &1.sequence_piece_id)
+      end
+
+    pieces
+    |> Enum.group_by(& &1.act)
+    |> Enum.sort_by(fn {act, _} -> {is_nil(act), act} end)
+    |> Enum.map(fn {act, act_pieces} ->
+      {act,
+       Enum.map(act_pieces, fn piece ->
+         {piece, Map.get(versions_by_piece, piece.id, [])}
+       end)}
+    end)
+  end
+
+  defp review_status(weights, through_lines) do
+    cond do
+      Enum.all?(through_lines, &Map.has_key?(weights, &1)) -> :reviewed
+      Enum.any?(through_lines, &Map.has_key?(weights, &1)) -> :partial
+      true -> :unreviewed
+    end
+  end
+end

--- a/lib/storybox_web/router.ex
+++ b/lib/storybox_web/router.ex
@@ -32,6 +32,7 @@ defmodule StoryboxWeb.Router do
       on_mount: AshAuthentication.Phoenix.LiveSession do
       live "/", StoryListLive
       live "/stories/:story_id", StoryOverviewLive
+      live "/stories/:story_id/treatment", TreatmentLive
     end
   end
 

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -133,6 +133,104 @@ if long_road = all_stories["The Long Road Home"] do
     IO.puts("  Created world for The Long Road Home")
   end
 
+  # Sequence pieces and versions (only seed if none exist yet)
+  existing_sequence_count =
+    Storybox.Stories.SequencePiece
+    |> Ash.Query.filter(story_id == ^long_road.id)
+    |> Ash.read!(authorize?: false)
+    |> length()
+
+  if existing_sequence_count == 0 do
+    # Act 1 — The Return
+    {:ok, piece_return} =
+      Storybox.Stories.SequencePiece
+      |> Ash.Changeset.for_create(:create, %{
+        title: "The Return",
+        act: "Act 1",
+        position: 1,
+        story_id: long_road.id
+      })
+      |> Ash.create(authorize?: false)
+
+    {:ok, return_v1} =
+      Storybox.Stories.SequenceVersion
+      |> Ash.Changeset.for_create(:create, %{
+        sequence_piece_id: piece_return.id,
+        content_uri: "storybox://stories/#{long_road.id}/sequences/#{piece_return.id}/v1",
+        version_number: 1,
+        upstream_status: :current,
+        weights: %{"preference" => 0.8, "theme" => 0.6}
+      })
+      |> Ash.create(authorize?: false)
+
+    {:ok, _return_v2} =
+      Storybox.Stories.SequenceVersion
+      |> Ash.Changeset.for_create(:create, %{
+        sequence_piece_id: piece_return.id,
+        content_uri: "storybox://stories/#{long_road.id}/sequences/#{piece_return.id}/v2",
+        version_number: 2,
+        upstream_status: :stale,
+        weights: %{}
+      })
+      |> Ash.create(authorize?: false)
+
+    # Approve v1
+    piece_return
+    |> Ash.Changeset.for_update(:approve_version, %{version_id: return_v1.id})
+    |> Ash.update!(authorize?: false)
+
+    # Act 1 — Old Faces
+    {:ok, piece_old_faces} =
+      Storybox.Stories.SequencePiece
+      |> Ash.Changeset.for_create(:create, %{
+        title: "Old Faces",
+        act: "Act 1",
+        position: 2,
+        story_id: long_road.id
+      })
+      |> Ash.create(authorize?: false)
+
+    {:ok, old_faces_v1} =
+      Storybox.Stories.SequenceVersion
+      |> Ash.Changeset.for_create(:create, %{
+        sequence_piece_id: piece_old_faces.id,
+        content_uri: "storybox://stories/#{long_road.id}/sequences/#{piece_old_faces.id}/v1",
+        version_number: 1,
+        upstream_status: :current,
+        weights: %{"preference" => 0.5}
+      })
+      |> Ash.create(authorize?: false)
+
+    # Approve v1
+    piece_old_faces
+    |> Ash.Changeset.for_update(:approve_version, %{version_id: old_faces_v1.id})
+    |> Ash.update!(authorize?: false)
+
+    # Act 2 — The Silence (no approved version)
+    {:ok, _piece_silence} =
+      Storybox.Stories.SequencePiece
+      |> Ash.Changeset.for_create(:create, %{
+        title: "The Silence",
+        act: "Act 2",
+        position: 3,
+        story_id: long_road.id
+      })
+      |> Ash.create(authorize?: false)
+
+    # (no act) — Epilogue (no versions)
+    {:ok, _piece_epilogue} =
+      Storybox.Stories.SequencePiece
+      |> Ash.Changeset.for_create(:create, %{
+        title: "Epilogue",
+        act: nil,
+        position: 4,
+        story_id: long_road.id
+      })
+      |> Ash.create(authorize?: false)
+
+    IO.puts("  Created 4 sequence pieces for The Long Road Home")
+  end
+
   # Synopsis versions (only seed if none exist yet)
   if existing_synopsis_count == 0 do
     Ash.ActionInput.for_action(Storybox.Stories.SynopsisVersion, :create_version, %{

--- a/test/storybox_web/live/treatment_live_test.exs
+++ b/test/storybox_web/live/treatment_live_test.exs
@@ -1,0 +1,414 @@
+defmodule StoryboxWeb.TreatmentLiveTest do
+  use StoryboxWeb.ConnCase
+
+  import Phoenix.LiveViewTest
+
+  require Ash.Query
+
+  # Seed data graph:
+  #
+  #   alice ──► "The Illusionist"  (through_lines: ["preference", "theme"])
+  #               ├── Act 1
+  #               │    ├── Piece "The Reveal"   pos 1  approved → v1
+  #               │    │     ├── v1  weights: {preference→0.9, theme→0.7}  status: current  [approved]
+  #               │    │     └── v2  weights: {}                           status: stale
+  #               │    └── Piece "The Escape"   pos 2  approved → nil
+  #               │          └── v1  weights: {}                           status: current
+  #               ├── Act 2
+  #               │    └── Piece "Fallout"      pos 3  approved → v3
+  #               │          └── v3  weights: {preference→0.5}             status: current  [approved]
+  #               └── (no act)
+  #                    └── Piece "Coda"         pos 4  approved → nil
+  #                          (no versions)
+  #
+  #   bob  ──► "Bob's Story"  (separate user, used for auth isolation checks)
+
+  setup do
+    {:ok, alice} =
+      Storybox.Accounts.User
+      |> Ash.Changeset.for_create(:register_with_password, %{
+        email: "alice@example.com",
+        password: "password123!",
+        password_confirmation: "password123!"
+      })
+      |> Ash.create()
+
+    {:ok, bob} =
+      Storybox.Accounts.User
+      |> Ash.Changeset.for_create(:register_with_password, %{
+        email: "bob@example.com",
+        password: "password123!",
+        password_confirmation: "password123!"
+      })
+      |> Ash.create()
+
+    {:ok, story} =
+      Storybox.Stories.Story
+      |> Ash.Changeset.for_create(:create, %{
+        title: "The Illusionist",
+        through_lines: ["preference", "theme"],
+        user_id: alice.id
+      })
+      |> Ash.create()
+
+    {:ok, bobs_story} =
+      Storybox.Stories.Story
+      |> Ash.Changeset.for_create(:create, %{
+        title: "Bob's Story",
+        user_id: bob.id
+      })
+      |> Ash.create()
+
+    # Act 1 — "The Reveal" (pos 1), approved → v1
+    {:ok, piece_reveal} =
+      Storybox.Stories.SequencePiece
+      |> Ash.Changeset.for_create(:create, %{
+        title: "The Reveal",
+        act: "Act 1",
+        position: 1,
+        story_id: story.id
+      })
+      |> Ash.create()
+
+    {:ok, reveal_v1} =
+      Storybox.Stories.SequenceVersion
+      |> Ash.Changeset.for_create(:create, %{
+        sequence_piece_id: piece_reveal.id,
+        content_uri: "storybox://test/reveal/v1",
+        version_number: 1,
+        upstream_status: :current,
+        weights: %{"preference" => 0.9, "theme" => 0.7}
+      })
+      |> Ash.create()
+
+    {:ok, reveal_v2} =
+      Storybox.Stories.SequenceVersion
+      |> Ash.Changeset.for_create(:create, %{
+        sequence_piece_id: piece_reveal.id,
+        content_uri: "storybox://test/reveal/v2",
+        version_number: 2,
+        upstream_status: :stale,
+        weights: %{}
+      })
+      |> Ash.create()
+
+    {:ok, piece_reveal} =
+      piece_reveal
+      |> Ash.Changeset.for_update(:approve_version, %{version_id: reveal_v1.id})
+      |> Ash.update()
+
+    # Act 1 — "The Escape" (pos 2), no approved version
+    {:ok, piece_escape} =
+      Storybox.Stories.SequencePiece
+      |> Ash.Changeset.for_create(:create, %{
+        title: "The Escape",
+        act: "Act 1",
+        position: 2,
+        story_id: story.id
+      })
+      |> Ash.create()
+
+    {:ok, escape_v1} =
+      Storybox.Stories.SequenceVersion
+      |> Ash.Changeset.for_create(:create, %{
+        sequence_piece_id: piece_escape.id,
+        content_uri: "storybox://test/escape/v1",
+        version_number: 1,
+        upstream_status: :current,
+        weights: %{}
+      })
+      |> Ash.create()
+
+    # Act 2 — "Fallout" (pos 3), approved → v3
+    {:ok, piece_fallout} =
+      Storybox.Stories.SequencePiece
+      |> Ash.Changeset.for_create(:create, %{
+        title: "Fallout",
+        act: "Act 2",
+        position: 3,
+        story_id: story.id
+      })
+      |> Ash.create()
+
+    {:ok, fallout_v3} =
+      Storybox.Stories.SequenceVersion
+      |> Ash.Changeset.for_create(:create, %{
+        sequence_piece_id: piece_fallout.id,
+        content_uri: "storybox://test/fallout/v3",
+        version_number: 3,
+        upstream_status: :current,
+        weights: %{"preference" => 0.5}
+      })
+      |> Ash.create()
+
+    {:ok, piece_fallout} =
+      piece_fallout
+      |> Ash.Changeset.for_update(:approve_version, %{version_id: fallout_v3.id})
+      |> Ash.update()
+
+    # No act — "Coda" (pos 4), no versions
+    {:ok, piece_coda} =
+      Storybox.Stories.SequencePiece
+      |> Ash.Changeset.for_create(:create, %{
+        title: "Coda",
+        act: nil,
+        position: 4,
+        story_id: story.id
+      })
+      |> Ash.create()
+
+    %{
+      alice: alice,
+      bob: bob,
+      story: story,
+      bobs_story: bobs_story,
+      piece_reveal: piece_reveal,
+      reveal_v1: reveal_v1,
+      reveal_v2: reveal_v2,
+      piece_escape: piece_escape,
+      escape_v1: escape_v1,
+      piece_fallout: piece_fallout,
+      fallout_v3: fallout_v3,
+      piece_coda: piece_coda
+    }
+  end
+
+  describe "unauthenticated access" do
+    test "redirects to sign-in when not logged in", %{conn: conn, story: story} do
+      assert {:error, {:redirect, %{to: "/sign-in"}}} =
+               live(conn, "/stories/#{story.id}/treatment")
+    end
+  end
+
+  describe "authorization" do
+    test "redirects to / when visiting another user's story", %{
+      conn: conn,
+      alice: alice,
+      bobs_story: bobs_story
+    } do
+      conn = log_in_user(conn, alice)
+
+      assert {:error, {:redirect, %{to: "/"}}} =
+               live(conn, "/stories/#{bobs_story.id}/treatment")
+    end
+
+    test "redirects to / when story_id does not exist", %{conn: conn, alice: alice} do
+      conn = log_in_user(conn, alice)
+      fake_id = Ash.UUID.generate()
+
+      assert {:error, {:redirect, %{to: "/"}}} =
+               live(conn, "/stories/#{fake_id}/treatment")
+    end
+  end
+
+  describe "page header" do
+    test "renders the story title", %{conn: conn, alice: alice, story: story} do
+      conn = log_in_user(conn, alice)
+      {:ok, _view, html} = live(conn, "/stories/#{story.id}/treatment")
+
+      assert html =~ "The Illusionist"
+    end
+  end
+
+  describe "act grouping" do
+    test "renders Act 1 label before The Reveal and The Escape", %{
+      conn: conn,
+      alice: alice,
+      story: story
+    } do
+      conn = log_in_user(conn, alice)
+      {:ok, _view, html} = live(conn, "/stories/#{story.id}/treatment")
+
+      assert html =~ "Act 1"
+      assert html =~ "The Reveal"
+      assert html =~ "The Escape"
+    end
+
+    test "renders Act 2 label before Fallout", %{conn: conn, alice: alice, story: story} do
+      conn = log_in_user(conn, alice)
+      {:ok, _view, html} = live(conn, "/stories/#{story.id}/treatment")
+
+      assert html =~ "Act 2"
+      assert html =~ "Fallout"
+    end
+
+    test "renders Coda under the no-act grouping", %{conn: conn, alice: alice, story: story} do
+      conn = log_in_user(conn, alice)
+      {:ok, _view, html} = live(conn, "/stories/#{story.id}/treatment")
+
+      assert html =~ "No act"
+      assert html =~ "Coda"
+    end
+
+    test "The Reveal appears before The Escape (position order within Act 1)", %{
+      conn: conn,
+      alice: alice,
+      story: story
+    } do
+      conn = log_in_user(conn, alice)
+      {:ok, _view, html} = live(conn, "/stories/#{story.id}/treatment")
+
+      reveal_pos = :binary.match(html, "The Reveal") |> elem(0)
+      escape_pos = :binary.match(html, "The Escape") |> elem(0)
+
+      assert reveal_pos < escape_pos
+    end
+  end
+
+  describe "version display" do
+    test "The Reveal shows v1 as approved", %{conn: conn, alice: alice, story: story} do
+      conn = log_in_user(conn, alice)
+      {:ok, _view, html} = live(conn, "/stories/#{story.id}/treatment")
+
+      assert html =~ "v1"
+      assert html =~ "Approved"
+    end
+
+    test "The Reveal v1 shows upstream status current", %{
+      conn: conn,
+      alice: alice,
+      story: story
+    } do
+      conn = log_in_user(conn, alice)
+      {:ok, _view, html} = live(conn, "/stories/#{story.id}/treatment")
+
+      assert html =~ "current"
+    end
+
+    test "The Reveal v2 shows upstream status stale", %{conn: conn, alice: alice, story: story} do
+      conn = log_in_user(conn, alice)
+      {:ok, _view, html} = live(conn, "/stories/#{story.id}/treatment")
+
+      assert html =~ "stale"
+    end
+
+    test "The Escape has no approved marker", %{conn: conn, alice: alice, story: story} do
+      conn = log_in_user(conn, alice)
+      {:ok, _view, html} = live(conn, "/stories/#{story.id}/treatment")
+
+      # "Approved" badge appears for The Reveal v1 and Fallout v3 — but NOT for The Escape
+      assert length(:binary.matches(html, "Approved")) == 2
+    end
+
+    test "Coda shows no-versions empty state", %{conn: conn, alice: alice, story: story} do
+      conn = log_in_user(conn, alice)
+      {:ok, _view, html} = live(conn, "/stories/#{story.id}/treatment")
+
+      assert html =~ "No versions yet."
+    end
+  end
+
+  describe "review status" do
+    test "The Reveal v1 shows reviewed (both through_lines present in weights)", %{
+      conn: conn,
+      alice: alice,
+      story: story
+    } do
+      conn = log_in_user(conn, alice)
+      {:ok, _view, html} = live(conn, "/stories/#{story.id}/treatment")
+
+      assert html =~ "reviewed"
+    end
+
+    test "The Reveal v2 shows unreviewed (empty weights)", %{
+      conn: conn,
+      alice: alice,
+      story: story
+    } do
+      conn = log_in_user(conn, alice)
+      {:ok, _view, html} = live(conn, "/stories/#{story.id}/treatment")
+
+      assert html =~ "unreviewed"
+    end
+
+    test "Fallout v3 shows partial (only preference present, theme missing)", %{
+      conn: conn,
+      alice: alice,
+      story: story
+    } do
+      conn = log_in_user(conn, alice)
+      {:ok, _view, html} = live(conn, "/stories/#{story.id}/treatment")
+
+      assert html =~ "partial"
+    end
+  end
+
+  describe "approve version" do
+    test "approving The Reveal v2 makes it the approved version", %{
+      conn: conn,
+      alice: alice,
+      story: story,
+      piece_reveal: piece_reveal,
+      reveal_v2: reveal_v2
+    } do
+      conn = log_in_user(conn, alice)
+      {:ok, view, _html} = live(conn, "/stories/#{story.id}/treatment")
+
+      view
+      |> element(
+        "[phx-click=\"approve_version\"][phx-value-piece-id=\"#{piece_reveal.id}\"][phx-value-version-id=\"#{reveal_v2.id}\"]"
+      )
+      |> render_click()
+
+      html = render(view)
+
+      # "Approved" still appears twice — on The Reveal v2 (newly approved) and Fallout v3
+      assert length(:binary.matches(html, "Approved")) == 2
+
+      # v2 is now marked approved in DB
+      updated_piece =
+        Storybox.Stories.SequencePiece
+        |> Ash.Query.filter(id == ^piece_reveal.id)
+        |> Ash.read_one!(authorize?: false)
+
+      assert updated_piece.approved_version_id == reveal_v2.id
+    end
+
+    test "approving a version on one piece does not change the approved pointer on another piece",
+         %{
+           conn: conn,
+           alice: alice,
+           story: story,
+           piece_reveal: piece_reveal,
+           reveal_v2: reveal_v2,
+           piece_fallout: piece_fallout,
+           fallout_v3: fallout_v3
+         } do
+      conn = log_in_user(conn, alice)
+      {:ok, view, _html} = live(conn, "/stories/#{story.id}/treatment")
+
+      view
+      |> element(
+        "[phx-click=\"approve_version\"][phx-value-piece-id=\"#{piece_reveal.id}\"][phx-value-version-id=\"#{reveal_v2.id}\"]"
+      )
+      |> render_click()
+
+      updated_fallout =
+        Storybox.Stories.SequencePiece
+        |> Ash.Query.filter(id == ^piece_fallout.id)
+        |> Ash.read_one!(authorize?: false)
+
+      assert updated_fallout.approved_version_id == fallout_v3.id
+    end
+  end
+
+  describe "empty story" do
+    test "shows no-sequences empty state for a story with no sequences", %{
+      conn: conn,
+      alice: alice
+    } do
+      {:ok, empty_story} =
+        Storybox.Stories.Story
+        |> Ash.Changeset.for_create(:create, %{
+          title: "Blank Story",
+          user_id: alice.id
+        })
+        |> Ash.create()
+
+      conn = log_in_user(conn, alice)
+      {:ok, _view, html} = live(conn, "/stories/#{empty_story.id}/treatment")
+
+      assert html =~ "No sequences yet."
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `/stories/:story_id/treatment` LiveView listing all sequence pieces grouped by act
- Each piece shows all versions with version number, upstream status badge, and review status badge (reviewed/partial/unreviewed, derived from `weights` vs `story.through_lines`)
- Approve button on any unapproved version calls `:approve_version` on the piece and re-renders immediately via LiveView
- Empty states for stories with no sequences and pieces with no versions
- Seeds extended with 4 sequence pieces for "The Long Road Home" covering all rendering states (approved+current, stale, no-approved-pointer, no-versions)

## Key decisions

- **Load all versions per piece** (not just the approved one) — the UI needs to show the full version list so the user can choose which to approve. The API treatment view only loads the approved version; this LiveView intentionally loads more.
- **Review status derived at render time** from `weights` map vs `story.through_lines`: all through_lines present → `reviewed`, some → `partial`, none/empty → `unreviewed`. No stored field needed.
- **`phx-value-piece-id` / `phx-value-version-id`** used as event params (kebab-case, matching Phoenix LiveView's automatic conversion from `phx-value-*` attributes).

## Test plan

- [x] `mix precommit` passes — 188 tests, 0 failures
- [x] Auth guards: unauthenticated → `/sign-in`, wrong user → `/`
- [x] Act grouping and position ordering within acts
- [x] Approved marker, upstream status, and all three review statuses
- [x] Approve interaction updates DB and re-renders correctly
- [x] Cross-piece isolation: approving on one piece does not affect another
- [x] Empty states: no sequences, no versions
- [x] Browser: verify act groupings, badges, and approve button feel correct at http://localhost:4000/stories/:id/treatment ✅ confirmed

closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)