### PR TITLE
feat: POST /api/auth/token — credential exchange for bearer token

### DIFF
--- a/lib/storybox_web/controllers/api_controller.ex
+++ b/lib/storybox_web/controllers/api_controller.ex
@@ -3,6 +3,45 @@ defmodule StoryboxWeb.ApiController do
 
   require Ash.Query
 
+  def token(conn, %{"email" => email, "password" => password, "story_id" => story_id}) do
+    strategy = AshAuthentication.Info.strategy!(Storybox.Accounts.User, :password)
+
+    case AshAuthentication.Strategy.action(strategy, :sign_in, %{
+           email: email,
+           password: password
+         }) do
+      {:ok, user} ->
+        case Storybox.Stories.Story
+             |> Ash.Query.filter(id == ^story_id and user_id == ^user.id)
+             |> Ash.read_one(authorize?: false) do
+          {:ok, nil} ->
+            conn |> put_status(404) |> json(%{error: "story not found"})
+
+          {:ok, _story} ->
+            case Storybox.Accounts.ApiToken.generate(%{
+                   story_id: story_id,
+                   user_id: user.id
+                 }) do
+              {:ok, raw_token, _record} ->
+                json(conn, %{token: raw_token})
+
+              {:error, _} ->
+                conn |> put_status(500) |> json(%{error: "failed to generate token"})
+            end
+
+          {:error, _} ->
+            conn |> put_status(500) |> json(%{error: "internal error"})
+        end
+
+      {:error, _} ->
+        conn |> put_status(401) |> json(%{error: "invalid credentials"})
+    end
+  end
+
+  def token(conn, _params) do
+    conn |> put_status(422) |> json(%{error: "email, password, and story_id are required"})
+  end
+
   def ping(conn, %{"story_id" => story_id}) do
     json(conn, %{status: "ok", story_id: story_id})
   end

--- a/lib/storybox_web/router.ex
+++ b/lib/storybox_web/router.ex
@@ -39,6 +39,12 @@ defmodule StoryboxWeb.Router do
   end
 
   scope "/api", StoryboxWeb do
+    pipe_through :api
+
+    post "/auth/token", ApiController, :token
+  end
+
+  scope "/api", StoryboxWeb do
     pipe_through [:api, :require_api_auth]
 
     get "/stories/:story_id/ping", ApiController, :ping

--- a/test/storybox_web/controllers/api_token_test.exs
+++ b/test/storybox_web/controllers/api_token_test.exs
@@ -1,0 +1,156 @@
+defmodule StoryboxWeb.ApiTokenTest do
+  use StoryboxWeb.ConnCase
+
+  setup do
+    {:ok, user} =
+      Storybox.Accounts.User
+      |> Ash.Changeset.for_create(:register_with_password, %{
+        email: "token_test@example.com",
+        password: "Password1!",
+        password_confirmation: "Password1!"
+      })
+      |> Ash.create()
+
+    {:ok, other_user} =
+      Storybox.Accounts.User
+      |> Ash.Changeset.for_create(:register_with_password, %{
+        email: "other_token_test@example.com",
+        password: "Password1!",
+        password_confirmation: "Password1!"
+      })
+      |> Ash.create()
+
+    {:ok, story} =
+      Storybox.Stories.Story
+      |> Ash.Changeset.for_create(:create, %{
+        title: "Token Test Story",
+        user_id: user.id
+      })
+      |> Ash.create()
+
+    {:ok, other_story} =
+      Storybox.Stories.Story
+      |> Ash.Changeset.for_create(:create, %{
+        title: "Other User Story",
+        user_id: other_user.id
+      })
+      |> Ash.create()
+
+    %{user: user, story: story, other_story: other_story}
+  end
+
+  describe "POST /api/auth/token" do
+    test "returns a token for valid credentials and owned story", %{
+      conn: conn,
+      story: story
+    } do
+      conn =
+        post(conn, "/api/auth/token", %{
+          email: "token_test@example.com",
+          password: "Password1!",
+          story_id: story.id
+        })
+
+      assert %{"token" => token} = json_response(conn, 200)
+      assert is_binary(token) and byte_size(token) > 0
+    end
+
+    test "returned token is accepted by authenticated endpoints", %{
+      conn: conn,
+      story: story
+    } do
+      %{"token" => token} =
+        conn
+        |> post("/api/auth/token", %{
+          email: "token_test@example.com",
+          password: "Password1!",
+          story_id: story.id
+        })
+        |> json_response(200)
+
+      ping_conn =
+        build_conn()
+        |> put_req_header("authorization", "Bearer #{token}")
+        |> get("/api/stories/#{story.id}/ping")
+
+      assert json_response(ping_conn, 200)["status"] == "ok"
+    end
+
+    test "returns 401 for wrong password", %{conn: conn, story: story} do
+      conn =
+        post(conn, "/api/auth/token", %{
+          email: "token_test@example.com",
+          password: "wrongpassword",
+          story_id: story.id
+        })
+
+      assert json_response(conn, 401)["error"] == "invalid credentials"
+    end
+
+    test "returns 401 for unknown email", %{conn: conn, story: story} do
+      conn =
+        post(conn, "/api/auth/token", %{
+          email: "nobody@example.com",
+          password: "Password1!",
+          story_id: story.id
+        })
+
+      assert json_response(conn, 401)["error"] == "invalid credentials"
+    end
+
+    test "returns 404 for a story owned by a different user", %{
+      conn: conn,
+      other_story: other_story
+    } do
+      conn =
+        post(conn, "/api/auth/token", %{
+          email: "token_test@example.com",
+          password: "Password1!",
+          story_id: other_story.id
+        })
+
+      assert json_response(conn, 404)["error"] == "story not found"
+    end
+
+    test "returns 404 for a story_id that does not exist", %{conn: conn} do
+      conn =
+        post(conn, "/api/auth/token", %{
+          email: "token_test@example.com",
+          password: "Password1!",
+          story_id: Ecto.UUID.generate()
+        })
+
+      assert json_response(conn, 404)["error"] == "story not found"
+    end
+
+    test "returns 422 when story_id is missing", %{conn: conn} do
+      conn =
+        post(conn, "/api/auth/token", %{
+          email: "token_test@example.com",
+          password: "Password1!"
+        })
+
+      assert json_response(conn, 422)["error"] =~ "required"
+    end
+
+    test "returns 422 when email is missing", %{conn: conn, story: story} do
+      conn =
+        post(conn, "/api/auth/token", %{
+          password: "Password1!",
+          story_id: story.id
+        })
+
+      assert json_response(conn, 422)["error"] =~ "required"
+    end
+
+    test "returns 422 when password is missing", %{conn: conn, story: story} do
+      conn =
+        post(conn, "/api/auth/token", %{
+          email: "token_test@example.com",
+          story_id: story.id
+        })
+
+      assert json_response(conn, 422)["error"] =~ "required"
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds an unauthenticated `POST /api/auth/token` endpoint that accepts `email`, `password`, and `story_id`, verifies credentials via AshAuthentication, confirms the story is owned by that user, and returns a raw bearer token. Closes the bootstrap gap — previously a token could only be obtained via `iex` inside the container.

## Key decisions

- **Separate unauthenticated scope** — the new route lives in its own `/api` scope piped through `:api` only, above the existing `:require_api_auth` scope. This keeps the auth check out of the token endpoint without loosening security on any other route.
- **`AshAuthentication.Strategy.action/3` with `:sign_in`** — the strategy action atom is `:sign_in`, not `:sign_in_with_password` (the action name on the resource). Discovered via test failure; documented here to save future confusion.
- **Story ownership check before token generation** — credentials are verified first, then story ownership is confirmed. A valid user asking for a token scoped to another user's story gets 404, not 403, to avoid leaking story existence.

## Error responses

| Condition | Status |
|---|---|
| Bad credentials | 401 |
| Story not found / not owned by user | 404 |
| Missing `email`, `password`, or `story_id` | 422 |
| Token generation failure | 500 |

## Test plan

- [x] `mix precommit` — 231 tests, 0 failures
- [x] Valid credentials + owned story → 200 with token
- [x] Returned token accepted by `GET /api/stories/:id/ping`
- [x] Wrong password → 401
- [x] Unknown email → 401
- [x] Story owned by different user → 404
- [x] Non-existent story_id → 404
- [x] Missing `story_id` → 422
- [x] Missing `email` → 422
- [x] Missing `password` → 422

closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)