### PR TITLE
API: fix UTF-8 double-encoding in MinIO content — closes #51

### DIFF
--- a/lib/storybox/storage.ex
+++ b/lib/storybox/storage.ex
@@ -28,7 +28,7 @@ defmodule Storybox.Storage do
     path = uri_to_path(uri)
 
     case ExAws.S3.get_object(@bucket, path) |> ExAws.request() do
-      {:ok, %{body: body}} -> {:ok, body}
+      {:ok, %{body: body}} -> {:ok, IO.iodata_to_binary(body)}
       {:error, reason} -> {:error, reason}
     end
   end

--- a/test/storybox/storage_test.exs
+++ b/test/storybox/storage_test.exs
@@ -42,5 +42,20 @@ defmodule Storybox.StorageTest do
       assert {:ok, ^uri} = Storage.put_content(uri, content)
       assert {:ok, ^content} = Storage.get_content(uri)
     end
+
+    test "round-trips content containing non-ASCII characters unchanged" do
+      uri = Storage.uri_for_synopsis(@story_id, 98)
+
+      content =
+        "Frank carries something back with him \u2014 something that has no name.\n\u201CHe never told us,\u201D she said."
+
+      assert {:ok, ^uri} = Storage.put_content(uri, content)
+      assert {:ok, retrieved} = Storage.get_content(uri)
+
+      assert retrieved == content,
+             "non-ASCII characters were mangled: #{inspect(retrieved)}"
+
+      assert String.valid?(retrieved), "retrieved content is not valid UTF-8"
+    end
   end
 end

--- a/test/storybox_web/controllers/synopsis_view_test.exs
+++ b/test/storybox_web/controllers/synopsis_view_test.exs
@@ -106,6 +106,32 @@ defmodule StoryboxWeb.SynopsisViewTest do
       assert json_response(conn, 503)["error"] == "content unavailable"
     end
 
+    test "returns non-ASCII characters (em dash, smart quotes) without double-encoding", %{
+      conn: conn,
+      story: story,
+      raw_token: raw_token
+    } do
+      content = "Frank carries something back \u2014 something that has no name."
+
+      {:ok, _v} =
+        Storybox.Stories.SynopsisVersion
+        |> Ash.ActionInput.for_action(:create_version, %{
+          story_id: story.id,
+          content: content
+        })
+        |> Ash.run_action()
+
+      conn =
+        conn
+        |> authed(raw_token)
+        |> get("/api/stories/#{story.id}/views/synopsis")
+
+      body = json_response(conn, 200)
+
+      assert body["content"] == content,
+             "content was double-encoded: #{inspect(body["content"])}"
+    end
+
     test "returns 403 when token is scoped to a different story", %{
       conn: conn,
       other_story: other_story,


### PR DESCRIPTION
## Summary

- `Storage.get_content/1` now wraps the response body with `IO.iodata_to_binary/1` before returning
- ExAws/hackney can return the S3 body as an iolist (nested list of binaries) rather than a flat binary; Jason then serialised each byte as a Latin-1 codepoint, producing Mojibake (e.g. `—` → `â€"`)
- `IO.iodata_to_binary/1` is idempotent on an already-flat binary, so this is safe for all content

## Test plan

- [x] `mix precommit` — 216 tests, 0 failures
- [x] Storage round-trip with non-ASCII content (`—`, `"`, `"`) — retrieved bytes identical to uploaded bytes
- [x] `String.valid?/1` is true for retrieved content
- [x] `GET /api/stories/:id/views/synopsis` returns `—` not `â€"` for synopsis containing an em dash

closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)