### PR TITLE
LiveView: weight and review UI

### DIFF
--- a/lib/storybox/stories/scene_version.ex
+++ b/lib/storybox/stories/scene_version.ex
@@ -38,5 +38,9 @@ defmodule Storybox.Stories.SceneVersion do
     update :mark_stale do
       change set_attribute(:upstream_status, :stale)
     end
+
+    update :set_weights do
+      accept [:weights]
+    end
   end
 end

--- a/lib/storybox/stories/sequence_version.ex
+++ b/lib/storybox/stories/sequence_version.ex
@@ -38,5 +38,9 @@ defmodule Storybox.Stories.SequenceVersion do
     update :mark_stale do
       change set_attribute(:upstream_status, :stale)
     end
+
+    update :set_weights do
+      accept [:weights]
+    end
   end
 end

--- a/lib/storybox_web/live/scene_compare_live.ex
+++ b/lib/storybox_web/live/scene_compare_live.ex
@@ -61,6 +61,7 @@ defmodule StoryboxWeb.SceneCompareLive do
                      |> assign(:right_version, nil)
                      |> assign(:left_content, nil)
                      |> assign(:right_content, nil)
+                     |> assign(:weight_forms, MapSet.new())
                      |> assign(:page_title, "#{story.title} — #{scene.title} Compare")}
                 end
             end
@@ -124,6 +125,52 @@ defmodule StoryboxWeb.SceneCompareLive do
   end
 
   @impl true
+  def handle_event("toggle_weight_form", %{"version-id" => version_id}, socket) do
+    weight_forms =
+      if MapSet.member?(socket.assigns.weight_forms, version_id) do
+        MapSet.delete(socket.assigns.weight_forms, version_id)
+      else
+        MapSet.put(socket.assigns.weight_forms, version_id)
+      end
+
+    {:noreply, assign(socket, :weight_forms, weight_forms)}
+  end
+
+  @impl true
+  def handle_event("set_weights", %{"version_id" => version_id, "weights" => raw_weights}, socket) do
+    weights = parse_weights(raw_weights)
+
+    version =
+      Storybox.Stories.SceneVersion
+      |> Ash.Query.filter(id == ^version_id)
+      |> Ash.read_one!(authorize?: false)
+
+    version
+    |> Ash.Changeset.for_update(:set_weights, %{weights: weights})
+    |> Ash.update!(authorize?: false)
+
+    versions = load_versions(socket.assigns.scene)
+    weight_forms = MapSet.delete(socket.assigns.weight_forms, version_id)
+
+    left_version =
+      if socket.assigns.left_version,
+        do: find_version(versions, socket.assigns.left_version.version_number),
+        else: nil
+
+    right_version =
+      if socket.assigns.right_version,
+        do: find_version(versions, socket.assigns.right_version.version_number),
+        else: nil
+
+    {:noreply,
+     socket
+     |> assign(:versions, versions)
+     |> assign(:left_version, left_version)
+     |> assign(:right_version, right_version)
+     |> assign(:weight_forms, weight_forms)}
+  end
+
+  @impl true
   def render(assigns) do
     ~H"""
     <Layouts.app flash={@flash} current_user={@current_user}>
@@ -173,45 +220,63 @@ defmodule StoryboxWeb.SceneCompareLive do
             </div>
 
             <%= if @left_version do %>
+              <% rs = review_status(@left_version.weights, @story.through_lines) %>
               <div class={[
-                "flex flex-wrap items-center gap-2 rounded p-2 text-sm",
-                if(@left_version.id == @scene.approved_version_id, do: "bg-base-200", else: "")
+                "rounded p-2 text-sm",
+                if(@left_version.id == @scene.approved_version_id, do: "bg-base-200", else: ""),
+                if(rs == :unreviewed, do: "ring-2 ring-warning", else: "")
               ]}>
-                <span class="font-mono font-semibold">v{@left_version.version_number}</span>
+                <div class="flex flex-wrap items-center gap-2">
+                  <span class="font-mono font-semibold">v{@left_version.version_number}</span>
 
-                <%= if @left_version.id == @scene.approved_version_id do %>
-                  <span class="badge badge-success badge-sm">Approved</span>
-                <% end %>
+                  <%= if @left_version.id == @scene.approved_version_id do %>
+                    <span class="badge badge-success badge-sm">Approved</span>
+                  <% end %>
 
-                <span class={[
-                  "badge badge-sm",
-                  if(@left_version.upstream_status == :stale,
-                    do: "badge-warning",
-                    else: "badge-ghost"
-                  )
-                ]}>
-                  {@left_version.upstream_status}
-                </span>
+                  <span class={[
+                    "badge badge-sm",
+                    if(@left_version.upstream_status == :stale,
+                      do: "badge-warning",
+                      else: "badge-ghost"
+                    )
+                  ]}>
+                    {@left_version.upstream_status}
+                  </span>
 
-                <span class={[
-                  "badge badge-sm",
-                  case review_status(@left_version.weights, @story.through_lines) do
-                    :reviewed -> "badge-info"
-                    :partial -> "badge-warning"
-                    :unreviewed -> "badge-ghost"
-                  end
-                ]}>
-                  {review_status(@left_version.weights, @story.through_lines)}
-                </span>
+                  <span class={[
+                    "badge badge-sm",
+                    case rs do
+                      :reviewed -> "badge-info"
+                      :partial -> "badge-warning"
+                      :unreviewed -> "badge-ghost"
+                    end
+                  ]}>
+                    {rs}
+                  </span>
 
-                <%= if @left_version.id != @scene.approved_version_id do %>
-                  <button
-                    class="btn btn-xs btn-outline ml-auto"
-                    phx-click="approve_version"
-                    phx-value-version-id={@left_version.id}
-                  >
-                    Approve
-                  </button>
+                  <div class="ml-auto flex items-center gap-2">
+                    <button
+                      class="btn btn-xs btn-ghost"
+                      phx-click="toggle_weight_form"
+                      phx-value-version-id={@left_version.id}
+                    >
+                      Review
+                    </button>
+
+                    <%= if @left_version.id != @scene.approved_version_id do %>
+                      <button
+                        class="btn btn-xs btn-outline"
+                        phx-click="approve_version"
+                        phx-value-version-id={@left_version.id}
+                      >
+                        Approve
+                      </button>
+                    <% end %>
+                  </div>
+                </div>
+
+                <%= if MapSet.member?(@weight_forms, @left_version.id) do %>
+                  <.weight_form version={@left_version} through_lines={@story.through_lines} />
                 <% end %>
               </div>
 
@@ -252,45 +317,63 @@ defmodule StoryboxWeb.SceneCompareLive do
             </div>
 
             <%= if @right_version do %>
+              <% rs = review_status(@right_version.weights, @story.through_lines) %>
               <div class={[
-                "flex flex-wrap items-center gap-2 rounded p-2 text-sm",
-                if(@right_version.id == @scene.approved_version_id, do: "bg-base-200", else: "")
+                "rounded p-2 text-sm",
+                if(@right_version.id == @scene.approved_version_id, do: "bg-base-200", else: ""),
+                if(rs == :unreviewed, do: "ring-2 ring-warning", else: "")
               ]}>
-                <span class="font-mono font-semibold">v{@right_version.version_number}</span>
+                <div class="flex flex-wrap items-center gap-2">
+                  <span class="font-mono font-semibold">v{@right_version.version_number}</span>
 
-                <%= if @right_version.id == @scene.approved_version_id do %>
-                  <span class="badge badge-success badge-sm">Approved</span>
-                <% end %>
+                  <%= if @right_version.id == @scene.approved_version_id do %>
+                    <span class="badge badge-success badge-sm">Approved</span>
+                  <% end %>
 
-                <span class={[
-                  "badge badge-sm",
-                  if(@right_version.upstream_status == :stale,
-                    do: "badge-warning",
-                    else: "badge-ghost"
-                  )
-                ]}>
-                  {@right_version.upstream_status}
-                </span>
+                  <span class={[
+                    "badge badge-sm",
+                    if(@right_version.upstream_status == :stale,
+                      do: "badge-warning",
+                      else: "badge-ghost"
+                    )
+                  ]}>
+                    {@right_version.upstream_status}
+                  </span>
 
-                <span class={[
-                  "badge badge-sm",
-                  case review_status(@right_version.weights, @story.through_lines) do
-                    :reviewed -> "badge-info"
-                    :partial -> "badge-warning"
-                    :unreviewed -> "badge-ghost"
-                  end
-                ]}>
-                  {review_status(@right_version.weights, @story.through_lines)}
-                </span>
+                  <span class={[
+                    "badge badge-sm",
+                    case rs do
+                      :reviewed -> "badge-info"
+                      :partial -> "badge-warning"
+                      :unreviewed -> "badge-ghost"
+                    end
+                  ]}>
+                    {rs}
+                  </span>
 
-                <%= if @right_version.id != @scene.approved_version_id do %>
-                  <button
-                    class="btn btn-xs btn-outline ml-auto"
-                    phx-click="approve_version"
-                    phx-value-version-id={@right_version.id}
-                  >
-                    Approve
-                  </button>
+                  <div class="ml-auto flex items-center gap-2">
+                    <button
+                      class="btn btn-xs btn-ghost"
+                      phx-click="toggle_weight_form"
+                      phx-value-version-id={@right_version.id}
+                    >
+                      Review
+                    </button>
+
+                    <%= if @right_version.id != @scene.approved_version_id do %>
+                      <button
+                        class="btn btn-xs btn-outline"
+                        phx-click="approve_version"
+                        phx-value-version-id={@right_version.id}
+                      >
+                        Approve
+                      </button>
+                    <% end %>
+                  </div>
+                </div>
+
+                <%= if MapSet.member?(@weight_forms, @right_version.id) do %>
+                  <.weight_form version={@right_version} through_lines={@story.through_lines} />
                 <% end %>
               </div>
 
@@ -306,6 +389,41 @@ defmodule StoryboxWeb.SceneCompareLive do
         </div>
       </div>
     </Layouts.app>
+    """
+  end
+
+  defp weight_form(assigns) do
+    ~H"""
+    <form phx-submit="set_weights" class="mt-3 space-y-2 border-t border-base-300 pt-3">
+      <input type="hidden" name="version_id" value={@version.id} />
+      <%= for tl <- @through_lines do %>
+        <% current = Map.get(@version.weights, tl, 0.0) %>
+        <div class="flex items-center gap-3">
+          <label class="text-xs text-base-content/70 w-24 shrink-0">{tl}</label>
+          <input
+            type="range"
+            name={"weights[#{tl}]"}
+            min="0"
+            max="1"
+            step="0.05"
+            value={current}
+            class="range range-xs flex-1"
+          />
+          <span class="text-xs font-mono w-8 text-right">{format_weight(current)}</span>
+        </div>
+      <% end %>
+      <div class="flex justify-end gap-2 pt-1">
+        <button
+          type="button"
+          class="btn btn-xs btn-ghost"
+          phx-click="toggle_weight_form"
+          phx-value-version-id={@version.id}
+        >
+          Cancel
+        </button>
+        <button type="submit" class="btn btn-xs btn-primary">Save</button>
+      </div>
+    </form>
     """
   end
 
@@ -360,4 +478,17 @@ defmodule StoryboxWeb.SceneCompareLive do
       true -> :unreviewed
     end
   end
+
+  defp parse_weights(raw) do
+    Map.new(raw, fn {k, v} ->
+      case Float.parse(v) do
+        {f, _} -> {k, f}
+        :error -> {k, 0.0}
+      end
+    end)
+  end
+
+  defp format_weight(v) when is_float(v), do: :erlang.float_to_binary(v, decimals: 2)
+  defp format_weight(v) when is_integer(v), do: :erlang.float_to_binary(v * 1.0, decimals: 2)
+  defp format_weight(_), do: "—"
 end

--- a/lib/storybox_web/live/script_live.ex
+++ b/lib/storybox_web/live/script_live.ex
@@ -43,6 +43,7 @@ defmodule StoryboxWeb.ScriptLive do
                  |> assign(:scenes, load_scenes(sequence))
                  |> assign(:mode, :latest)
                  |> assign(:content, %{})
+                 |> assign(:weight_forms, MapSet.new())
                  |> assign(:page_title, "#{story.title} — #{sequence.title} Script")}
             end
         end
@@ -62,6 +63,41 @@ defmodule StoryboxWeb.ScriptLive do
      socket
      |> assign(:mode, :latest)
      |> assign(:content, fetch_visible_content(socket.assigns.scenes, :latest))}
+  end
+
+  @impl true
+  def handle_event("toggle_weight_form", %{"version-id" => version_id}, socket) do
+    weight_forms =
+      if MapSet.member?(socket.assigns.weight_forms, version_id) do
+        MapSet.delete(socket.assigns.weight_forms, version_id)
+      else
+        MapSet.put(socket.assigns.weight_forms, version_id)
+      end
+
+    {:noreply, assign(socket, :weight_forms, weight_forms)}
+  end
+
+  @impl true
+  def handle_event("set_weights", %{"version_id" => version_id, "weights" => raw_weights}, socket) do
+    weights = parse_weights(raw_weights)
+
+    version =
+      Storybox.Stories.SceneVersion
+      |> Ash.Query.filter(id == ^version_id)
+      |> Ash.read_one!(authorize?: false)
+
+    version
+    |> Ash.Changeset.for_update(:set_weights, %{weights: weights})
+    |> Ash.update!(authorize?: false)
+
+    scenes = load_scenes(socket.assigns.sequence)
+    weight_forms = MapSet.delete(socket.assigns.weight_forms, version_id)
+
+    {:noreply,
+     socket
+     |> assign(:scenes, scenes)
+     |> assign(:content, fetch_visible_content(scenes, socket.assigns.mode))
+     |> assign(:weight_forms, weight_forms)}
   end
 
   @impl true
@@ -150,11 +186,13 @@ defmodule StoryboxWeb.ScriptLive do
                     </p>
                   <% else %>
                     <%= for version <- visible do %>
-                      <div class="space-y-2">
-                        <div class={[
-                          "flex flex-wrap items-center gap-2 rounded p-2 text-sm",
-                          if(version.id == piece.approved_version_id, do: "bg-base-300", else: "")
-                        ]}>
+                      <% rs = review_status(version.weights, @story.through_lines) %>
+                      <div class={[
+                        "rounded p-2 text-sm",
+                        if(version.id == piece.approved_version_id, do: "bg-base-300", else: ""),
+                        if(rs == :unreviewed, do: "ring-2 ring-warning", else: "")
+                      ]}>
+                        <div class="flex flex-wrap items-center gap-2">
                           <span class="font-mono font-semibold">v{version.version_number}</span>
 
                           <%= if version.id == piece.approved_version_id do %>
@@ -173,29 +211,43 @@ defmodule StoryboxWeb.ScriptLive do
 
                           <span class={[
                             "badge badge-sm",
-                            case review_status(version.weights, @story.through_lines) do
+                            case rs do
                               :reviewed -> "badge-info"
                               :partial -> "badge-warning"
                               :unreviewed -> "badge-ghost"
                             end
                           ]}>
-                            {review_status(version.weights, @story.through_lines)}
+                            {rs}
                           </span>
 
-                          <%= if version.id != piece.approved_version_id do %>
+                          <div class="ml-auto flex items-center gap-2">
                             <button
-                              class="btn btn-xs btn-outline ml-auto"
-                              phx-click="approve_version"
-                              phx-value-piece-id={piece.id}
+                              class="btn btn-xs btn-ghost"
+                              phx-click="toggle_weight_form"
                               phx-value-version-id={version.id}
                             >
-                              Approve
+                              Review
                             </button>
-                          <% end %>
+
+                            <%= if version.id != piece.approved_version_id do %>
+                              <button
+                                class="btn btn-xs btn-outline"
+                                phx-click="approve_version"
+                                phx-value-piece-id={piece.id}
+                                phx-value-version-id={version.id}
+                              >
+                                Approve
+                              </button>
+                            <% end %>
+                          </div>
                         </div>
 
+                        <%= if MapSet.member?(@weight_forms, version.id) do %>
+                          <.weight_form version={version} through_lines={@story.through_lines} />
+                        <% end %>
+
                         <%= if Map.get(@content, version.id) do %>
-                          <pre class="text-sm whitespace-pre-wrap font-mono bg-base-300 rounded p-3 leading-relaxed overflow-x-auto">{Map.get(@content, version.id)}</pre>
+                          <pre class="mt-2 text-sm whitespace-pre-wrap font-mono bg-base-300 rounded p-3 leading-relaxed overflow-x-auto">{Map.get(@content, version.id)}</pre>
                         <% end %>
                       </div>
                     <% end %>
@@ -207,6 +259,41 @@ defmodule StoryboxWeb.ScriptLive do
         <% end %>
       </div>
     </Layouts.app>
+    """
+  end
+
+  defp weight_form(assigns) do
+    ~H"""
+    <form phx-submit="set_weights" class="mt-3 space-y-2 border-t border-base-300 pt-3">
+      <input type="hidden" name="version_id" value={@version.id} />
+      <%= for tl <- @through_lines do %>
+        <% current = Map.get(@version.weights, tl, 0.0) %>
+        <div class="flex items-center gap-3">
+          <label class="text-xs text-base-content/70 w-24 shrink-0">{tl}</label>
+          <input
+            type="range"
+            name={"weights[#{tl}]"}
+            min="0"
+            max="1"
+            step="0.05"
+            value={current}
+            class="range range-xs flex-1"
+          />
+          <span class="text-xs font-mono w-8 text-right">{format_weight(current)}</span>
+        </div>
+      <% end %>
+      <div class="flex justify-end gap-2 pt-1">
+        <button
+          type="button"
+          class="btn btn-xs btn-ghost"
+          phx-click="toggle_weight_form"
+          phx-value-version-id={@version.id}
+        >
+          Cancel
+        </button>
+        <button type="submit" class="btn btn-xs btn-primary">Save</button>
+      </div>
+    </form>
     """
   end
 
@@ -270,4 +357,17 @@ defmodule StoryboxWeb.ScriptLive do
       true -> :unreviewed
     end
   end
+
+  defp parse_weights(raw) do
+    Map.new(raw, fn {k, v} ->
+      case Float.parse(v) do
+        {f, _} -> {k, f}
+        :error -> {k, 0.0}
+      end
+    end)
+  end
+
+  defp format_weight(v) when is_float(v), do: :erlang.float_to_binary(v, decimals: 2)
+  defp format_weight(v) when is_integer(v), do: :erlang.float_to_binary(v * 1.0, decimals: 2)
+  defp format_weight(_), do: "—"
 end

--- a/lib/storybox_web/live/treatment_live.ex
+++ b/lib/storybox_web/live/treatment_live.ex
@@ -30,9 +30,45 @@ defmodule StoryboxWeb.TreatmentLive do
              |> assign(:story, story)
              |> assign(:acts, acts)
              |> assign(:content, fetch_primary_content(acts))
+             |> assign(:weight_forms, MapSet.new())
              |> assign(:page_title, "#{story.title} — Treatment")}
         end
     end
+  end
+
+  @impl true
+  def handle_event("toggle_weight_form", %{"version-id" => version_id}, socket) do
+    weight_forms =
+      if MapSet.member?(socket.assigns.weight_forms, version_id) do
+        MapSet.delete(socket.assigns.weight_forms, version_id)
+      else
+        MapSet.put(socket.assigns.weight_forms, version_id)
+      end
+
+    {:noreply, assign(socket, :weight_forms, weight_forms)}
+  end
+
+  @impl true
+  def handle_event("set_weights", %{"version_id" => version_id, "weights" => raw_weights}, socket) do
+    weights = parse_weights(raw_weights)
+
+    version =
+      Storybox.Stories.SequenceVersion
+      |> Ash.Query.filter(id == ^version_id)
+      |> Ash.read_one!(authorize?: false)
+
+    version
+    |> Ash.Changeset.for_update(:set_weights, %{weights: weights})
+    |> Ash.update!(authorize?: false)
+
+    acts = load_acts(socket.assigns.story)
+    weight_forms = MapSet.delete(socket.assigns.weight_forms, version_id)
+
+    {:noreply,
+     socket
+     |> assign(:acts, acts)
+     |> assign(:content, fetch_primary_content(acts))
+     |> assign(:weight_forms, weight_forms)}
   end
 
   @impl true
@@ -106,46 +142,70 @@ defmodule StoryboxWeb.TreatmentLive do
                       <% else %>
                         <div class="space-y-2">
                           <%= for version <- versions do %>
+                            <% rs = review_status(version.weights, @story.through_lines) %>
                             <div class={[
-                              "flex flex-wrap items-center gap-2 rounded p-2 text-sm",
-                              if(version.id == piece.approved_version_id, do: "bg-base-300", else: "")
+                              "rounded p-2 text-sm",
+                              if(version.id == piece.approved_version_id,
+                                do: "bg-base-300",
+                                else: ""
+                              ),
+                              if(rs == :unreviewed, do: "ring-2 ring-warning", else: "")
                             ]}>
-                              <span class="font-mono font-semibold">v{version.version_number}</span>
+                              <div class="flex flex-wrap items-center gap-2">
+                                <span class="font-mono font-semibold">v{version.version_number}</span>
 
-                              <%= if version.id == piece.approved_version_id do %>
-                                <span class="badge badge-success badge-sm">Approved</span>
-                              <% end %>
+                                <%= if version.id == piece.approved_version_id do %>
+                                  <span class="badge badge-success badge-sm">Approved</span>
+                                <% end %>
 
-                              <span class={[
-                                "badge badge-sm",
-                                if(version.upstream_status == :stale,
-                                  do: "badge-warning",
-                                  else: "badge-ghost"
-                                )
-                              ]}>
-                                {version.upstream_status}
-                              </span>
+                                <span class={[
+                                  "badge badge-sm",
+                                  if(version.upstream_status == :stale,
+                                    do: "badge-warning",
+                                    else: "badge-ghost"
+                                  )
+                                ]}>
+                                  {version.upstream_status}
+                                </span>
 
-                              <span class={[
-                                "badge badge-sm",
-                                case review_status(version.weights, @story.through_lines) do
-                                  :reviewed -> "badge-info"
-                                  :partial -> "badge-warning"
-                                  :unreviewed -> "badge-ghost"
-                                end
-                              ]}>
-                                {review_status(version.weights, @story.through_lines)}
-                              </span>
+                                <span class={[
+                                  "badge badge-sm",
+                                  case rs do
+                                    :reviewed -> "badge-info"
+                                    :partial -> "badge-warning"
+                                    :unreviewed -> "badge-ghost"
+                                  end
+                                ]}>
+                                  {rs}
+                                </span>
 
-                              <%= if version.id != piece.approved_version_id do %>
-                                <button
-                                  class="btn btn-xs btn-outline ml-auto"
-                                  phx-click="approve_version"
-                                  phx-value-piece-id={piece.id}
-                                  phx-value-version-id={version.id}
-                                >
-                                  Approve
-                                </button>
+                                <div class="ml-auto flex items-center gap-2">
+                                  <button
+                                    class="btn btn-xs btn-ghost"
+                                    phx-click="toggle_weight_form"
+                                    phx-value-version-id={version.id}
+                                  >
+                                    Review
+                                  </button>
+
+                                  <%= if version.id != piece.approved_version_id do %>
+                                    <button
+                                      class="btn btn-xs btn-outline"
+                                      phx-click="approve_version"
+                                      phx-value-piece-id={piece.id}
+                                      phx-value-version-id={version.id}
+                                    >
+                                      Approve
+                                    </button>
+                                  <% end %>
+                                </div>
+                              </div>
+
+                              <%= if MapSet.member?(@weight_forms, version.id) do %>
+                                <.weight_form
+                                  version={version}
+                                  through_lines={@story.through_lines}
+                                />
                               <% end %>
                             </div>
                           <% end %>
@@ -160,6 +220,41 @@ defmodule StoryboxWeb.TreatmentLive do
         <% end %>
       </div>
     </Layouts.app>
+    """
+  end
+
+  defp weight_form(assigns) do
+    ~H"""
+    <form phx-submit="set_weights" class="mt-3 space-y-2 border-t border-base-300 pt-3">
+      <input type="hidden" name="version_id" value={@version.id} />
+      <%= for tl <- @through_lines do %>
+        <% current = Map.get(@version.weights, tl, 0.0) %>
+        <div class="flex items-center gap-3">
+          <label class="text-xs text-base-content/70 w-24 shrink-0">{tl}</label>
+          <input
+            type="range"
+            name={"weights[#{tl}]"}
+            min="0"
+            max="1"
+            step="0.05"
+            value={current}
+            class="range range-xs flex-1"
+          />
+          <span class="text-xs font-mono w-8 text-right">{format_weight(current)}</span>
+        </div>
+      <% end %>
+      <div class="flex justify-end gap-2 pt-1">
+        <button
+          type="button"
+          class="btn btn-xs btn-ghost"
+          phx-click="toggle_weight_form"
+          phx-value-version-id={@version.id}
+        >
+          Cancel
+        </button>
+        <button type="submit" class="btn btn-xs btn-primary">Save</button>
+      </div>
+    </form>
     """
   end
 
@@ -231,4 +326,17 @@ defmodule StoryboxWeb.TreatmentLive do
       true -> :unreviewed
     end
   end
+
+  defp parse_weights(raw) do
+    Map.new(raw, fn {k, v} ->
+      case Float.parse(v) do
+        {f, _} -> {k, f}
+        :error -> {k, 0.0}
+      end
+    end)
+  end
+
+  defp format_weight(v) when is_float(v), do: :erlang.float_to_binary(v, decimals: 2)
+  defp format_weight(v) when is_integer(v), do: :erlang.float_to_binary(v * 1.0, decimals: 2)
+  defp format_weight(_), do: "—"
 end

--- a/test/storybox/stories/scene_piece_test.exs
+++ b/test/storybox/stories/scene_piece_test.exs
@@ -1,6 +1,8 @@
 defmodule Storybox.Stories.ScenePieceTest do
   use Storybox.DataCase
 
+  require Ash.Query
+
   setup do
     {:ok, user} =
       Storybox.Accounts.User
@@ -149,6 +151,72 @@ defmodule Storybox.Stories.ScenePieceTest do
                |> Ash.update()
 
       assert updated_piece.approved_version_id == version.id
+    end
+  end
+
+  describe "set_weights action on SceneVersion" do
+    test "sets weights map on a version with empty weights and persists it", %{sequence: sequence} do
+      {:ok, piece} =
+        Storybox.Stories.ScenePiece
+        |> Ash.Changeset.for_create(:create, %{
+          title: "Test Scene",
+          position: 1,
+          sequence_piece_id: sequence.id
+        })
+        |> Ash.create()
+
+      {:ok, version} =
+        Storybox.Stories.SceneVersion
+        |> Ash.Changeset.for_create(:create, %{
+          scene_piece_id: piece.id,
+          content_uri: "storybox://test/scene/v1",
+          version_number: 1,
+          weights: %{}
+        })
+        |> Ash.create()
+
+      assert {:ok, updated} =
+               version
+               |> Ash.Changeset.for_update(:set_weights, %{weights: %{"preference" => 0.6}})
+               |> Ash.update()
+
+      assert updated.weights == %{"preference" => 0.6}
+
+      reloaded =
+        Storybox.Stories.SceneVersion
+        |> Ash.Query.filter(id == ^version.id)
+        |> Ash.read_one!(authorize?: false)
+
+      assert reloaded.weights == %{"preference" => 0.6}
+    end
+
+    test "replacing weights removes keys not in the new map", %{sequence: sequence} do
+      {:ok, piece} =
+        Storybox.Stories.ScenePiece
+        |> Ash.Changeset.for_create(:create, %{
+          title: "Test Scene 2",
+          position: 2,
+          sequence_piece_id: sequence.id
+        })
+        |> Ash.create()
+
+      {:ok, version} =
+        Storybox.Stories.SceneVersion
+        |> Ash.Changeset.for_create(:create, %{
+          scene_piece_id: piece.id,
+          content_uri: "storybox://test/scene/v2",
+          version_number: 1,
+          weights: %{"preference" => 0.9, "theme" => 0.7}
+        })
+        |> Ash.create()
+
+      assert {:ok, updated} =
+               version
+               |> Ash.Changeset.for_update(:set_weights, %{weights: %{"preference" => 0.4}})
+               |> Ash.update()
+
+      assert updated.weights == %{"preference" => 0.4}
+      refute Map.has_key?(updated.weights, "theme")
     end
   end
 

--- a/test/storybox/stories/sequence_piece_test.exs
+++ b/test/storybox/stories/sequence_piece_test.exs
@@ -1,6 +1,8 @@
 defmodule Storybox.Stories.SequencePieceTest do
   use Storybox.DataCase
 
+  require Ash.Query
+
   setup do
     {:ok, user} =
       Storybox.Accounts.User
@@ -154,6 +156,72 @@ defmodule Storybox.Stories.SequencePieceTest do
                |> Ash.update()
 
       assert updated_piece.approved_version_id == version.id
+    end
+  end
+
+  describe "set_weights action on SequenceVersion" do
+    test "sets weights map on a version with empty weights and persists it", %{story: story} do
+      {:ok, piece} =
+        Storybox.Stories.SequencePiece
+        |> Ash.Changeset.for_create(:create, %{
+          title: "Test Piece",
+          position: 1,
+          story_id: story.id
+        })
+        |> Ash.create()
+
+      {:ok, version} =
+        Storybox.Stories.SequenceVersion
+        |> Ash.Changeset.for_create(:create, %{
+          sequence_piece_id: piece.id,
+          content_uri: "storybox://test/v1",
+          version_number: 1,
+          weights: %{}
+        })
+        |> Ash.create()
+
+      assert {:ok, updated} =
+               version
+               |> Ash.Changeset.for_update(:set_weights, %{weights: %{"preference" => 0.8}})
+               |> Ash.update()
+
+      assert updated.weights == %{"preference" => 0.8}
+
+      reloaded =
+        Storybox.Stories.SequenceVersion
+        |> Ash.Query.filter(id == ^version.id)
+        |> Ash.read_one!(authorize?: false)
+
+      assert reloaded.weights == %{"preference" => 0.8}
+    end
+
+    test "replacing weights removes keys not in the new map", %{story: story} do
+      {:ok, piece} =
+        Storybox.Stories.SequencePiece
+        |> Ash.Changeset.for_create(:create, %{
+          title: "Test Piece",
+          position: 2,
+          story_id: story.id
+        })
+        |> Ash.create()
+
+      {:ok, version} =
+        Storybox.Stories.SequenceVersion
+        |> Ash.Changeset.for_create(:create, %{
+          sequence_piece_id: piece.id,
+          content_uri: "storybox://test/v2",
+          version_number: 1,
+          weights: %{"preference" => 0.9, "theme" => 0.7}
+        })
+        |> Ash.create()
+
+      assert {:ok, updated} =
+               version
+               |> Ash.Changeset.for_update(:set_weights, %{weights: %{"preference" => 0.5}})
+               |> Ash.update()
+
+      assert updated.weights == %{"preference" => 0.5}
+      refute Map.has_key?(updated.weights, "theme")
     end
   end
 

--- a/test/storybox_web/live/script_live_test.exs
+++ b/test/storybox_web/live/script_live_test.exs
@@ -1,0 +1,189 @@
+defmodule StoryboxWeb.ScriptLiveTest do
+  use StoryboxWeb.ConnCase
+
+  import Phoenix.LiveViewTest
+
+  require Ash.Query
+
+  # Seed data graph:
+  #
+  #   alice ──► "The Illusionist"  (through_lines: ["preference"])
+  #               └── Sequence "Act 1"  pos 1
+  #                     ├── Scene "Opening"  pos 1  approved → nil
+  #                     │     ├── v1  weights: {}      status: current
+  #                     │     └── v2  weights: {}      status: current
+  #                     └── Scene "Confrontation"  pos 2  approved → v1
+  #                           └── v1  weights: {preference→0.9}  status: current  [approved]
+
+  setup do
+    {:ok, alice} =
+      Storybox.Accounts.User
+      |> Ash.Changeset.for_create(:register_with_password, %{
+        email: "alice@example.com",
+        password: "password123!",
+        password_confirmation: "password123!"
+      })
+      |> Ash.create()
+
+    {:ok, story} =
+      Storybox.Stories.Story
+      |> Ash.Changeset.for_create(:create, %{
+        title: "The Illusionist",
+        through_lines: ["preference"],
+        user_id: alice.id
+      })
+      |> Ash.create()
+
+    {:ok, sequence} =
+      Storybox.Stories.SequencePiece
+      |> Ash.Changeset.for_create(:create, %{
+        title: "Act 1",
+        position: 1,
+        story_id: story.id
+      })
+      |> Ash.create()
+
+    # Scene "Opening" — two versions, no approved
+    {:ok, scene_opening} =
+      Storybox.Stories.ScenePiece
+      |> Ash.Changeset.for_create(:create, %{
+        title: "Opening",
+        position: 1,
+        sequence_piece_id: sequence.id
+      })
+      |> Ash.create()
+
+    {:ok, opening_v1} =
+      Storybox.Stories.SceneVersion
+      |> Ash.Changeset.for_create(:create, %{
+        scene_piece_id: scene_opening.id,
+        content_uri: "storybox://test/opening/v1",
+        version_number: 1,
+        upstream_status: :current,
+        weights: %{}
+      })
+      |> Ash.create()
+
+    {:ok, opening_v2} =
+      Storybox.Stories.SceneVersion
+      |> Ash.Changeset.for_create(:create, %{
+        scene_piece_id: scene_opening.id,
+        content_uri: "storybox://test/opening/v2",
+        version_number: 2,
+        upstream_status: :current,
+        weights: %{}
+      })
+      |> Ash.create()
+
+    # Scene "Confrontation" — one version, approved, already reviewed
+    {:ok, scene_confrontation} =
+      Storybox.Stories.ScenePiece
+      |> Ash.Changeset.for_create(:create, %{
+        title: "Confrontation",
+        position: 2,
+        sequence_piece_id: sequence.id
+      })
+      |> Ash.create()
+
+    {:ok, confrontation_v1} =
+      Storybox.Stories.SceneVersion
+      |> Ash.Changeset.for_create(:create, %{
+        scene_piece_id: scene_confrontation.id,
+        content_uri: "storybox://test/confrontation/v1",
+        version_number: 1,
+        upstream_status: :current,
+        weights: %{"preference" => 0.9}
+      })
+      |> Ash.create()
+
+    {:ok, scene_confrontation} =
+      scene_confrontation
+      |> Ash.Changeset.for_update(:approve_version, %{version_id: confrontation_v1.id})
+      |> Ash.update()
+
+    %{
+      alice: alice,
+      story: story,
+      sequence: sequence,
+      scene_opening: scene_opening,
+      opening_v1: opening_v1,
+      opening_v2: opening_v2,
+      scene_confrontation: scene_confrontation,
+      confrontation_v1: confrontation_v1
+    }
+  end
+
+  describe "weight form" do
+    test "unreviewed version row has the ring-warning indicator", %{
+      conn: conn,
+      alice: alice,
+      story: story,
+      sequence: sequence
+    } do
+      conn = log_in_user(conn, alice)
+      {:ok, _view, html} = live(conn, "/stories/#{story.id}/sequences/#{sequence.id}/script")
+
+      assert html =~ "ring-warning"
+    end
+
+    test "clicking Review on Opening v2 (latest) renders a range input for each through_line", %{
+      conn: conn,
+      alice: alice,
+      story: story,
+      sequence: sequence,
+      opening_v2: opening_v2
+    } do
+      conn = log_in_user(conn, alice)
+      {:ok, view, _html} = live(conn, "/stories/#{story.id}/sequences/#{sequence.id}/script")
+
+      html =
+        view
+        |> element(
+          "[phx-click=\"toggle_weight_form\"][phx-value-version-id=\"#{opening_v2.id}\"]",
+          "Review"
+        )
+        |> render_click()
+
+      assert html =~ ~s(name="weights[preference]")
+    end
+
+    test "submitting the weight form persists weights and updates the badge", %{
+      conn: conn,
+      alice: alice,
+      story: story,
+      sequence: sequence,
+      opening_v2: opening_v2
+    } do
+      conn = log_in_user(conn, alice)
+      {:ok, view, _html} = live(conn, "/stories/#{story.id}/sequences/#{sequence.id}/script")
+
+      # Open the form on the latest version (v2)
+      view
+      |> element(
+        "[phx-click=\"toggle_weight_form\"][phx-value-version-id=\"#{opening_v2.id}\"]",
+        "Review"
+      )
+      |> render_click()
+
+      # Submit weights
+      view
+      |> form("form[phx-submit=\"set_weights\"]",
+        version_id: opening_v2.id,
+        weights: %{"preference" => "0.75"}
+      )
+      |> render_submit()
+
+      # Persisted in DB
+      updated =
+        Storybox.Stories.SceneVersion
+        |> Ash.Query.filter(id == ^opening_v2.id)
+        |> Ash.read_one!(authorize?: false)
+
+      assert updated.weights == %{"preference" => 0.75}
+
+      # Badge shows reviewed
+      html = render(view)
+      assert html =~ "reviewed"
+    end
+  end
+end

--- a/test/storybox_web/live/treatment_live_test.exs
+++ b/test/storybox_web/live/treatment_live_test.exs
@@ -392,6 +392,91 @@ defmodule StoryboxWeb.TreatmentLiveTest do
     end
   end
 
+  describe "weight form" do
+    test "unreviewed version row has the ring-warning indicator", %{
+      conn: conn,
+      alice: alice,
+      story: story
+    } do
+      conn = log_in_user(conn, alice)
+      {:ok, _view, html} = live(conn, "/stories/#{story.id}/treatment")
+
+      # reveal_v2 has empty weights — should render ring-2 ring-warning
+      assert html =~ "ring-warning"
+    end
+
+    test "Review button is present for each version", %{
+      conn: conn,
+      alice: alice,
+      story: story
+    } do
+      conn = log_in_user(conn, alice)
+      {:ok, _view, html} = live(conn, "/stories/#{story.id}/treatment")
+
+      assert html =~ "Review"
+    end
+
+    test "clicking Review on The Reveal v2 opens a form with a range input per through_line", %{
+      conn: conn,
+      alice: alice,
+      story: story,
+      reveal_v2: reveal_v2
+    } do
+      conn = log_in_user(conn, alice)
+      {:ok, view, _html} = live(conn, "/stories/#{story.id}/treatment")
+
+      html =
+        view
+        |> element(
+          "[phx-click=\"toggle_weight_form\"][phx-value-version-id=\"#{reveal_v2.id}\"]",
+          "Review"
+        )
+        |> render_click()
+
+      # Story has through_lines ["preference", "theme"] — expect both inputs
+      assert html =~ ~s(name="weights[preference]")
+      assert html =~ ~s(name="weights[theme]")
+    end
+
+    test "submitting the weight form persists weights and shows the reviewed badge", %{
+      conn: conn,
+      alice: alice,
+      story: story,
+      reveal_v2: reveal_v2
+    } do
+      conn = log_in_user(conn, alice)
+      {:ok, view, _html} = live(conn, "/stories/#{story.id}/treatment")
+
+      # Open the form
+      view
+      |> element(
+        "[phx-click=\"toggle_weight_form\"][phx-value-version-id=\"#{reveal_v2.id}\"]",
+        "Review"
+      )
+      |> render_click()
+
+      # Submit weights for both through_lines
+      view
+      |> form("form[phx-submit=\"set_weights\"]",
+        version_id: reveal_v2.id,
+        weights: %{"preference" => "0.8", "theme" => "0.6"}
+      )
+      |> render_submit()
+
+      # Weights persisted in DB
+      updated =
+        Storybox.Stories.SequenceVersion
+        |> Ash.Query.filter(id == ^reveal_v2.id)
+        |> Ash.read_one!(authorize?: false)
+
+      assert updated.weights == %{"preference" => 0.8, "theme" => 0.6}
+
+      # reviewed badge visible
+      html = render(view)
+      assert html =~ "reviewed"
+    end
+  end
+
   describe "empty story" do
     test "shows no-sequences empty state for a story with no sequences", %{
       conn: conn,


### PR DESCRIPTION
## Summary

- Adds `update :set_weights` action to `SequenceVersion` and `SceneVersion` — replaces the `weights` map in full (no migration needed, column already exists)
- Adds inline "Review" panel to each version row in `TreatmentLive`, `ScriptLive`, and `SceneCompareLive` — one range slider per `through_line`, Cancel/Save buttons
- Unreviewed version rows gain a `ring-2 ring-warning` border as a visual prominence indicator; badge transitions to `reviewed` / `partial` / `unreviewed` after save without a page reload

## Key decisions

- **Full-map replace on save** — `set_weights` accepts the entire new `weights` map, which means keys not in the submitted form are dropped. This keeps the action simple and avoids partial-update races.
- **Inline expand rather than modal** — weight form opens in-place per version, consistent with the existing approve/compare action pattern on these views.
- **Save on explicit submit** — avoided `phx-change` on each slider (fires on every drag tick) in favour of a form submit so DB writes are intentional.

## Test plan

- [x] `mix precommit` passes (214 tests, 0 failures)
- [x] `:set_weights` on `SequenceVersion` persists full weights map
- [x] `:set_weights` on `SequenceVersion` replaces map (old keys gone)
- [x] `:set_weights` on `SceneVersion` persists full weights map
- [x] `:set_weights` on `SceneVersion` replaces map
- [x] `TreatmentLive`: unreviewed version rows have `ring-warning` class
- [x] `TreatmentLive`: Review toggle opens form with range inputs per through_line
- [x] `TreatmentLive`: form submit persists weights and shows `reviewed` badge
- [x] `ScriptLive`: Review toggle opens form with range input
- [x] `ScriptLive`: form submit persists weights and updates badge
- [x] User: inspect in browser (dark + light mode), try slider interaction

closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)