### PR TITLE
feat: rename piece/version vocabulary to view/piece (#74)

### DIFF
--- a/docs/data_model.md
+++ b/docs/data_model.md
@@ -14,9 +14,8 @@ updated_at
 
 has_many :characters
 has_many :worlds
-has_many :synopsis_versions
-has_many :sequence_pieces
-has_many :scene_pieces
+has_many :synopsis_views
+has_many :treatment_views
 belongs_to :user
 ```
 
@@ -45,7 +44,7 @@ inserted_at
 belongs_to :story
 ```
 
-### SynopsisVersion
+### SynopsisView
 ```
 id
 story_id
@@ -56,7 +55,7 @@ inserted_at
 belongs_to :story
 ```
 
-### SequencePiece
+### TreatmentView
 ```
 id
 story_id
@@ -66,48 +65,47 @@ position:       :integer
 approved_version_id
 
 belongs_to :story
-has_many :sequence_versions
+has_many :treatment_pieces
+has_many :script_views
 ```
 
-### SequenceVersion
+### TreatmentPiece
 ```
 id
-sequence_piece_id
-content_uri:      :string    # storybox://stories/:id/sequences/:seq_id/v:n
+treatment_view_id
+content_uri:      :string    # storybox://stories/:id/sequences/:view_id/v:n
 version_number:   :integer
 weights:          :map        # %{"preference" => 0.9} — empty = unreviewed
 upstream_status:  :atom       # :current | :stale
 inserted_at
 
-belongs_to :sequence_piece
+belongs_to :treatment_view
 has_many :upstream_changes
 ```
 
-### ScenePiece
+### ScriptView
 ```
 id
-story_id
-sequence_piece_id
+treatment_view_id
 title
 position:           :integer
 approved_version_id
 
-belongs_to :story
-belongs_to :sequence_piece
-has_many :scene_versions
+belongs_to :treatment_view
+has_many :script_pieces
 ```
 
-### SceneVersion
+### ScriptPiece
 ```
 id
-scene_piece_id
-content_uri:      :string   # storybox://stories/:id/scenes/:scene_id/v:n
+script_view_id
+content_uri:      :string   # storybox://stories/:id/scenes/:view_id/v:n
 version_number:   :integer
 weights:          :map       # %{"preference" => 0.9} — empty = unreviewed
 upstream_status:  :atom      # :current | :stale
 inserted_at
 
-belongs_to :scene_piece
+belongs_to :script_view
 has_many :upstream_changes
 ```
 
@@ -116,7 +114,7 @@ has_many :upstream_changes
 id
 story_id
 name:    :string
-entries: :map   # %{scene_piece_id => scene_version_id}
+entries: :map   # %{script_view_id => script_piece_id}
 inserted_at
 
 belongs_to :story
@@ -126,11 +124,11 @@ belongs_to :story
 ```
 id
 piece_version_id
-piece_version_type:       :string   # "sequence" | "scene"
-component_type:           :string   # "story" | "character" | "world" | "synopsis"
+piece_version_type:       :atom     # :treatment_piece | :script_piece
+component_type:           :atom     # :story | :character | :world
 component_id:             :uuid
-component_version_before: :integer
-component_version_after:  :integer
+version_before:           :string
+version_after:            :string
 acknowledged:             :boolean  # true once user has seen and acted on it
 inserted_at
 ```
@@ -155,14 +153,14 @@ inserted_at
 
 ## Tags
 
-Tags are named pointers on a Piece to a specific version. They are how views align to a particular state of a piece.
+Tags are named pointers on a View to a specific piece. They are how views align to a particular state of a piece.
 
-**`approved_version_id`** (on SequencePiece and ScenePiece):
-- Points to the version considered approved for the `:approved` view
+**`approved_version_id`** (on TreatmentView and ScriptView):
+- Points to the piece considered approved for the `:approved` view
 - Updated by the `:approve_version` action
-- A piece may have no approved version (pointer is nil)
+- A view may have no approved piece (pointer is nil)
 
-Publishing is not a separate state. Every version that exists is available. The `:approved` view assembles from approved pointers; `:latest` resolves to the highest version number. A `:snapshot` captures a named map of `piece_id → version_id` at a point in time.
+Publishing is not a separate state. Every piece that exists is available. The `:approved` view assembles from approved pointers; `:latest` resolves to the highest version number. A `:snapshot` captures a named map of `view_id → piece_id` at a point in time.
 
 ---
 
@@ -179,16 +177,16 @@ Content URIs follow the pattern `storybox://stories/:story_id/:type/:id/v:n` and
 
 ## Key Actions (Ash Custom Actions)
 
-**`:create_version`** on SequencePiece / ScenePiece
+**`:create_version`** on TreatmentView / ScriptView
 - Stores content to MinIO, gets URI back
-- Creates new immutable version record
+- Creates new immutable piece record (TreatmentPiece / ScriptPiece)
 - Sets `upstream_status: :current`, `weights: %{}`
 
-**`:approve_version`** on SequencePiece / ScenePiece
-- Updates `approved_version_id` to the given version
+**`:approve_version`** on TreatmentView / ScriptView
+- Updates `approved_version_id` to the given piece
 - Optionally sets `weights: %{"preference" => 1.0}` if not already reviewed
 
 **`:propagate_change`** — triggered when Story, Character, or World is updated
 - Walks downstream dependency graph
-- Creates `UpstreamChange` records on all affected piece versions
-- Sets `upstream_status: :stale` on those versions
+- Creates `UpstreamChange` records on all affected pieces
+- Sets `upstream_status: :stale` on those pieces

--- a/lib/storybox/stories.ex
+++ b/lib/storybox/stories.ex
@@ -5,11 +5,11 @@ defmodule Storybox.Stories do
     resource Storybox.Stories.Story
     resource Storybox.Stories.Character
     resource Storybox.Stories.World
-    resource Storybox.Stories.SynopsisVersion
-    resource Storybox.Stories.SequencePiece
-    resource Storybox.Stories.SequenceVersion
-    resource Storybox.Stories.ScenePiece
-    resource Storybox.Stories.SceneVersion
+    resource Storybox.Stories.SynopsisView
+    resource Storybox.Stories.TreatmentView
+    resource Storybox.Stories.TreatmentPiece
+    resource Storybox.Stories.ScriptView
+    resource Storybox.Stories.ScriptPiece
     resource Storybox.Stories.ScriptSnapshot
     resource Storybox.Stories.UpstreamChange
   end

--- a/lib/storybox/stories/notifiers/propagate_upstream_change.ex
+++ b/lib/storybox/stories/notifiers/propagate_upstream_change.ex
@@ -4,10 +4,10 @@ defmodule Storybox.Stories.Notifiers.PropagateUpstreamChange do
   require Ash.Query
 
   alias Storybox.Stories.{
-    ScenePiece,
-    SceneVersion,
-    SequencePiece,
-    SequenceVersion,
+    ScriptView,
+    ScriptPiece,
+    TreatmentView,
+    TreatmentPiece,
     UpstreamChange
   }
 
@@ -35,26 +35,26 @@ defmodule Storybox.Stories.Notifiers.PropagateUpstreamChange do
   defp component_info(Storybox.Stories.World, record), do: {record.story_id, :world, record.id}
 
   defp propagate(story_id, component_type, component_id, version_before, version_after) do
-    sequence_pieces =
-      SequencePiece
+    treatment_views =
+      TreatmentView
       |> Ash.Query.filter(story_id == ^story_id)
       |> Ash.read!()
 
-    for sp <- sequence_pieces do
-      sequence_versions =
-        SequenceVersion
-        |> Ash.Query.filter(sequence_piece_id == ^sp.id)
+    for tv <- treatment_views do
+      treatment_pieces =
+        TreatmentPiece
+        |> Ash.Query.filter(treatment_view_id == ^tv.id)
         |> Ash.read!()
 
-      for sv <- sequence_versions do
-        sv
+      for tp <- treatment_pieces do
+        tp
         |> Ash.Changeset.for_update(:mark_stale, %{})
         |> Ash.update!()
 
         UpstreamChange
         |> Ash.Changeset.for_create(:create, %{
-          piece_version_type: :sequence_version,
-          piece_version_id: sv.id,
+          piece_version_type: :treatment_piece,
+          piece_version_id: tp.id,
           component_type: component_type,
           component_id: component_id,
           version_before: version_before,
@@ -63,26 +63,26 @@ defmodule Storybox.Stories.Notifiers.PropagateUpstreamChange do
         |> Ash.create!()
       end
 
-      scene_pieces =
-        ScenePiece
-        |> Ash.Query.filter(sequence_piece_id == ^sp.id)
+      script_views =
+        ScriptView
+        |> Ash.Query.filter(treatment_view_id == ^tv.id)
         |> Ash.read!()
 
-      for scene_piece <- scene_pieces do
-        scene_versions =
-          SceneVersion
-          |> Ash.Query.filter(scene_piece_id == ^scene_piece.id)
+      for script_view <- script_views do
+        script_pieces =
+          ScriptPiece
+          |> Ash.Query.filter(script_view_id == ^script_view.id)
           |> Ash.read!()
 
-        for sv <- scene_versions do
-          sv
+        for sp <- script_pieces do
+          sp
           |> Ash.Changeset.for_update(:mark_stale, %{})
           |> Ash.update!()
 
           UpstreamChange
           |> Ash.Changeset.for_create(:create, %{
-            piece_version_type: :scene_version,
-            piece_version_id: sv.id,
+            piece_version_type: :script_piece,
+            piece_version_id: sp.id,
             component_type: component_type,
             component_id: component_id,
             version_before: version_before,

--- a/lib/storybox/stories/script_piece.ex
+++ b/lib/storybox/stories/script_piece.ex
@@ -1,10 +1,10 @@
-defmodule Storybox.Stories.SequenceVersion do
+defmodule Storybox.Stories.ScriptPiece do
   use Ash.Resource,
     domain: Storybox.Stories,
     data_layer: AshPostgres.DataLayer
 
   postgres do
-    table "sequence_versions"
+    table "script_pieces"
     repo Storybox.Repo
   end
 
@@ -25,14 +25,14 @@ defmodule Storybox.Stories.SequenceVersion do
   end
 
   relationships do
-    belongs_to :sequence_piece, Storybox.Stories.SequencePiece, allow_nil?: false, public?: true
+    belongs_to :script_view, Storybox.Stories.ScriptView, allow_nil?: false, public?: true
   end
 
   actions do
     defaults [:read]
 
     create :create do
-      accept [:sequence_piece_id, :content_uri, :version_number, :upstream_status, :weights]
+      accept [:script_view_id, :content_uri, :version_number, :upstream_status, :weights]
     end
 
     update :mark_stale do

--- a/lib/storybox/stories/script_snapshot.ex
+++ b/lib/storybox/stories/script_snapshot.ex
@@ -38,19 +38,19 @@ defmodule Storybox.Stories.ScriptSnapshot do
       run fn input, _context ->
         story_id = input.arguments.story_id
 
-        sequence_ids =
-          Storybox.Stories.SequencePiece
+        treatment_view_ids =
+          Storybox.Stories.TreatmentView
           |> Ash.Query.filter(story_id == ^story_id)
           |> Ash.read!(authorize?: false)
           |> Enum.map(& &1.id)
 
         entries =
-          Storybox.Stories.ScenePiece
-          |> Ash.Query.filter(sequence_piece_id in ^sequence_ids)
+          Storybox.Stories.ScriptView
+          |> Ash.Query.filter(treatment_view_id in ^treatment_view_ids)
           |> Ash.read!(authorize?: false)
           |> Enum.reject(&is_nil(&1.approved_version_id))
-          |> Map.new(fn piece ->
-            {to_string(piece.id), to_string(piece.approved_version_id)}
+          |> Map.new(fn view ->
+            {to_string(view.id), to_string(view.approved_version_id)}
           end)
 
         Storybox.Stories.ScriptSnapshot

--- a/lib/storybox/stories/script_view.ex
+++ b/lib/storybox/stories/script_view.ex
@@ -1,4 +1,4 @@
-defmodule Storybox.Stories.ScenePiece do
+defmodule Storybox.Stories.ScriptView do
   use Ash.Resource,
     domain: Storybox.Stories,
     data_layer: AshPostgres.DataLayer
@@ -6,7 +6,7 @@ defmodule Storybox.Stories.ScenePiece do
   require Ash.Query
 
   postgres do
-    table "scene_pieces"
+    table "script_views"
     repo Storybox.Repo
   end
 
@@ -21,15 +21,15 @@ defmodule Storybox.Stories.ScenePiece do
   end
 
   relationships do
-    belongs_to :sequence_piece, Storybox.Stories.SequencePiece, allow_nil?: false, public?: true
-    has_many :scene_versions, Storybox.Stories.SceneVersion, public?: true
+    belongs_to :treatment_view, Storybox.Stories.TreatmentView, allow_nil?: false, public?: true
+    has_many :script_pieces, Storybox.Stories.ScriptPiece, public?: true
   end
 
   actions do
     defaults [:read, :destroy]
 
     create :create do
-      accept [:title, :position, :sequence_piece_id]
+      accept [:title, :position, :treatment_view_id]
     end
 
     update :update do
@@ -42,40 +42,41 @@ defmodule Storybox.Stories.ScenePiece do
     end
 
     action :create_version, :struct do
-      constraints instance_of: Storybox.Stories.SceneVersion
+      constraints instance_of: Storybox.Stories.ScriptPiece
       argument :content, :string, allow_nil?: false
-      argument :scene_piece_id, :uuid, allow_nil?: false
+      argument :script_view_id, :uuid, allow_nil?: false
 
       run fn input, _context ->
-        piece_id = input.arguments.scene_piece_id
+        view_id = input.arguments.script_view_id
 
-        [piece] =
-          Storybox.Stories.ScenePiece
-          |> Ash.Query.filter(id == ^piece_id)
+        [view] =
+          Storybox.Stories.ScriptView
+          |> Ash.Query.filter(id == ^view_id)
           |> Ash.read!(authorize?: false)
 
-        [sequence] =
-          Storybox.Stories.SequencePiece
-          |> Ash.Query.filter(id == ^piece.sequence_piece_id)
+        [treatment_view] =
+          Storybox.Stories.TreatmentView
+          |> Ash.Query.filter(id == ^view.treatment_view_id)
           |> Ash.read!(authorize?: false)
 
-        existing_versions =
-          Storybox.Stories.SceneVersion
-          |> Ash.Query.filter(scene_piece_id == ^piece_id)
+        existing_pieces =
+          Storybox.Stories.ScriptPiece
+          |> Ash.Query.filter(script_view_id == ^view_id)
           |> Ash.read!(authorize?: false)
 
         next_version_number =
-          existing_versions
+          existing_pieces
           |> Enum.map(& &1.version_number)
           |> Enum.max(fn -> 0 end)
           |> Kernel.+(1)
 
-        uri = Storybox.Storage.uri_for_scene(sequence.story_id, piece_id, next_version_number)
+        uri =
+          Storybox.Storage.uri_for_scene(treatment_view.story_id, view_id, next_version_number)
 
         with {:ok, _} <- Storybox.Storage.put_content(uri, input.arguments.content) do
-          Storybox.Stories.SceneVersion
+          Storybox.Stories.ScriptPiece
           |> Ash.Changeset.for_create(:create, %{
-            scene_piece_id: piece_id,
+            script_view_id: view_id,
             content_uri: uri,
             version_number: next_version_number,
             upstream_status: :current,

--- a/lib/storybox/stories/story.ex
+++ b/lib/storybox/stories/story.ex
@@ -24,8 +24,8 @@ defmodule Storybox.Stories.Story do
     belongs_to :user, Storybox.Accounts.User, allow_nil?: false, public?: true
     has_many :characters, Storybox.Stories.Character, public?: true
     has_one :world, Storybox.Stories.World, public?: true
-    has_many :synopsis_versions, Storybox.Stories.SynopsisVersion, public?: true
-    has_many :sequence_pieces, Storybox.Stories.SequencePiece, public?: true
+    has_many :synopsis_views, Storybox.Stories.SynopsisView, public?: true
+    has_many :treatment_views, Storybox.Stories.TreatmentView, public?: true
   end
 
   actions do

--- a/lib/storybox/stories/synopsis_view.ex
+++ b/lib/storybox/stories/synopsis_view.ex
@@ -1,4 +1,4 @@
-defmodule Storybox.Stories.SynopsisVersion do
+defmodule Storybox.Stories.SynopsisView do
   use Ash.Resource,
     domain: Storybox.Stories,
     data_layer: AshPostgres.DataLayer
@@ -6,7 +6,7 @@ defmodule Storybox.Stories.SynopsisVersion do
   require Ash.Query
 
   postgres do
-    table "synopsis_versions"
+    table "synopsis_views"
     repo Storybox.Repo
   end
 
@@ -31,20 +31,20 @@ defmodule Storybox.Stories.SynopsisVersion do
     end
 
     action :create_version, :struct do
-      constraints instance_of: Storybox.Stories.SynopsisVersion
+      constraints instance_of: Storybox.Stories.SynopsisView
       argument :content, :string, allow_nil?: false
       argument :story_id, :uuid, allow_nil?: false
 
       run fn input, _context ->
         story_id = input.arguments.story_id
 
-        existing_versions =
-          Storybox.Stories.SynopsisVersion
+        existing_views =
+          Storybox.Stories.SynopsisView
           |> Ash.Query.filter(story_id == ^story_id)
           |> Ash.read!(authorize?: false)
 
         next_version_number =
-          existing_versions
+          existing_views
           |> Enum.map(& &1.version_number)
           |> Enum.max(fn -> 0 end)
           |> Kernel.+(1)
@@ -52,7 +52,7 @@ defmodule Storybox.Stories.SynopsisVersion do
         uri = Storybox.Storage.uri_for_synopsis(story_id, next_version_number)
 
         with {:ok, _} <- Storybox.Storage.put_content(uri, input.arguments.content) do
-          Storybox.Stories.SynopsisVersion
+          Storybox.Stories.SynopsisView
           |> Ash.Changeset.for_create(:create, %{
             story_id: story_id,
             content_uri: uri,

--- a/lib/storybox/stories/treatment_piece.ex
+++ b/lib/storybox/stories/treatment_piece.ex
@@ -1,10 +1,10 @@
-defmodule Storybox.Stories.SceneVersion do
+defmodule Storybox.Stories.TreatmentPiece do
   use Ash.Resource,
     domain: Storybox.Stories,
     data_layer: AshPostgres.DataLayer
 
   postgres do
-    table "scene_versions"
+    table "treatment_pieces"
     repo Storybox.Repo
   end
 
@@ -25,14 +25,14 @@ defmodule Storybox.Stories.SceneVersion do
   end
 
   relationships do
-    belongs_to :scene_piece, Storybox.Stories.ScenePiece, allow_nil?: false, public?: true
+    belongs_to :treatment_view, Storybox.Stories.TreatmentView, allow_nil?: false, public?: true
   end
 
   actions do
     defaults [:read]
 
     create :create do
-      accept [:scene_piece_id, :content_uri, :version_number, :upstream_status, :weights]
+      accept [:treatment_view_id, :content_uri, :version_number, :upstream_status, :weights]
     end
 
     update :mark_stale do

--- a/lib/storybox/stories/treatment_view.ex
+++ b/lib/storybox/stories/treatment_view.ex
@@ -1,4 +1,4 @@
-defmodule Storybox.Stories.SequencePiece do
+defmodule Storybox.Stories.TreatmentView do
   use Ash.Resource,
     domain: Storybox.Stories,
     data_layer: AshPostgres.DataLayer
@@ -6,7 +6,7 @@ defmodule Storybox.Stories.SequencePiece do
   require Ash.Query
 
   postgres do
-    table "sequence_pieces"
+    table "treatment_views"
     repo Storybox.Repo
   end
 
@@ -23,7 +23,7 @@ defmodule Storybox.Stories.SequencePiece do
 
   relationships do
     belongs_to :story, Storybox.Stories.Story, allow_nil?: false, public?: true
-    has_many :sequence_versions, Storybox.Stories.SequenceVersion, public?: true
+    has_many :treatment_pieces, Storybox.Stories.TreatmentPiece, public?: true
   end
 
   actions do
@@ -43,35 +43,35 @@ defmodule Storybox.Stories.SequencePiece do
     end
 
     action :create_version, :struct do
-      constraints instance_of: Storybox.Stories.SequenceVersion
+      constraints instance_of: Storybox.Stories.TreatmentPiece
       argument :content, :string, allow_nil?: false
-      argument :sequence_piece_id, :uuid, allow_nil?: false
+      argument :treatment_view_id, :uuid, allow_nil?: false
 
       run fn input, _context ->
-        piece_id = input.arguments.sequence_piece_id
+        view_id = input.arguments.treatment_view_id
 
-        [piece] =
-          Storybox.Stories.SequencePiece
-          |> Ash.Query.filter(id == ^piece_id)
+        [view] =
+          Storybox.Stories.TreatmentView
+          |> Ash.Query.filter(id == ^view_id)
           |> Ash.read!(authorize?: false)
 
-        existing_versions =
-          Storybox.Stories.SequenceVersion
-          |> Ash.Query.filter(sequence_piece_id == ^piece_id)
+        existing_pieces =
+          Storybox.Stories.TreatmentPiece
+          |> Ash.Query.filter(treatment_view_id == ^view_id)
           |> Ash.read!(authorize?: false)
 
         next_version_number =
-          existing_versions
+          existing_pieces
           |> Enum.map(& &1.version_number)
           |> Enum.max(fn -> 0 end)
           |> Kernel.+(1)
 
-        uri = Storybox.Storage.uri_for_sequence(piece.story_id, piece_id, next_version_number)
+        uri = Storybox.Storage.uri_for_sequence(view.story_id, view_id, next_version_number)
 
         with {:ok, _} <- Storybox.Storage.put_content(uri, input.arguments.content) do
-          Storybox.Stories.SequenceVersion
+          Storybox.Stories.TreatmentPiece
           |> Ash.Changeset.for_create(:create, %{
-            sequence_piece_id: piece_id,
+            treatment_view_id: view_id,
             content_uri: uri,
             version_number: next_version_number,
             upstream_status: :current,

--- a/lib/storybox/stories/upstream_change.ex
+++ b/lib/storybox/stories/upstream_change.ex
@@ -12,7 +12,7 @@ defmodule Storybox.Stories.UpstreamChange do
     uuid_primary_key :id
 
     attribute :piece_version_type, :atom,
-      constraints: [one_of: [:sequence_version, :scene_version]],
+      constraints: [one_of: [:treatment_piece, :script_piece]],
       allow_nil?: false,
       public?: true
 

--- a/lib/storybox_web/controllers/api_controller.ex
+++ b/lib/storybox_web/controllers/api_controller.ex
@@ -50,7 +50,7 @@ defmodule StoryboxWeb.ApiController do
     story = conn.assigns.current_story
 
     latest =
-      Storybox.Stories.SynopsisVersion
+      Storybox.Stories.SynopsisView
       |> Ash.Query.filter(story_id == ^story.id)
       |> Ash.Query.sort(version_number: :desc)
       |> Ash.Query.limit(1)
@@ -62,13 +62,13 @@ defmodule StoryboxWeb.ApiController do
         |> put_status(404)
         |> json(%{error: "no synopsis found"})
 
-      {:ok, version} ->
-        case Storybox.Storage.get_content(version.content_uri) do
+      {:ok, view} ->
+        case Storybox.Storage.get_content(view.content_uri) do
           {:ok, content} ->
             json(conn, %{
               story_id: story.id,
-              version_number: version.version_number,
-              inserted_at: version.inserted_at,
+              version_number: view.version_number,
+              inserted_at: view.inserted_at,
               content: content
             })
 
@@ -88,31 +88,31 @@ defmodule StoryboxWeb.ApiController do
   def treatment_view(conn, _params) do
     story = conn.assigns.current_story
 
-    pieces =
-      Storybox.Stories.SequencePiece
+    views =
+      Storybox.Stories.TreatmentView
       |> Ash.Query.filter(story_id == ^story.id)
       |> Ash.Query.sort(position: :asc)
       |> Ash.read!(authorize?: false)
 
     approved_ids =
-      pieces
+      views
       |> Enum.map(& &1.approved_version_id)
       |> Enum.reject(&is_nil/1)
 
-    versions_by_id =
+    pieces_by_id =
       case approved_ids do
         [] ->
           %{}
 
         ids ->
-          Storybox.Stories.SequenceVersion
+          Storybox.Stories.TreatmentPiece
           |> Ash.Query.filter(id in ^ids)
           |> Ash.read!(authorize?: false)
           |> Map.new(&{&1.id, &1})
       end
 
     acts =
-      pieces
+      views
       |> Enum.group_by(& &1.act)
       |> Enum.sort_by(fn {act, seqs} ->
         {if(is_nil(act), do: 1, else: 0), Enum.min_by(seqs, & &1.position).position}
@@ -121,14 +121,14 @@ defmodule StoryboxWeb.ApiController do
         %{
           act: act,
           sequences:
-            Enum.map(seqs, fn piece ->
-              version = versions_by_id[piece.approved_version_id]
+            Enum.map(seqs, fn view ->
+              piece = pieces_by_id[view.approved_version_id]
 
               %{
-                id: piece.id,
-                title: piece.title,
-                position: piece.position,
-                approved_version: format_version(version)
+                id: view.id,
+                title: view.title,
+                position: view.position,
+                approved_version: format_version(piece)
               }
             end)
         }
@@ -149,46 +149,46 @@ defmodule StoryboxWeb.ApiController do
         conn |> put_status(400) |> json(%{error: reason})
 
       {:ok, mode, snapshot_id} ->
-        sequences =
-          Storybox.Stories.SequencePiece
+        treatment_views =
+          Storybox.Stories.TreatmentView
           |> Ash.Query.filter(story_id == ^story.id)
           |> Ash.Query.sort(position: :asc)
           |> Ash.read!(authorize?: false)
 
-        sequence_ids = Enum.map(sequences, & &1.id)
+        treatment_view_ids = Enum.map(treatment_views, & &1.id)
 
-        scene_pieces =
-          Storybox.Stories.ScenePiece
-          |> Ash.Query.filter(sequence_piece_id in ^sequence_ids)
+        script_views =
+          Storybox.Stories.ScriptView
+          |> Ash.Query.filter(treatment_view_id in ^treatment_view_ids)
           |> Ash.Query.sort(position: :asc)
           |> Ash.read!(authorize?: false)
 
-        scenes_by_sequence = Enum.group_by(scene_pieces, & &1.sequence_piece_id)
-        scene_piece_ids = Enum.map(scene_pieces, & &1.id)
+        scenes_by_sequence = Enum.group_by(script_views, & &1.treatment_view_id)
+        script_view_ids = Enum.map(script_views, & &1.id)
 
-        case resolve_script_versions(mode, snapshot_id, story.id, scene_pieces, scene_piece_ids) do
+        case resolve_script_versions(mode, snapshot_id, story.id, script_views, script_view_ids) do
           {:error, :snapshot_not_found} ->
             conn |> put_status(404) |> json(%{error: "snapshot not found"})
 
           {:ok, versions_map} ->
-            case build_script_scenes(scene_pieces, versions_map) do
+            case build_script_scenes(script_views, versions_map) do
               {:error, :content_unavailable} ->
                 conn |> put_status(503) |> json(%{error: "content unavailable"})
 
               {:ok, scenes_with_content} ->
                 result =
-                  sequences
-                  |> Enum.map(fn seq ->
+                  treatment_views
+                  |> Enum.map(fn tv ->
                     scenes =
                       scenes_by_sequence
-                      |> Map.get(seq.id, [])
+                      |> Map.get(tv.id, [])
                       |> Enum.map(&scenes_with_content[&1.id])
 
                     %{
-                      id: seq.id,
-                      title: seq.title,
-                      act: seq.act,
-                      position: seq.position,
+                      id: tv.id,
+                      title: tv.title,
+                      act: tv.act,
+                      position: tv.position,
                       scenes: scenes
                     }
                   end)
@@ -221,16 +221,16 @@ defmodule StoryboxWeb.ApiController do
 
   defp parse_script_mode(_), do: {:error, "mode is required"}
 
-  defp resolve_script_versions("latest", _snapshot_id, _story_id, _scene_pieces, scene_piece_ids) do
-    all_versions =
-      Storybox.Stories.SceneVersion
-      |> Ash.Query.filter(scene_piece_id in ^scene_piece_ids)
+  defp resolve_script_versions("latest", _snapshot_id, _story_id, _script_views, script_view_ids) do
+    all_pieces =
+      Storybox.Stories.ScriptPiece
+      |> Ash.Query.filter(script_view_id in ^script_view_ids)
       |> Ash.read!(authorize?: false)
 
     versions_map =
-      all_versions
-      |> Enum.group_by(& &1.scene_piece_id)
-      |> Map.new(fn {id, vs} -> {id, Enum.max_by(vs, & &1.version_number)} end)
+      all_pieces
+      |> Enum.group_by(& &1.script_view_id)
+      |> Map.new(fn {id, ps} -> {id, Enum.max_by(ps, & &1.version_number)} end)
 
     {:ok, versions_map}
   end
@@ -239,35 +239,35 @@ defmodule StoryboxWeb.ApiController do
          "approved",
          _snapshot_id,
          _story_id,
-         scene_pieces,
-         _scene_piece_ids
+         script_views,
+         _script_view_ids
        ) do
     approved_ids =
-      scene_pieces
+      script_views
       |> Enum.map(& &1.approved_version_id)
       |> Enum.reject(&is_nil/1)
 
-    versions_by_id =
+    pieces_by_id =
       case approved_ids do
         [] ->
           %{}
 
         ids ->
-          Storybox.Stories.SceneVersion
+          Storybox.Stories.ScriptPiece
           |> Ash.Query.filter(id in ^ids)
           |> Ash.read!(authorize?: false)
           |> Map.new(&{&1.id, &1})
       end
 
     versions_map =
-      Map.new(scene_pieces, fn piece ->
-        {piece.id, versions_by_id[piece.approved_version_id]}
+      Map.new(script_views, fn view ->
+        {view.id, pieces_by_id[view.approved_version_id]}
       end)
 
     {:ok, versions_map}
   end
 
-  defp resolve_script_versions("snapshot", snapshot_id, story_id, scene_pieces, _scene_piece_ids) do
+  defp resolve_script_versions("snapshot", snapshot_id, story_id, script_views, _script_view_ids) do
     result =
       Storybox.Stories.ScriptSnapshot
       |> Ash.Query.filter(id == ^snapshot_id and story_id == ^story_id)
@@ -278,24 +278,24 @@ defmodule StoryboxWeb.ApiController do
         {:error, :snapshot_not_found}
 
       {:ok, snapshot} ->
-        version_ids = Map.values(snapshot.entries)
+        piece_ids = Map.values(snapshot.entries)
 
-        versions_by_id =
-          case version_ids do
+        pieces_by_id =
+          case piece_ids do
             [] ->
               %{}
 
             ids ->
-              Storybox.Stories.SceneVersion
+              Storybox.Stories.ScriptPiece
               |> Ash.Query.filter(id in ^ids)
               |> Ash.read!(authorize?: false)
               |> Map.new(&{to_string(&1.id), &1})
           end
 
         versions_map =
-          Map.new(scene_pieces, fn piece ->
-            version_id = snapshot.entries[to_string(piece.id)]
-            {piece.id, versions_by_id[version_id]}
+          Map.new(script_views, fn view ->
+            piece_id = snapshot.entries[to_string(view.id)]
+            {view.id, pieces_by_id[piece_id]}
           end)
 
         {:ok, versions_map}
@@ -305,32 +305,32 @@ defmodule StoryboxWeb.ApiController do
     end
   end
 
-  defp build_script_scenes(scene_pieces, versions_map) do
-    Enum.reduce_while(scene_pieces, {:ok, %{}}, fn piece, {:ok, acc} ->
-      version = versions_map[piece.id]
+  defp build_script_scenes(script_views, versions_map) do
+    Enum.reduce_while(script_views, {:ok, %{}}, fn view, {:ok, acc} ->
+      piece = versions_map[view.id]
 
-      case fetch_scene_content(version) do
+      case fetch_scene_content(piece) do
         {:error, :content_unavailable} ->
           {:halt, {:error, :content_unavailable}}
 
         {:ok, content} ->
           scene = %{
-            id: piece.id,
-            title: piece.title,
-            position: piece.position,
-            version: format_version(version),
+            id: view.id,
+            title: view.title,
+            position: view.position,
+            version: format_version(piece),
             content: content
           }
 
-          {:cont, {:ok, Map.put(acc, piece.id, scene)}}
+          {:cont, {:ok, Map.put(acc, view.id, scene)}}
       end
     end)
   end
 
   defp fetch_scene_content(nil), do: {:ok, nil}
 
-  defp fetch_scene_content(version) do
-    case Storybox.Storage.get_content(version.content_uri) do
+  defp fetch_scene_content(piece) do
+    case Storybox.Storage.get_content(piece.content_uri) do
       {:ok, content} -> {:ok, content}
       {:error, _} -> {:error, :content_unavailable}
     end
@@ -339,32 +339,32 @@ defmodule StoryboxWeb.ApiController do
   def sequence_detail(conn, %{"id" => id}) do
     story = conn.assigns.current_story
 
-    case Storybox.Stories.SequencePiece
+    case Storybox.Stories.TreatmentView
          |> Ash.Query.filter(id == ^id and story_id == ^story.id)
          |> Ash.read_one(authorize?: false) do
       {:ok, nil} ->
         conn |> put_status(404) |> json(%{error: "not found"})
 
-      {:ok, piece} ->
-        version_query =
-          if piece.approved_version_id do
-            Storybox.Stories.SequenceVersion
-            |> Ash.Query.filter(id == ^piece.approved_version_id)
+      {:ok, view} ->
+        piece_query =
+          if view.approved_version_id do
+            Storybox.Stories.TreatmentPiece
+            |> Ash.Query.filter(id == ^view.approved_version_id)
             |> Ash.read_one(authorize?: false)
           else
-            Storybox.Stories.SequenceVersion
-            |> Ash.Query.filter(sequence_piece_id == ^piece.id)
+            Storybox.Stories.TreatmentPiece
+            |> Ash.Query.filter(treatment_view_id == ^view.id)
             |> Ash.Query.sort(version_number: :desc)
             |> Ash.Query.limit(1)
             |> Ash.read_one(authorize?: false)
           end
 
-        case version_query do
+        case piece_query do
           {:ok, nil} ->
             conn |> put_status(404) |> json(%{error: "no version available"})
 
-          {:ok, version} ->
-            case Storybox.Storage.get_content(version.content_uri) do
+          {:ok, piece} ->
+            case Storybox.Storage.get_content(piece.content_uri) do
               {:ok, content} ->
                 characters =
                   Storybox.Stories.Character
@@ -377,11 +377,11 @@ defmodule StoryboxWeb.ApiController do
                   |> Ash.read_one!(authorize?: false)
 
                 json(conn, %{
-                  id: piece.id,
-                  title: piece.title,
-                  act: piece.act,
-                  position: piece.position,
-                  version: format_version(version),
+                  id: view.id,
+                  title: view.title,
+                  act: view.act,
+                  position: view.position,
+                  version: format_version(piece),
                   content: content,
                   context: %{
                     world: format_world(world),
@@ -409,9 +409,9 @@ defmodule StoryboxWeb.ApiController do
          {:parse_from, {from_num, ""}} <- {:parse_from, Integer.parse(from_str)},
          {:parse_to, {to_num, ""}} <- {:parse_to, Integer.parse(to_str)},
          {:from_sv, {:ok, from_sv}} when not is_nil(from_sv) <-
-           {:from_sv, load_synopsis_version(story.id, from_num)},
+           {:from_sv, load_synopsis_view(story.id, from_num)},
          {:to_sv, {:ok, to_sv}} when not is_nil(to_sv) <-
-           {:to_sv, load_synopsis_version(story.id, to_num)},
+           {:to_sv, load_synopsis_view(story.id, to_num)},
          {:from_content, {:ok, from_content}} <-
            {:from_content, Storybox.Storage.get_content(from_sv.content_uri)},
          {:to_content, {:ok, to_content}} <-
@@ -427,37 +427,37 @@ defmodule StoryboxWeb.ApiController do
           {:del, lines} -> %{op: "del", lines: lines}
         end)
 
-      pieces =
-        Storybox.Stories.SequencePiece
+      treatment_views =
+        Storybox.Stories.TreatmentView
         |> Ash.Query.filter(story_id == ^story.id)
         |> Ash.Query.sort(position: :asc)
         |> Ash.read!(authorize?: false)
 
       approved_ids =
-        pieces
+        treatment_views
         |> Enum.map(& &1.approved_version_id)
         |> Enum.reject(&is_nil/1)
 
-      versions_by_id =
+      pieces_by_id =
         case approved_ids do
           [] ->
             %{}
 
           ids ->
-            Storybox.Stories.SequenceVersion
+            Storybox.Stories.TreatmentPiece
             |> Ash.Query.filter(id in ^ids)
             |> Ash.read!(authorize?: false)
             |> Map.new(&{&1.id, &1})
         end
 
       {affected, unaffected, new} =
-        Enum.reduce(pieces, {[], [], []}, fn piece, {aff, unaff, new_acc} ->
-          version = versions_by_id[piece.approved_version_id]
-          formatted = format_piece(piece, version)
+        Enum.reduce(treatment_views, {[], [], []}, fn view, {aff, unaff, new_acc} ->
+          piece = pieces_by_id[view.approved_version_id]
+          formatted = format_piece(view, piece)
 
           cond do
-            is_nil(piece.approved_version_id) -> {aff, unaff, [formatted | new_acc]}
-            version && version.upstream_status == :stale -> {[formatted | aff], unaff, new_acc}
+            is_nil(view.approved_version_id) -> {aff, unaff, [formatted | new_acc]}
+            piece && piece.upstream_status == :stale -> {[formatted | aff], unaff, new_acc}
             true -> {aff, [formatted | unaff], new_acc}
           end
         end)
@@ -503,31 +503,31 @@ defmodule StoryboxWeb.ApiController do
     end
   end
 
-  defp load_synopsis_version(story_id, version_number) do
-    Storybox.Stories.SynopsisVersion
+  defp load_synopsis_view(story_id, version_number) do
+    Storybox.Stories.SynopsisView
     |> Ash.Query.filter(story_id == ^story_id and version_number == ^version_number)
     |> Ash.read_one(authorize?: false)
   end
 
-  defp format_piece(piece, version) do
+  defp format_piece(view, piece) do
     %{
-      id: piece.id,
-      title: piece.title,
-      act: piece.act,
-      position: piece.position,
-      approved_version: format_version(version)
+      id: view.id,
+      title: view.title,
+      act: view.act,
+      position: view.position,
+      approved_version: format_version(piece)
     }
   end
 
   defp format_version(nil), do: nil
 
-  defp format_version(version) do
+  defp format_version(piece) do
     %{
-      id: version.id,
-      version_number: version.version_number,
-      upstream_status: version.upstream_status,
-      weights: version.weights,
-      inserted_at: version.inserted_at
+      id: piece.id,
+      version_number: piece.version_number,
+      upstream_status: piece.upstream_status,
+      weights: piece.weights,
+      inserted_at: piece.inserted_at
     }
   end
 
@@ -549,21 +549,21 @@ defmodule StoryboxWeb.ApiController do
     if is_nil(content) || content == "" do
       conn |> put_status(400) |> json(%{error: "content is required"})
     else
-      piece =
-        Storybox.Stories.SequencePiece
+      view =
+        Storybox.Stories.TreatmentView
         |> Ash.Query.filter(id == ^id and story_id == ^story.id)
         |> Ash.read!(authorize?: false)
         |> List.first()
 
-      if piece do
-        case Storybox.Stories.SequencePiece
+      if view do
+        case Storybox.Stories.TreatmentView
              |> Ash.ActionInput.for_action(:create_version, %{
                content: content,
-               sequence_piece_id: piece.id
+               treatment_view_id: view.id
              })
              |> Ash.run_action(authorize?: false) do
-          {:ok, version} ->
-            conn |> put_status(201) |> json(format_version(version))
+          {:ok, piece} ->
+            conn |> put_status(201) |> json(format_version(piece))
 
           {:error, _} ->
             conn |> put_status(503) |> json(%{error: "storage error"})
@@ -581,29 +581,29 @@ defmodule StoryboxWeb.ApiController do
     if is_nil(content) || content == "" do
       conn |> put_status(400) |> json(%{error: "content is required"})
     else
-      scene =
-        Storybox.Stories.ScenePiece
+      script_view =
+        Storybox.Stories.ScriptView
         |> Ash.Query.filter(id == ^id)
         |> Ash.read!(authorize?: false)
         |> List.first()
 
       owner =
-        if scene do
-          Storybox.Stories.SequencePiece
-          |> Ash.Query.filter(id == ^scene.sequence_piece_id and story_id == ^story.id)
+        if script_view do
+          Storybox.Stories.TreatmentView
+          |> Ash.Query.filter(id == ^script_view.treatment_view_id and story_id == ^story.id)
           |> Ash.read!(authorize?: false)
           |> List.first()
         end
 
-      if scene && owner do
-        case Storybox.Stories.ScenePiece
+      if script_view && owner do
+        case Storybox.Stories.ScriptView
              |> Ash.ActionInput.for_action(:create_version, %{
                content: content,
-               scene_piece_id: scene.id
+               script_view_id: script_view.id
              })
              |> Ash.run_action(authorize?: false) do
-          {:ok, version} ->
-            conn |> put_status(201) |> json(format_version(version))
+          {:ok, piece} ->
+            conn |> put_status(201) |> json(format_version(piece))
 
           {:error, _} ->
             conn |> put_status(503) |> json(%{error: "storage error"})
@@ -617,52 +617,52 @@ defmodule StoryboxWeb.ApiController do
   def upstream_changes(conn, _params) do
     story = conn.assigns.current_story
 
-    seq_piece_ids =
-      Storybox.Stories.SequencePiece
+    treatment_view_ids =
+      Storybox.Stories.TreatmentView
       |> Ash.Query.filter(story_id == ^story.id)
       |> Ash.read!(authorize?: false)
       |> Enum.map(& &1.id)
 
-    scene_piece_ids =
-      case seq_piece_ids do
+    script_view_ids =
+      case treatment_view_ids do
         [] ->
           []
 
         ids ->
-          Storybox.Stories.ScenePiece
-          |> Ash.Query.filter(sequence_piece_id in ^ids)
+          Storybox.Stories.ScriptView
+          |> Ash.Query.filter(treatment_view_id in ^ids)
           |> Ash.read!(authorize?: false)
           |> Enum.map(& &1.id)
       end
 
-    seq_version_ids =
-      case seq_piece_ids do
+    treatment_piece_ids =
+      case treatment_view_ids do
         [] ->
           []
 
         ids ->
-          Storybox.Stories.SequenceVersion
-          |> Ash.Query.filter(sequence_piece_id in ^ids)
+          Storybox.Stories.TreatmentPiece
+          |> Ash.Query.filter(treatment_view_id in ^ids)
           |> Ash.read!(authorize?: false)
           |> Enum.map(& &1.id)
       end
 
-    scene_version_ids =
-      case scene_piece_ids do
+    script_piece_ids =
+      case script_view_ids do
         [] ->
           []
 
         ids ->
-          Storybox.Stories.SceneVersion
-          |> Ash.Query.filter(scene_piece_id in ^ids)
+          Storybox.Stories.ScriptPiece
+          |> Ash.Query.filter(script_view_id in ^ids)
           |> Ash.read!(authorize?: false)
           |> Enum.map(& &1.id)
       end
 
-    all_version_ids = seq_version_ids ++ scene_version_ids
+    all_piece_ids = treatment_piece_ids ++ script_piece_ids
 
     changes =
-      case all_version_ids do
+      case all_piece_ids do
         [] ->
           []
 

--- a/lib/storybox_web/live/scene_compare_live.ex
+++ b/lib/storybox_web/live/scene_compare_live.ex
@@ -23,46 +23,48 @@ defmodule StoryboxWeb.SceneCompareLive do
              |> redirect(to: ~p"/")}
 
           story ->
-            scene =
-              Storybox.Stories.ScenePiece
+            script_view =
+              Storybox.Stories.ScriptView
               |> Ash.Query.filter(id == ^scene_id)
               |> Ash.read_one!(authorize?: false)
 
-            case scene do
+            case script_view do
               nil ->
                 {:ok,
                  socket
                  |> put_flash(:error, "Scene not found.")
                  |> redirect(to: ~p"/")}
 
-              scene ->
-                sequence =
-                  Storybox.Stories.SequencePiece
-                  |> Ash.Query.filter(id == ^scene.sequence_piece_id and story_id == ^story.id)
+              script_view ->
+                treatment_view =
+                  Storybox.Stories.TreatmentView
+                  |> Ash.Query.filter(
+                    id == ^script_view.treatment_view_id and story_id == ^story.id
+                  )
                   |> Ash.read_one!(authorize?: false)
 
-                case sequence do
+                case treatment_view do
                   nil ->
                     {:ok,
                      socket
                      |> put_flash(:error, "Scene not found.")
                      |> redirect(to: ~p"/")}
 
-                  sequence ->
-                    versions = load_versions(scene)
+                  treatment_view ->
+                    pieces = load_pieces(script_view)
 
                     {:ok,
                      socket
                      |> assign(:story, story)
-                     |> assign(:sequence, sequence)
-                     |> assign(:scene, scene)
-                     |> assign(:versions, versions)
+                     |> assign(:sequence, treatment_view)
+                     |> assign(:scene, script_view)
+                     |> assign(:versions, pieces)
                      |> assign(:left_version, nil)
                      |> assign(:right_version, nil)
                      |> assign(:left_content, nil)
                      |> assign(:right_content, nil)
                      |> assign(:weight_forms, MapSet.new())
-                     |> assign(:page_title, "#{story.title} — #{scene.title} Compare")}
+                     |> assign(:page_title, "#{story.title} — #{script_view.title} Compare")}
                 end
             end
         end
@@ -71,18 +73,18 @@ defmodule StoryboxWeb.SceneCompareLive do
 
   @impl true
   def handle_params(params, _uri, socket) do
-    versions = socket.assigns.versions
+    pieces = socket.assigns.versions
 
     right_version =
       case parse_version_number(params["right"]) do
-        nil -> default_right(versions)
-        n -> find_version(versions, n) || default_right(versions)
+        nil -> default_right(pieces)
+        n -> find_version(pieces, n) || default_right(pieces)
       end
 
     left_version =
       case parse_version_number(params["left"]) do
-        nil -> default_left(versions)
-        n -> find_version(versions, n) || default_left(versions)
+        nil -> default_left(pieces)
+        n -> find_version(pieces, n) || default_left(pieces)
       end
 
     {:noreply,
@@ -99,27 +101,27 @@ defmodule StoryboxWeb.SceneCompareLive do
     |> Ash.Changeset.for_update(:approve_version, %{version_id: version_id})
     |> Ash.update!(authorize?: false)
 
-    scene =
-      Storybox.Stories.ScenePiece
+    script_view =
+      Storybox.Stories.ScriptView
       |> Ash.Query.filter(id == ^socket.assigns.scene.id)
       |> Ash.read_one!(authorize?: false)
 
-    versions = load_versions(scene)
+    pieces = load_pieces(script_view)
 
     left_version =
       if socket.assigns.left_version,
-        do: find_version(versions, socket.assigns.left_version.version_number),
+        do: find_version(pieces, socket.assigns.left_version.version_number),
         else: nil
 
     right_version =
       if socket.assigns.right_version,
-        do: find_version(versions, socket.assigns.right_version.version_number),
+        do: find_version(pieces, socket.assigns.right_version.version_number),
         else: nil
 
     {:noreply,
      socket
-     |> assign(:scene, scene)
-     |> assign(:versions, versions)
+     |> assign(:scene, script_view)
+     |> assign(:versions, pieces)
      |> assign(:left_version, left_version)
      |> assign(:right_version, right_version)}
   end
@@ -140,31 +142,31 @@ defmodule StoryboxWeb.SceneCompareLive do
   def handle_event("set_weights", %{"version_id" => version_id, "weights" => raw_weights}, socket) do
     weights = parse_weights(raw_weights)
 
-    version =
-      Storybox.Stories.SceneVersion
+    piece =
+      Storybox.Stories.ScriptPiece
       |> Ash.Query.filter(id == ^version_id)
       |> Ash.read_one!(authorize?: false)
 
-    version
+    piece
     |> Ash.Changeset.for_update(:set_weights, %{weights: weights})
     |> Ash.update!(authorize?: false)
 
-    versions = load_versions(socket.assigns.scene)
+    pieces = load_pieces(socket.assigns.scene)
     weight_forms = MapSet.delete(socket.assigns.weight_forms, version_id)
 
     left_version =
       if socket.assigns.left_version,
-        do: find_version(versions, socket.assigns.left_version.version_number),
+        do: find_version(pieces, socket.assigns.left_version.version_number),
         else: nil
 
     right_version =
       if socket.assigns.right_version,
-        do: find_version(versions, socket.assigns.right_version.version_number),
+        do: find_version(pieces, socket.assigns.right_version.version_number),
         else: nil
 
     {:noreply,
      socket
-     |> assign(:versions, versions)
+     |> assign(:versions, pieces)
      |> assign(:left_version, left_version)
      |> assign(:right_version, right_version)
      |> assign(:weight_forms, weight_forms)}
@@ -429,15 +431,15 @@ defmodule StoryboxWeb.SceneCompareLive do
     """
   end
 
-  defp load_versions(scene) do
-    Storybox.Stories.SceneVersion
-    |> Ash.Query.filter(scene_piece_id == ^scene.id)
+  defp load_pieces(script_view) do
+    Storybox.Stories.ScriptPiece
+    |> Ash.Query.filter(script_view_id == ^script_view.id)
     |> Ash.Query.sort(version_number: :desc)
     |> Ash.read!(authorize?: false)
   end
 
-  defp find_version(_versions, nil), do: nil
-  defp find_version(versions, number), do: Enum.find(versions, &(&1.version_number == number))
+  defp find_version(_pieces, nil), do: nil
+  defp find_version(pieces, number), do: Enum.find(pieces, &(&1.version_number == number))
 
   defp default_right([]), do: nil
   defp default_right([latest | _]), do: latest
@@ -448,8 +450,8 @@ defmodule StoryboxWeb.SceneCompareLive do
 
   defp fetch_content(nil), do: nil
 
-  defp fetch_content(version) do
-    case Storybox.Storage.get_content(version.content_uri) do
+  defp fetch_content(piece) do
+    case Storybox.Storage.get_content(piece.content_uri) do
       {:ok, text} -> text
       _ -> nil
     end

--- a/lib/storybox_web/live/script_live.ex
+++ b/lib/storybox_web/live/script_live.ex
@@ -23,28 +23,28 @@ defmodule StoryboxWeb.ScriptLive do
              |> redirect(to: ~p"/")}
 
           story ->
-            sequence =
-              Storybox.Stories.SequencePiece
+            treatment_view =
+              Storybox.Stories.TreatmentView
               |> Ash.Query.filter(id == ^sequence_id and story_id == ^story.id)
               |> Ash.read_one!(authorize?: false)
 
-            case sequence do
+            case treatment_view do
               nil ->
                 {:ok,
                  socket
                  |> put_flash(:error, "Sequence not found.")
                  |> redirect(to: ~p"/stories/#{story.id}/treatment")}
 
-              sequence ->
+              treatment_view ->
                 {:ok,
                  socket
                  |> assign(:story, story)
-                 |> assign(:sequence, sequence)
-                 |> assign(:scenes, load_scenes(sequence))
+                 |> assign(:sequence, treatment_view)
+                 |> assign(:scenes, load_scenes(treatment_view))
                  |> assign(:mode, :latest)
                  |> assign(:content, %{})
                  |> assign(:weight_forms, MapSet.new())
-                 |> assign(:page_title, "#{story.title} — #{sequence.title} Script")}
+                 |> assign(:page_title, "#{story.title} — #{treatment_view.title} Script")}
             end
         end
     end
@@ -81,12 +81,12 @@ defmodule StoryboxWeb.ScriptLive do
   def handle_event("set_weights", %{"version_id" => version_id, "weights" => raw_weights}, socket) do
     weights = parse_weights(raw_weights)
 
-    version =
-      Storybox.Stories.SceneVersion
+    piece =
+      Storybox.Stories.ScriptPiece
       |> Ash.Query.filter(id == ^version_id)
       |> Ash.read_one!(authorize?: false)
 
-    version
+    piece
     |> Ash.Changeset.for_update(:set_weights, %{weights: weights})
     |> Ash.update!(authorize?: false)
 
@@ -106,12 +106,12 @@ defmodule StoryboxWeb.ScriptLive do
         %{"piece-id" => piece_id, "version-id" => version_id},
         socket
       ) do
-    piece =
-      Storybox.Stories.ScenePiece
+    script_view =
+      Storybox.Stories.ScriptView
       |> Ash.Query.filter(id == ^piece_id)
       |> Ash.read_one!(authorize?: false)
 
-    piece
+    script_view
     |> Ash.Changeset.for_update(:approve_version, %{version_id: version_id})
     |> Ash.update!(authorize?: false)
 
@@ -159,16 +159,18 @@ defmodule StoryboxWeb.ScriptLive do
           <p class="text-base-content/60 text-sm">No scenes yet.</p>
         <% else %>
           <div class="space-y-4">
-            <%= for {piece, versions} <- @scenes do %>
-              <% visible = visible_versions(piece, versions, @mode) %>
+            <%= for {script_view, pieces} <- @scenes do %>
+              <% visible = visible_pieces(script_view, pieces, @mode) %>
               <div class="card bg-base-200 shadow-sm">
                 <div class="card-body py-4 space-y-3">
                   <div class="flex items-center gap-2">
-                    <span class="badge badge-outline badge-sm font-mono">#{piece.position}</span>
-                    <h3 class="font-semibold">{piece.title}</h3>
-                    <%= if length(versions) > 1 do %>
+                    <span class="badge badge-outline badge-sm font-mono">
+                      #{script_view.position}
+                    </span>
+                    <h3 class="font-semibold">{script_view.title}</h3>
+                    <%= if length(pieces) > 1 do %>
                       <.link
-                        navigate={~p"/stories/#{@story.id}/scenes/#{piece.id}/compare"}
+                        navigate={~p"/stories/#{@story.id}/scenes/#{script_view.id}/compare"}
                         class="ml-auto text-sm text-base-content/60 hover:text-base-content"
                       >
                         Compare →
@@ -185,28 +187,28 @@ defmodule StoryboxWeb.ScriptLive do
                       <% end %>
                     </p>
                   <% else %>
-                    <%= for version <- visible do %>
-                      <% rs = review_status(version.weights, @story.through_lines) %>
+                    <%= for piece <- visible do %>
+                      <% rs = review_status(piece.weights, @story.through_lines) %>
                       <div class={[
                         "rounded p-2 text-sm",
-                        if(version.id == piece.approved_version_id, do: "bg-base-300", else: ""),
+                        if(piece.id == script_view.approved_version_id, do: "bg-base-300", else: ""),
                         if(rs == :unreviewed, do: "ring-2 ring-warning", else: "")
                       ]}>
                         <div class="flex flex-wrap items-center gap-2">
-                          <span class="font-mono font-semibold">v{version.version_number}</span>
+                          <span class="font-mono font-semibold">v{piece.version_number}</span>
 
-                          <%= if version.id == piece.approved_version_id do %>
+                          <%= if piece.id == script_view.approved_version_id do %>
                             <span class="badge badge-success badge-sm">Approved</span>
                           <% end %>
 
                           <span class={[
                             "badge badge-sm",
-                            if(version.upstream_status == :stale,
+                            if(piece.upstream_status == :stale,
                               do: "badge-warning",
                               else: "badge-ghost"
                             )
                           ]}>
-                            {version.upstream_status}
+                            {piece.upstream_status}
                           </span>
 
                           <span class={[
@@ -224,17 +226,17 @@ defmodule StoryboxWeb.ScriptLive do
                             <button
                               class="btn btn-xs btn-ghost"
                               phx-click="toggle_weight_form"
-                              phx-value-version-id={version.id}
+                              phx-value-version-id={piece.id}
                             >
                               Review
                             </button>
 
-                            <%= if version.id != piece.approved_version_id do %>
+                            <%= if piece.id != script_view.approved_version_id do %>
                               <button
                                 class="btn btn-xs btn-outline"
                                 phx-click="approve_version"
-                                phx-value-piece-id={piece.id}
-                                phx-value-version-id={version.id}
+                                phx-value-piece-id={script_view.id}
+                                phx-value-version-id={piece.id}
                               >
                                 Approve
                               </button>
@@ -242,12 +244,12 @@ defmodule StoryboxWeb.ScriptLive do
                           </div>
                         </div>
 
-                        <%= if MapSet.member?(@weight_forms, version.id) do %>
-                          <.weight_form version={version} through_lines={@story.through_lines} />
+                        <%= if MapSet.member?(@weight_forms, piece.id) do %>
+                          <.weight_form version={piece} through_lines={@story.through_lines} />
                         <% end %>
 
-                        <%= if Map.get(@content, version.id) do %>
-                          <pre class="mt-2 text-sm whitespace-pre-wrap font-mono bg-base-300 rounded p-3 leading-relaxed overflow-x-auto">{Map.get(@content, version.id)}</pre>
+                        <%= if Map.get(@content, piece.id) do %>
+                          <pre class="mt-2 text-sm whitespace-pre-wrap font-mono bg-base-300 rounded p-3 leading-relaxed overflow-x-auto">{Map.get(@content, piece.id)}</pre>
                         <% end %>
                       </div>
                     <% end %>
@@ -299,57 +301,57 @@ defmodule StoryboxWeb.ScriptLive do
     """
   end
 
-  defp load_scenes(sequence) do
-    pieces =
-      Storybox.Stories.ScenePiece
-      |> Ash.Query.filter(sequence_piece_id == ^sequence.id)
+  defp load_scenes(treatment_view) do
+    script_views =
+      Storybox.Stories.ScriptView
+      |> Ash.Query.filter(treatment_view_id == ^treatment_view.id)
       |> Ash.Query.sort(position: :asc)
       |> Ash.read!(authorize?: false)
 
-    piece_ids = Enum.map(pieces, & &1.id)
+    view_ids = Enum.map(script_views, & &1.id)
 
-    versions_by_piece =
-      case piece_ids do
+    pieces_by_view =
+      case view_ids do
         [] ->
           %{}
 
         ids ->
-          Storybox.Stories.SceneVersion
-          |> Ash.Query.filter(scene_piece_id in ^ids)
+          Storybox.Stories.ScriptPiece
+          |> Ash.Query.filter(script_view_id in ^ids)
           |> Ash.Query.sort(version_number: :desc)
           |> Ash.read!(authorize?: false)
-          |> Enum.group_by(& &1.scene_piece_id)
+          |> Enum.group_by(& &1.script_view_id)
       end
 
-    Enum.map(pieces, fn piece ->
-      {piece, Map.get(versions_by_piece, piece.id, [])}
+    Enum.map(script_views, fn sv ->
+      {sv, Map.get(pieces_by_view, sv.id, [])}
     end)
   end
 
   defp fetch_visible_content(scenes, mode) do
     scenes
-    |> Enum.flat_map(fn {piece, versions} -> visible_versions(piece, versions, mode) end)
-    |> Enum.map(fn version ->
+    |> Enum.flat_map(fn {script_view, pieces} -> visible_pieces(script_view, pieces, mode) end)
+    |> Enum.map(fn piece ->
       content =
-        case Storybox.Storage.get_content(version.content_uri) do
+        case Storybox.Storage.get_content(piece.content_uri) do
           {:ok, text} -> text
           _ -> nil
         end
 
-      {version.id, content}
+      {piece.id, content}
     end)
     |> Map.new()
   end
 
-  defp visible_versions(_piece, versions, :latest) do
-    case versions do
+  defp visible_pieces(_script_view, pieces, :latest) do
+    case pieces do
       [] -> []
       [latest | _] -> [latest]
     end
   end
 
-  defp visible_versions(piece, versions, :approved) do
-    Enum.filter(versions, &(&1.id == piece.approved_version_id))
+  defp visible_pieces(script_view, pieces, :approved) do
+    Enum.filter(pieces, &(&1.id == script_view.approved_version_id))
   end
 
   defp review_status(weights, through_lines) do

--- a/lib/storybox_web/live/story_overview_live.ex
+++ b/lib/storybox_web/live/story_overview_live.ex
@@ -33,14 +33,14 @@ defmodule StoryboxWeb.StoryOverviewLive do
               |> Ash.Query.filter(story_id == ^story.id)
               |> Ash.read_one!(authorize?: false)
 
-            synopsis_versions =
-              Storybox.Stories.SynopsisVersion
+            synopsis_views =
+              Storybox.Stories.SynopsisView
               |> Ash.Query.filter(story_id == ^story.id)
               |> Ash.Query.sort(version_number: :desc)
               |> Ash.read!(authorize?: false)
 
             latest_synopsis_content =
-              case synopsis_versions do
+              case synopsis_views do
                 [latest | _] ->
                   case Storybox.Storage.get_content(latest.content_uri) do
                     {:ok, content} -> content
@@ -56,7 +56,7 @@ defmodule StoryboxWeb.StoryOverviewLive do
                story: story,
                characters: characters,
                world: world,
-               synopsis_versions: synopsis_versions,
+               synopsis_views: synopsis_views,
                latest_synopsis_content: latest_synopsis_content,
                page_title: story.title
              )}
@@ -176,7 +176,7 @@ defmodule StoryboxWeb.StoryOverviewLive do
 
         <section class="space-y-3">
           <h2 class="text-xl font-semibold">Synopsis</h2>
-          <%= if @synopsis_versions == [] do %>
+          <%= if @synopsis_views == [] do %>
             <p class="text-base-content/60 text-sm">No synopsis versions yet.</p>
           <% else %>
             <%= if @latest_synopsis_content do %>
@@ -187,12 +187,12 @@ defmodule StoryboxWeb.StoryOverviewLive do
               </div>
             <% end %>
             <ul class="space-y-2">
-              <%= for {version, index} <- Enum.with_index(@synopsis_versions) do %>
+              <%= for {view, index} <- Enum.with_index(@synopsis_views) do %>
                 <li class="card bg-base-100 shadow-sm">
                   <div class="card-body py-3 flex flex-row items-center gap-3">
-                    <span class="font-mono font-semibold">v{version.version_number}</span>
+                    <span class="font-mono font-semibold">v{view.version_number}</span>
                     <span class="text-base-content/60 text-sm">
-                      {Calendar.strftime(version.inserted_at, "%B %-d, %Y")}
+                      {Calendar.strftime(view.inserted_at, "%B %-d, %Y")}
                     </span>
                     <%= if index == 0 do %>
                       <span class="badge badge-success badge-sm">Latest</span>

--- a/lib/storybox_web/live/treatment_live.ex
+++ b/lib/storybox_web/live/treatment_live.ex
@@ -52,12 +52,12 @@ defmodule StoryboxWeb.TreatmentLive do
   def handle_event("set_weights", %{"version_id" => version_id, "weights" => raw_weights}, socket) do
     weights = parse_weights(raw_weights)
 
-    version =
-      Storybox.Stories.SequenceVersion
+    piece =
+      Storybox.Stories.TreatmentPiece
       |> Ash.Query.filter(id == ^version_id)
       |> Ash.read_one!(authorize?: false)
 
-    version
+    piece
     |> Ash.Changeset.for_update(:set_weights, %{weights: weights})
     |> Ash.update!(authorize?: false)
 
@@ -77,12 +77,12 @@ defmodule StoryboxWeb.TreatmentLive do
         %{"piece-id" => piece_id, "version-id" => version_id},
         socket
       ) do
-    piece =
-      Storybox.Stories.SequencePiece
+    view =
+      Storybox.Stories.TreatmentView
       |> Ash.Query.filter(id == ^piece_id)
       |> Ash.read_one!(authorize?: false)
 
-    piece
+    view
     |> Ash.Changeset.for_update(:approve_version, %{version_id: version_id})
     |> Ash.update!(authorize?: false)
 
@@ -110,62 +110,62 @@ defmodule StoryboxWeb.TreatmentLive do
         <%= if @acts == [] do %>
           <p class="text-base-content/60 text-sm">No sequences yet.</p>
         <% else %>
-          <%= for {act_label, pieces_with_versions} <- @acts do %>
+          <%= for {act_label, views_with_pieces} <- @acts do %>
             <section class="space-y-3">
               <h2 class="text-lg font-semibold text-base-content/80 border-b border-base-300 pb-1">
                 {act_label || "No act"}
               </h2>
               <div class="space-y-3">
-                <%= for {piece, versions} <- pieces_with_versions do %>
+                <%= for {view, pieces} <- views_with_pieces do %>
                   <div class="card bg-base-200 shadow-sm">
                     <div class="card-body py-4 space-y-3">
                       <div class="flex items-center gap-2">
-                        <span class="badge badge-outline badge-sm font-mono">#{piece.position}</span>
-                        <h3 class="font-semibold">{piece.title}</h3>
+                        <span class="badge badge-outline badge-sm font-mono">#{view.position}</span>
+                        <h3 class="font-semibold">{view.title}</h3>
                         <.link
-                          navigate={~p"/stories/#{@story.id}/sequences/#{piece.id}/script"}
+                          navigate={~p"/stories/#{@story.id}/sequences/#{view.id}/script"}
                           class="ml-auto text-sm text-base-content/60 hover:text-base-content"
                         >
                           Script →
                         </.link>
                       </div>
 
-                      <% primary = primary_version(piece, versions) %>
+                      <% primary = primary_piece(view, pieces) %>
                       <%= if primary && Map.get(@content, primary.id) do %>
                         <p class="text-sm text-base-content/80 whitespace-pre-wrap">
                           {Map.get(@content, primary.id)}
                         </p>
                       <% end %>
 
-                      <%= if versions == [] do %>
+                      <%= if pieces == [] do %>
                         <p class="text-base-content/50 text-sm">No versions yet.</p>
                       <% else %>
                         <div class="space-y-2">
-                          <%= for version <- versions do %>
-                            <% rs = review_status(version.weights, @story.through_lines) %>
+                          <%= for piece <- pieces do %>
+                            <% rs = review_status(piece.weights, @story.through_lines) %>
                             <div class={[
                               "rounded p-2 text-sm",
-                              if(version.id == piece.approved_version_id,
+                              if(piece.id == view.approved_version_id,
                                 do: "bg-base-300",
                                 else: ""
                               ),
                               if(rs == :unreviewed, do: "ring-2 ring-warning", else: "")
                             ]}>
                               <div class="flex flex-wrap items-center gap-2">
-                                <span class="font-mono font-semibold">v{version.version_number}</span>
+                                <span class="font-mono font-semibold">v{piece.version_number}</span>
 
-                                <%= if version.id == piece.approved_version_id do %>
+                                <%= if piece.id == view.approved_version_id do %>
                                   <span class="badge badge-success badge-sm">Approved</span>
                                 <% end %>
 
                                 <span class={[
                                   "badge badge-sm",
-                                  if(version.upstream_status == :stale,
+                                  if(piece.upstream_status == :stale,
                                     do: "badge-warning",
                                     else: "badge-ghost"
                                   )
                                 ]}>
-                                  {version.upstream_status}
+                                  {piece.upstream_status}
                                 </span>
 
                                 <span class={[
@@ -183,17 +183,17 @@ defmodule StoryboxWeb.TreatmentLive do
                                   <button
                                     class="btn btn-xs btn-ghost"
                                     phx-click="toggle_weight_form"
-                                    phx-value-version-id={version.id}
+                                    phx-value-version-id={piece.id}
                                   >
                                     Review
                                   </button>
 
-                                  <%= if version.id != piece.approved_version_id do %>
+                                  <%= if piece.id != view.approved_version_id do %>
                                     <button
                                       class="btn btn-xs btn-outline"
                                       phx-click="approve_version"
-                                      phx-value-piece-id={piece.id}
-                                      phx-value-version-id={version.id}
+                                      phx-value-piece-id={view.id}
+                                      phx-value-version-id={piece.id}
                                     >
                                       Approve
                                     </button>
@@ -201,9 +201,9 @@ defmodule StoryboxWeb.TreatmentLive do
                                 </div>
                               </div>
 
-                              <%= if MapSet.member?(@weight_forms, version.id) do %>
+                              <%= if MapSet.member?(@weight_forms, piece.id) do %>
                                 <.weight_form
-                                  version={version}
+                                  version={piece}
                                   through_lines={@story.through_lines}
                                 />
                               <% end %>
@@ -261,64 +261,63 @@ defmodule StoryboxWeb.TreatmentLive do
   end
 
   defp load_acts(story) do
-    pieces =
-      Storybox.Stories.SequencePiece
+    views =
+      Storybox.Stories.TreatmentView
       |> Ash.Query.filter(story_id == ^story.id)
       |> Ash.Query.sort(position: :asc)
       |> Ash.read!(authorize?: false)
 
-    piece_ids = Enum.map(pieces, & &1.id)
+    view_ids = Enum.map(views, & &1.id)
 
-    versions_by_piece =
-      case piece_ids do
+    pieces_by_view =
+      case view_ids do
         [] ->
           %{}
 
         ids ->
-          Storybox.Stories.SequenceVersion
-          |> Ash.Query.filter(sequence_piece_id in ^ids)
+          Storybox.Stories.TreatmentPiece
+          |> Ash.Query.filter(treatment_view_id in ^ids)
           |> Ash.Query.sort(version_number: :desc)
           |> Ash.read!(authorize?: false)
-          |> Enum.group_by(& &1.sequence_piece_id)
+          |> Enum.group_by(& &1.treatment_view_id)
       end
 
-    pieces
+    views
     |> Enum.group_by(& &1.act)
-    |> Enum.sort_by(fn {_act, act_pieces} ->
-      Enum.min_by(act_pieces, & &1.position).position
+    |> Enum.sort_by(fn {_act, act_views} ->
+      Enum.min_by(act_views, & &1.position).position
     end)
-    |> Enum.map(fn {act, act_pieces} ->
+    |> Enum.map(fn {act, act_views} ->
       {act,
-       Enum.map(act_pieces, fn piece ->
-         {piece, Map.get(versions_by_piece, piece.id, [])}
+       Enum.map(act_views, fn view ->
+         {view, Map.get(pieces_by_view, view.id, [])}
        end)}
     end)
   end
 
-  # Returns the approved version if set, otherwise the latest.
-  defp primary_version(piece, versions) do
-    case Enum.find(versions, &(&1.id == piece.approved_version_id)) do
-      nil -> List.first(versions)
+  defp primary_piece(view, pieces) do
+    case Enum.find(pieces, &(&1.id == view.approved_version_id)) do
+      nil -> List.first(pieces)
       approved -> approved
     end
   end
 
   defp fetch_primary_content(acts) do
     acts
-    |> Enum.flat_map(fn {_act, pieces_with_versions} ->
-      Enum.map(pieces_with_versions, fn {piece, versions} ->
-        primary_version(piece, versions)
+    |> Enum.flat_map(fn {_act, views_with_pieces} ->
+      Enum.map(views_with_pieces, fn {view, pieces} ->
+        primary_piece(view, pieces)
       end)
     end)
     |> Enum.reject(&is_nil/1)
-    |> Enum.map(fn version ->
+    |> Enum.map(fn piece ->
       content =
-        case Storybox.Storage.get_content(version.content_uri) do
+        case Storybox.Storage.get_content(piece.content_uri) do
           {:ok, text} -> text
           _ -> nil
         end
 
-      {version.id, content}
+      {piece.id, content}
     end)
     |> Map.new()
   end

--- a/priv/repo/migrations/20260426120000_rename_piece_version_vocabulary.exs
+++ b/priv/repo/migrations/20260426120000_rename_piece_version_vocabulary.exs
@@ -1,0 +1,15 @@
+defmodule Storybox.Repo.Migrations.RenamePieceVersionVocabulary do
+  use Ecto.Migration
+
+  def change do
+    rename table(:scene_pieces), to: table(:script_views)
+    rename table(:scene_versions), to: table(:script_pieces)
+    rename table(:sequence_pieces), to: table(:treatment_views)
+    rename table(:sequence_versions), to: table(:treatment_pieces)
+    rename table(:synopsis_versions), to: table(:synopsis_views)
+
+    rename table(:script_views), :sequence_piece_id, to: :treatment_view_id
+    rename table(:script_pieces), :scene_piece_id, to: :script_view_id
+    rename table(:treatment_pieces), :sequence_piece_id, to: :treatment_view_id
+  end
+end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -5,16 +5,11 @@ require Ash.Query
 #
 # Test account — email: dev@storybox.test / password: Password1!
 #
-# NOTE: This file uses pre-M5 vocabulary (SequencePiece, SequenceVersion,
-# ScenePiece, SceneVersion, SynopsisVersion). Issue #74 will rename these to
-# TreatmentView, TreatmentPiece, ScriptView, ScriptPiece, SynopsisView.
-# Update module references here when #74 lands.
-#
 # Reference story: Little Witch (pandaChest/projects/story/LittleWitch/)
 # The folder structure there mirrors the model:
-#   synopsis-{seq}-v{N}.fountain  → SynopsisVersion segments (post #71 redesign)
-#   {seq}-v{N}.fountain           → SequenceVersion content
-#   scenes/{slug}/script-v{N}.fountain → SceneVersion content
+#   synopsis-{seq}-v{N}.fountain  → SynopsisView segments (post #71 redesign)
+#   {seq}-v{N}.fountain           → TreatmentPiece content
+#   scenes/{slug}/script-v{N}.fountain → ScriptPiece content
 # ---------------------------------------------------------------------------
 
 dev_user =
@@ -47,7 +42,8 @@ stories = [
     title: "Little Witch",
     logline:
       "A girl trained only in healing opens the Book of Demons to find out if she is the Chosen One — and sets in motion a chain of manipulation that will burn the capital and strip away every illusion she has ever held.",
-    controlling_idea: "True power is earned through hard work. There are no shortcuts. There is no gift.",
+    controlling_idea:
+      "True power is earned through hard work. There are no shortcuts. There is no gift.",
     through_lines: ["preference", "theme"]
   },
   %{
@@ -126,7 +122,8 @@ if little_witch = all_stories["Little Witch"] do
          %{
            essence:
              "A lonely orphan with half-finished training who mistakes the feeling of being chosen for the fact of it.",
-           voice: "Genuine, service-oriented — her good impulses are what make her easy to weaponise.",
+           voice:
+             "Genuine, service-oriented — her good impulses are what make her easy to weaponise.",
            contradictions: ["capable yet unfinished", "grief-driven yet clear-eyed at the end"]
          }},
         {"Kestrel",
@@ -141,7 +138,10 @@ if little_witch = all_stories["Little Witch"] do
            essence:
              "Fleur's guardian. Never seen on screen after the prologue. The moral centre of the story in absentia.",
            voice: "Quiet. Unglamorous. Her example is the lesson, not her words.",
-           contradictions: ["careful yet afraid", "protective yet the source of the vulnerability"]
+           contradictions: [
+             "careful yet afraid",
+             "protective yet the source of the vulnerability"
+           ]
          }},
         {"The Flame Demon",
          %{
@@ -154,13 +154,17 @@ if little_witch = all_stories["Little Witch"] do
          %{
            essence:
              "An expansionist ruler who genuinely believes the prophecy. This makes him more dangerous than a cynic.",
-           voice: "Rational given his premise. He is collecting what he believes the world promised him.",
+           voice:
+             "Rational given his premise. He is collecting what he believes the world promised him.",
            contradictions: ["sincere yet monstrous", "building peace yet burning people"]
          }}
       ],
       name not in existing_characters do
     Storybox.Stories.Character
-    |> Ash.Changeset.for_create(:create, Map.merge(attrs, %{name: name, story_id: little_witch.id}))
+    |> Ash.Changeset.for_create(
+      :create,
+      Map.merge(attrs, %{name: name, story_id: little_witch.id})
+    )
     |> Ash.create!(authorize?: false)
 
     IO.puts("  Created character: #{name}")
@@ -172,13 +176,13 @@ if little_witch = all_stories["Little Witch"] do
   # The per-segment content lives in pandaChest as synopsis-{seq}-v1.fountain.
 
   existing_synopsis_count =
-    Storybox.Stories.SynopsisVersion
+    Storybox.Stories.SynopsisView
     |> Ash.Query.filter(story_id == ^little_witch.id)
     |> Ash.read!(authorize?: false)
     |> length()
 
   if existing_synopsis_count == 0 do
-    Ash.ActionInput.for_action(Storybox.Stories.SynopsisVersion, :create_version, %{
+    Ash.ActionInput.for_action(Storybox.Stories.SynopsisView, :create_version, %{
       story_id: little_witch.id,
       content: """
       Fleur is a young orphan raised in isolation by Silas, a healer and former member of the Order of Flame. Silas trained Fleur only in healing — never the full, dangerous discipline of demonkin. When the Alderman's men find Silas, she presses the chest key into Fleur's hands and walks out to meet them. Fleur is left alone.
@@ -198,52 +202,58 @@ if little_witch = all_stories["Little Witch"] do
   # -- Sequence pieces (TreatmentViews) + versions (TreatmentPieces) ---------
 
   existing_sequence_count =
-    Storybox.Stories.SequencePiece
+    Storybox.Stories.TreatmentView
     |> Ash.Query.filter(story_id == ^little_witch.id)
     |> Ash.read!(authorize?: false)
     |> length()
 
   if existing_sequence_count == 0 do
     sequences = [
-      {1, "Prologue — The Forest Road", "Prologue", """
-      Years before the story begins. A forest road at dusk. The Alderman's soldiers hunt Order remnants. Silas — a former Order member living in hiding — intervenes to protect a family and reveals who she was before. She acts with full training, borrows fire from the Book once, and registers the cost immediately. The family is dead. A small girl is left alone in the road. Silas takes her home. The question of what she saw in that moment sits in the prologue like an ember. It will not be answered here.
-      """},
-      {2, "The Cottage", "Act I", """
-      The cottage has become two people's life. Silas has taught Fleur the identification of herbs, the treatment of wounds, the patience of sitting with the sick. Fleur is capable — and restless in a way she can't name. She has heard the Chosen One whispers her whole life. Silas has redirected, gently, consistently, for years.
+      {1, "Prologue — The Forest Road", "Prologue",
+       """
+       Years before the story begins. A forest road at dusk. The Alderman's soldiers hunt Order remnants. Silas — a former Order member living in hiding — intervenes to protect a family and reveals who she was before. She acts with full training, borrows fire from the Book once, and registers the cost immediately. The family is dead. A small girl is left alone in the road. Silas takes her home. The question of what she saw in that moment sits in the prologue like an ember. It will not be answered here.
+       """},
+      {2, "The Cottage", "Act I",
+       """
+       The cottage has become two people's life. Silas has taught Fleur the identification of herbs, the treatment of wounds, the patience of sitting with the sick. Fleur is capable — and restless in a way she can't name. She has heard the Chosen One whispers her whole life. Silas has redirected, gently, consistently, for years.
 
-      The Alderman's soldiers arrive. Silas is calm in the way of someone who has been half-expecting this for a decade. She presses the chest key into Fleur's hands: "Hide. Do good. Never touch the Book." She holds Fleur's face — and then says the thing she has been unable to say: "You are what I should have been."
+       The Alderman's soldiers arrive. Silas is calm in the way of someone who has been half-expecting this for a decade. She presses the chest key into Fleur's hands: "Hide. Do good. Never touch the Book." She holds Fleur's face — and then says the thing she has been unable to say: "You are what I should have been."
 
-      She walks out to meet the soldiers. Fleur is left alone in the empty cottage with a key in her hand.
-      """},
-      {3, "The Summoning", "Act I", """
-      Fleur sits with the key for a long time. She turns over Silas's last words and finds a crack in them. She opens the chest. She takes out the Book. The fire stirs before she says the words.
+       She walks out to meet the soldiers. Fleur is left alone in the empty cottage with a key in her hand.
+       """},
+      {3, "The Summoning", "Act I",
+       """
+       Fleur sits with the key for a long time. She turns over Silas's last words and finds a crack in them. She opens the chest. She takes out the Book. The fire stirs before she says the words.
 
-      She attempts the summoning. It goes catastrophically wrong. The fire takes the cottage. In the ash and rain a diminished Flame Demon lies trapped. He looks up at Fleur and says: "There you are. I've been looking for you." He does not invent her hope. He locates it and feeds it.
+       She attempts the summoning. It goes catastrophically wrong. The fire takes the cottage. In the ash and rain a diminished Flame Demon lies trapped. He looks up at Fleur and says: "There you are. I've been looking for you." He does not invent her hope. He locates it and feeds it.
 
-      Fleur puts him in the iron lantern. She walks away from the burning cottage toward the road.
-      """},
-      {4, "Settling — Silas's Way", "Act II", """
-      Fleur enters the capital with nothing but the lantern. She does what Silas taught her. She tends wounds, sets bones, grinds herbs. Slow, invisible work. She builds a community through presence — not spectacle.
+       Fleur puts him in the iron lantern. She walks away from the burning cottage toward the road.
+       """},
+      {4, "Settling — Silas's Way", "Act II",
+       """
+       Fleur enters the capital with nothing but the lantern. She does what Silas taught her. She tends wounds, sets bones, grinds herbs. Slow, invisible work. She builds a community through presence — not spectacle.
 
-      But the work is slow, and Fleur is afraid. The demon whispers: let me help. Just enough to make her healing look like mundane skill. No one will suspect.
+       But the work is slow, and Fleur is afraid. The demon whispers: let me help. Just enough to make her healing look like mundane skill. No one will suspect.
 
-      Fleur accepts. The first shortcut. It works. The pattern is set. Each time Fleur leans on the demon, the honest work gets smaller and his influence grows.
-      """},
-      {5, "Kestrel's Game", "Act II", """
-      The Alderman notices Fleur's half-gestures of trained craft. Rather than burning her, he pauses — a desperate young witch could be useful. He gives her access to the sick, the poor, even the prisoners. His real intention: to parade her before Kestrel.
+       Fleur accepts. The first shortcut. It works. The pattern is set. Each time Fleur leans on the demon, the honest work gets smaller and his influence grows.
+       """},
+      {5, "Kestrel's Game", "Act II",
+       """
+       The Alderman notices Fleur's half-gestures of trained craft. Rather than burning her, he pauses — a desperate young witch could be useful. He gives her access to the sick, the poor, even the prisoners. His real intention: to parade her before Kestrel.
 
-      In the dungeon, Kestrel reads Silas in Fleur's training gaps — and makes a bitter, wrong reading: Silas took the Book, found an heir, built a private lineage. She tips off the Alderman about the demon, redirecting his plan toward a coronation. Then she works Fleur — filling the void Silas left, weaponising the truth about Silas's flight to crack Fleur's faith. She steers Fleur toward the fire the same way the war once steered her. She knows what she is doing. She does it anyway.
-      """},
-      {6, "The Tug of War", "Act II", """
-      The Alderman grooms Fleur for the coronation — the Chosen One crowned as Solar Queen, his dynasty legitimised. Kestrel advises from behind bars, positioning herself as counterweight while steering Fleur toward the demon. The demon grows. Each shortcut felt reasonable at the time.
+       In the dungeon, Kestrel reads Silas in Fleur's training gaps — and makes a bitter, wrong reading: Silas took the Book, found an heir, built a private lineage. She tips off the Alderman about the demon, redirecting his plan toward a coronation. Then she works Fleur — filling the void Silas left, weaponising the truth about Silas's flight to crack Fleur's faith. She steers Fleur toward the fire the same way the war once steered her. She knows what she is doing. She does it anyway.
+       """},
+      {6, "The Tug of War", "Act II",
+       """
+       The Alderman grooms Fleur for the coronation — the Chosen One crowned as Solar Queen, his dynasty legitimised. Kestrel advises from behind bars, positioning herself as counterweight while steering Fleur toward the demon. The demon grows. Each shortcut felt reasonable at the time.
 
-      Fleur walks into the coronation with her eyes open, believing she can save the community she built through honest work. The demon surges. Fleur loses control. The city burns. The prophecy is revealed as hollow. There is only destruction, and Fleur put it there.
-      """}
+       Fleur walks into the coronation with her eyes open, believing she can save the community she built through honest work. The demon surges. Fleur loses control. The city burns. The prophecy is revealed as hollow. There is only destruction, and Fleur put it there.
+       """}
     ]
 
     for {position, title, act, content} <- sequences do
       {:ok, seq} =
-        Storybox.Stories.SequencePiece
+        Storybox.Stories.TreatmentView
         |> Ash.Changeset.for_create(:create, %{
           title: title,
           act: act,
@@ -256,9 +266,9 @@ if little_witch = all_stories["Little Witch"] do
       Storybox.Storage.put_content(uri, String.trim(content))
 
       {:ok, v1} =
-        Storybox.Stories.SequenceVersion
+        Storybox.Stories.TreatmentPiece
         |> Ash.Changeset.for_create(:create, %{
-          sequence_piece_id: seq.id,
+          treatment_view_id: seq.id,
           content_uri: uri,
           version_number: 1,
           upstream_status: :current,
@@ -274,7 +284,7 @@ if little_witch = all_stories["Little Witch"] do
     # Reckoning — two versions: v1 approved (earlier draft), v2 stale (V3 ending)
     # Demonstrates: approved version + newer upstream version = staleness signal
     {:ok, reckoning} =
-      Storybox.Stories.SequencePiece
+      Storybox.Stories.TreatmentView
       |> Ash.Changeset.for_create(:create, %{
         title: "Reckoning — Kestrel's Choice",
         act: "Act III",
@@ -298,9 +308,9 @@ if little_witch = all_stories["Little Witch"] do
     """)
 
     {:ok, reckoning_v1} =
-      Storybox.Stories.SequenceVersion
+      Storybox.Stories.TreatmentPiece
       |> Ash.Changeset.for_create(:create, %{
-        sequence_piece_id: reckoning.id,
+        treatment_view_id: reckoning.id,
         content_uri: reckoning_v1_uri,
         version_number: 1,
         upstream_status: :current,
@@ -326,9 +336,9 @@ if little_witch = all_stories["Little Witch"] do
     """)
 
     {:ok, _reckoning_v2} =
-      Storybox.Stories.SequenceVersion
+      Storybox.Stories.TreatmentPiece
       |> Ash.Changeset.for_create(:create, %{
-        sequence_piece_id: reckoning.id,
+        treatment_view_id: reckoning.id,
         content_uri: reckoning_v2_uri,
         version_number: 2,
         upstream_status: :stale,
@@ -336,7 +346,7 @@ if little_witch = all_stories["Little Witch"] do
       })
       |> Ash.create(authorize?: false)
 
-    IO.puts("  Created 7 sequence pieces for Little Witch (reckoning has v1 approved + v2 stale)")
+    IO.puts("  Created 7 treatment views for Little Witch (reckoning has v1 approved + v2 stale)")
   end
 
   # -- Scene pieces (ScriptViews) + versions (ScriptPieces) ------------------
@@ -344,108 +354,111 @@ if little_witch = all_stories["Little Witch"] do
   # The final Reckoning scene has no version — demonstrates unresolvable view → Task.
 
   summoning =
-    Storybox.Stories.SequencePiece
+    Storybox.Stories.TreatmentView
     |> Ash.Query.filter(story_id == ^little_witch.id and title == "The Summoning")
     |> Ash.read_one!(authorize?: false)
 
   reckoning =
-    Storybox.Stories.SequencePiece
+    Storybox.Stories.TreatmentView
     |> Ash.Query.filter(story_id == ^little_witch.id and title == "Reckoning — Kestrel's Choice")
     |> Ash.read_one!(authorize?: false)
 
   if summoning do
     existing_summoning_scenes =
-      Storybox.Stories.ScenePiece
-      |> Ash.Query.filter(sequence_piece_id == ^summoning.id)
+      Storybox.Stories.ScriptView
+      |> Ash.Query.filter(treatment_view_id == ^summoning.id)
       |> Ash.read!(authorize?: false)
       |> length()
 
     if existing_summoning_scenes == 0 do
       summoning_scenes = [
-        {1, "INT. COTTAGE - NIGHT", """
-        INT. COTTAGE - NIGHT
+        {1, "INT. COTTAGE - NIGHT",
+         """
+         INT. COTTAGE - NIGHT
 
-        The cottage is dark. FLEUR stands at the chest, key in hand.
+         The cottage is dark. FLEUR stands at the chest, key in hand.
 
-        She has been standing here a long time.
+         She has been standing here a long time.
 
-        She opens the chest. Lifts out the BOOK OF DEMONS.
+         She opens the chest. Lifts out the BOOK OF DEMONS.
 
-        It is heavy and old and warm in a way that stone should not be warm.
+         It is heavy and old and warm in a way that stone should not be warm.
 
-        The fire in the hearth shifts toward her.
+         The fire in the hearth shifts toward her.
 
-        FLEUR
-        (to herself)
-        I'm just looking.
+         FLEUR
+         (to herself)
+         I'm just looking.
 
-        She opens the cover. Turns to the first page.
+         She opens the cover. Turns to the first page.
 
-        The hearth fire doubles.
+         The hearth fire doubles.
 
-        Fleur does not close the Book.
-        """},
-        {2, "EXT. COTTAGE - NIGHT", """
-        EXT. COTTAGE - NIGHT
+         Fleur does not close the Book.
+         """},
+        {2, "EXT. COTTAGE - NIGHT",
+         """
+         EXT. COTTAGE - NIGHT
 
-        Fire. The cottage burns from the inside out.
+         Fire. The cottage burns from the inside out.
 
-        FLEUR stands in the yard, hands raised, trying to unsay something.
+         FLEUR stands in the yard, hands raised, trying to unsay something.
 
-        The herbs. The medicines. The chest. Years of Silas.
+         The herbs. The medicines. The chest. Years of Silas.
 
-        All of it burning.
+         All of it burning.
 
-        She cannot stop it. She does not move.
+         She cannot stop it. She does not move.
 
-        The fire crests the roof. Sparks rise into the dark.
+         The fire crests the roof. Sparks rise into the dark.
 
-        A long beat. Rain begins.
+         A long beat. Rain begins.
 
-        The fire and the rain fight each other.
+         The fire and the rain fight each other.
 
-        Fleur is still standing there when the rain wins.
-        """},
-        {3, "EXT. RUINS - DAWN", """
-        EXT. RUINS - DAWN
+         Fleur is still standing there when the rain wins.
+         """},
+        {3, "EXT. RUINS - DAWN",
+         """
+         EXT. RUINS - DAWN
 
-        Ash and water. The cottage is a shell. Rain has kept the fire from spreading.
+         Ash and water. The cottage is a shell. Rain has kept the fire from spreading.
 
-        The FLAME DEMON lies trapped in a hollow at the base of the ruined hearth, held by the pooling water. He is small. Diminished.
+         The FLAME DEMON lies trapped in a hollow at the base of the ruined hearth, held by the pooling water. He is small. Diminished.
 
-        He looks up at FLEUR.
+         He looks up at FLEUR.
 
-        A long beat.
+         A long beat.
 
-        FLAME DEMON
-        There you are. I've been looking for you.
+         FLAME DEMON
+         There you are. I've been looking for you.
 
-        FLEUR
-        You burned my house.
+         FLEUR
+         You burned my house.
 
-        FLAME DEMON
-        (gently)
-        You opened the Book.
+         FLAME DEMON
+         (gently)
+         You opened the Book.
 
-        Fleur looks at the lantern in her hand. She looks at the demon.
+         Fleur looks at the lantern in her hand. She looks at the demon.
 
-        She opens the lantern.
+         She opens the lantern.
 
-        He flows into it like heat rising. The lantern brightens once — then settles.
+         He flows into it like heat rising. The lantern brightens once — then settles.
 
-        Fleur closes it. Holds it.
+         Fleur closes it. Holds it.
 
-        She starts walking toward the road.
-        """}
+         She starts walking toward the road.
+         """}
       ]
 
       for {position, title, content} <- summoning_scenes do
         {:ok, scene} =
-          Storybox.Stories.ScenePiece
+          Storybox.Stories.ScriptView
           |> Ash.Changeset.for_create(:create, %{
             title: title,
             position: position,
-            sequence_piece_id: summoning.id
+            treatment_view_id: summoning.id
           })
           |> Ash.create(authorize?: false)
 
@@ -453,9 +466,9 @@ if little_witch = all_stories["Little Witch"] do
         Storybox.Storage.put_content(uri, String.trim(content))
 
         {:ok, v1} =
-          Storybox.Stories.SceneVersion
+          Storybox.Stories.ScriptPiece
           |> Ash.Changeset.for_create(:create, %{
-            scene_piece_id: scene.id,
+            script_view_id: scene.id,
             content_uri: uri,
             version_number: 1,
             upstream_status: :current,
@@ -468,25 +481,25 @@ if little_witch = all_stories["Little Witch"] do
         |> Ash.update!(authorize?: false)
       end
 
-      IO.puts("  Created 3 scene pieces for The Summoning (all approved)")
+      IO.puts("  Created 3 script views for The Summoning (all approved)")
     end
   end
 
   if reckoning do
     existing_reckoning_scenes =
-      Storybox.Stories.ScenePiece
-      |> Ash.Query.filter(sequence_piece_id == ^reckoning.id)
+      Storybox.Stories.ScriptView
+      |> Ash.Query.filter(treatment_view_id == ^reckoning.id)
       |> Ash.read!(authorize?: false)
       |> length()
 
     if existing_reckoning_scenes == 0 do
       # Scene 1 — coronation fire (has approved script)
       {:ok, scene_coronation} =
-        Storybox.Stories.ScenePiece
+        Storybox.Stories.ScriptView
         |> Ash.Changeset.for_create(:create, %{
           title: "EXT. CORONATION SQUARE - NIGHT",
           position: 1,
-          sequence_piece_id: reckoning.id
+          treatment_view_id: reckoning.id
         })
         |> Ash.create(authorize?: false)
 
@@ -525,9 +538,9 @@ if little_witch = all_stories["Little Witch"] do
       """)
 
       {:ok, coronation_v1} =
-        Storybox.Stories.SceneVersion
+        Storybox.Stories.ScriptPiece
         |> Ash.Changeset.for_create(:create, %{
-          scene_piece_id: scene_coronation.id,
+          script_view_id: scene_coronation.id,
           content_uri: coronation_uri,
           version_number: 1,
           upstream_status: :current,
@@ -541,16 +554,16 @@ if little_witch = all_stories["Little Witch"] do
 
       # Scene 2 — Kestrel's choice (NO script version — unresolvable → Task)
       {:ok, _scene_kestrel} =
-        Storybox.Stories.ScenePiece
+        Storybox.Stories.ScriptView
         |> Ash.Changeset.for_create(:create, %{
           title: "EXT. RUINS — KESTREL'S CHOICE",
           position: 2,
-          sequence_piece_id: reckoning.id
+          treatment_view_id: reckoning.id
         })
         |> Ash.create(authorize?: false)
 
       IO.puts(
-        "  Created 2 scene pieces for Reckoning (1 approved, 1 empty — unresolvable → Task)"
+        "  Created 2 script views for Reckoning (1 approved, 1 empty — unresolvable → Task)"
       )
     end
   end

--- a/test/storybox/stories/script_snapshot_test.exs
+++ b/test/storybox/stories/script_snapshot_test.exs
@@ -16,8 +16,8 @@ defmodule Storybox.Stories.ScriptSnapshotTest do
       |> Ash.Changeset.for_create(:create, %{title: "Test Story", user_id: user.id})
       |> Ash.create()
 
-    {:ok, sequence} =
-      Storybox.Stories.SequencePiece
+    {:ok, treatment_view} =
+      Storybox.Stories.TreatmentView
       |> Ash.Changeset.for_create(:create, %{
         title: "Act 1",
         position: 1,
@@ -25,12 +25,12 @@ defmodule Storybox.Stories.ScriptSnapshotTest do
       })
       |> Ash.create()
 
-    %{story: story, sequence: sequence}
+    %{story: story, treatment_view: treatment_view}
   end
 
   describe "create" do
     test "creates a snapshot with explicit entries", %{story: story} do
-      entries = %{"scene-piece-1" => "scene-version-1"}
+      entries = %{"script-view-1" => "script-piece-1"}
 
       assert {:ok, snapshot} =
                Storybox.Stories.ScriptSnapshot
@@ -93,51 +93,51 @@ defmodule Storybox.Stories.ScriptSnapshotTest do
   end
 
   describe "capture action" do
-    test "captures approved versions for all scene pieces in a story", %{
+    test "captures approved versions for all script views in a story", %{
       story: story,
-      sequence: sequence
+      treatment_view: treatment_view
     } do
-      {:ok, piece1} =
-        Storybox.Stories.ScenePiece
+      {:ok, view1} =
+        Storybox.Stories.ScriptView
         |> Ash.Changeset.for_create(:create, %{
           title: "Scene 1",
           position: 1,
-          sequence_piece_id: sequence.id
+          treatment_view_id: treatment_view.id
         })
         |> Ash.create()
 
-      {:ok, piece2} =
-        Storybox.Stories.ScenePiece
+      {:ok, view2} =
+        Storybox.Stories.ScriptView
         |> Ash.Changeset.for_create(:create, %{
           title: "Scene 2",
           position: 2,
-          sequence_piece_id: sequence.id
+          treatment_view_id: treatment_view.id
         })
         |> Ash.create()
 
       {:ok, version1} =
-        Storybox.Stories.ScenePiece
+        Storybox.Stories.ScriptView
         |> Ash.ActionInput.for_action(:create_version, %{
-          scene_piece_id: piece1.id,
+          script_view_id: view1.id,
           content: "Scene one content"
         })
         |> Ash.run_action()
 
       {:ok, version2} =
-        Storybox.Stories.ScenePiece
+        Storybox.Stories.ScriptView
         |> Ash.ActionInput.for_action(:create_version, %{
-          scene_piece_id: piece2.id,
+          script_view_id: view2.id,
           content: "Scene two content"
         })
         |> Ash.run_action()
 
-      {:ok, piece1} =
-        piece1
+      {:ok, view1} =
+        view1
         |> Ash.Changeset.for_update(:approve_version, %{version_id: version1.id})
         |> Ash.update()
 
-      {:ok, piece2} =
-        piece2
+      {:ok, view2} =
+        view2
         |> Ash.Changeset.for_update(:approve_version, %{version_id: version2.id})
         |> Ash.update()
 
@@ -152,39 +152,42 @@ defmodule Storybox.Stories.ScriptSnapshotTest do
       assert snapshot.name == "Before Workshop"
       assert snapshot.story_id == story.id
 
-      assert snapshot.entries[to_string(piece1.id)] == to_string(piece1.approved_version_id)
-      assert snapshot.entries[to_string(piece2.id)] == to_string(piece2.approved_version_id)
+      assert snapshot.entries[to_string(view1.id)] == to_string(view1.approved_version_id)
+      assert snapshot.entries[to_string(view2.id)] == to_string(view2.approved_version_id)
     end
 
-    test "excludes scene pieces with no approved version", %{story: story, sequence: sequence} do
-      {:ok, piece_approved} =
-        Storybox.Stories.ScenePiece
+    test "excludes script views with no approved version", %{
+      story: story,
+      treatment_view: treatment_view
+    } do
+      {:ok, view_approved} =
+        Storybox.Stories.ScriptView
         |> Ash.Changeset.for_create(:create, %{
           title: "Approved Scene",
           position: 1,
-          sequence_piece_id: sequence.id
+          treatment_view_id: treatment_view.id
         })
         |> Ash.create()
 
-      {:ok, _piece_unapproved} =
-        Storybox.Stories.ScenePiece
+      {:ok, _view_unapproved} =
+        Storybox.Stories.ScriptView
         |> Ash.Changeset.for_create(:create, %{
           title: "Unapproved Scene",
           position: 2,
-          sequence_piece_id: sequence.id
+          treatment_view_id: treatment_view.id
         })
         |> Ash.create()
 
       {:ok, version} =
-        Storybox.Stories.ScenePiece
+        Storybox.Stories.ScriptView
         |> Ash.ActionInput.for_action(:create_version, %{
-          scene_piece_id: piece_approved.id,
+          script_view_id: view_approved.id,
           content: "Approved scene content"
         })
         |> Ash.run_action()
 
-      {:ok, piece_approved} =
-        piece_approved
+      {:ok, view_approved} =
+        view_approved
         |> Ash.Changeset.for_update(:approve_version, %{version_id: version.id})
         |> Ash.update()
 
@@ -198,11 +201,11 @@ defmodule Storybox.Stories.ScriptSnapshotTest do
 
       assert map_size(snapshot.entries) == 1
 
-      assert snapshot.entries[to_string(piece_approved.id)] ==
-               to_string(piece_approved.approved_version_id)
+      assert snapshot.entries[to_string(view_approved.id)] ==
+               to_string(view_approved.approved_version_id)
     end
 
-    test "capture with no scene pieces produces empty entries", %{story: story} do
+    test "capture with no script views produces empty entries", %{story: story} do
       assert {:ok, snapshot} =
                Storybox.Stories.ScriptSnapshot
                |> Ash.ActionInput.for_action(:capture, %{

--- a/test/storybox/stories/script_view_test.exs
+++ b/test/storybox/stories/script_view_test.exs
@@ -1,4 +1,4 @@
-defmodule Storybox.Stories.ScenePieceTest do
+defmodule Storybox.Stories.ScriptViewTest do
   use Storybox.DataCase
 
   require Ash.Query
@@ -18,8 +18,8 @@ defmodule Storybox.Stories.ScenePieceTest do
       |> Ash.Changeset.for_create(:create, %{title: "Test Story", user_id: user.id})
       |> Ash.create()
 
-    {:ok, sequence} =
-      Storybox.Stories.SequencePiece
+    {:ok, treatment_view} =
+      Storybox.Stories.TreatmentView
       |> Ash.Changeset.for_create(:create, %{
         title: "Act 1",
         position: 1,
@@ -27,39 +27,39 @@ defmodule Storybox.Stories.ScenePieceTest do
       })
       |> Ash.create()
 
-    %{story: story, sequence: sequence}
+    %{story: story, treatment_view: treatment_view}
   end
 
-  describe "create scene_piece" do
-    test "creates a scene_piece with required fields", %{sequence: sequence} do
-      assert {:ok, piece} =
-               Storybox.Stories.ScenePiece
+  describe "create script_view" do
+    test "creates a script_view with required fields", %{treatment_view: treatment_view} do
+      assert {:ok, view} =
+               Storybox.Stories.ScriptView
                |> Ash.Changeset.for_create(:create, %{
                  title: "Opening Scene",
                  position: 1,
-                 sequence_piece_id: sequence.id
+                 treatment_view_id: treatment_view.id
                })
                |> Ash.create()
 
-      assert piece.title == "Opening Scene"
-      assert piece.position == 1
-      assert piece.sequence_piece_id == sequence.id
-      assert is_nil(piece.approved_version_id)
+      assert view.title == "Opening Scene"
+      assert view.position == 1
+      assert view.treatment_view_id == treatment_view.id
+      assert is_nil(view.approved_version_id)
     end
 
-    test "fails without title", %{sequence: sequence} do
+    test "fails without title", %{treatment_view: treatment_view} do
       assert {:error, %Ash.Error.Invalid{}} =
-               Storybox.Stories.ScenePiece
+               Storybox.Stories.ScriptView
                |> Ash.Changeset.for_create(:create, %{
                  position: 1,
-                 sequence_piece_id: sequence.id
+                 treatment_view_id: treatment_view.id
                })
                |> Ash.create()
     end
 
-    test "fails without sequence_piece_id" do
+    test "fails without treatment_view_id" do
       assert {:error, %Ash.Error.Invalid{}} =
-               Storybox.Stories.ScenePiece
+               Storybox.Stories.ScriptView
                |> Ash.Changeset.for_create(:create, %{
                  title: "Test",
                  position: 1
@@ -69,106 +69,111 @@ defmodule Storybox.Stories.ScenePieceTest do
   end
 
   describe "create_version action" do
-    test "creates first version with version_number 1", %{story: story, sequence: sequence} do
-      {:ok, piece} =
-        Storybox.Stories.ScenePiece
+    test "creates first version with version_number 1", %{
+      story: story,
+      treatment_view: treatment_view
+    } do
+      {:ok, view} =
+        Storybox.Stories.ScriptView
         |> Ash.Changeset.for_create(:create, %{
           title: "Opening Scene",
           position: 1,
-          sequence_piece_id: sequence.id
+          treatment_view_id: treatment_view.id
         })
         |> Ash.create()
 
-      assert {:ok, version} =
-               Storybox.Stories.ScenePiece
+      assert {:ok, piece} =
+               Storybox.Stories.ScriptView
                |> Ash.ActionInput.for_action(:create_version, %{
-                 scene_piece_id: piece.id,
+                 script_view_id: view.id,
                  content: "INT. COFFEE SHOP - DAY"
                })
                |> Ash.run_action()
 
-      assert version.version_number == 1
-      assert version.upstream_status == :current
-      assert version.weights == %{}
-      assert version.scene_piece_id == piece.id
+      assert piece.version_number == 1
+      assert piece.upstream_status == :current
+      assert piece.weights == %{}
+      assert piece.script_view_id == view.id
 
-      assert version.content_uri ==
-               Storybox.Storage.uri_for_scene(story.id, piece.id, 1)
+      assert piece.content_uri ==
+               Storybox.Storage.uri_for_scene(story.id, view.id, 1)
     end
 
-    test "increments version_number for subsequent versions", %{sequence: sequence} do
-      {:ok, piece} =
-        Storybox.Stories.ScenePiece
+    test "increments version_number for subsequent versions", %{treatment_view: treatment_view} do
+      {:ok, view} =
+        Storybox.Stories.ScriptView
         |> Ash.Changeset.for_create(:create, %{
           title: "Test Scene",
           position: 1,
-          sequence_piece_id: sequence.id
+          treatment_view_id: treatment_view.id
         })
         |> Ash.create()
 
-      {:ok, _version1} =
-        Storybox.Stories.ScenePiece
+      {:ok, _piece1} =
+        Storybox.Stories.ScriptView
         |> Ash.ActionInput.for_action(:create_version, %{
-          scene_piece_id: piece.id,
+          script_view_id: view.id,
           content: "Version one content"
         })
         |> Ash.run_action()
 
-      assert {:ok, version2} =
-               Storybox.Stories.ScenePiece
+      assert {:ok, piece2} =
+               Storybox.Stories.ScriptView
                |> Ash.ActionInput.for_action(:create_version, %{
-                 scene_piece_id: piece.id,
+                 script_view_id: view.id,
                  content: "Version two content"
                })
                |> Ash.run_action()
 
-      assert version2.version_number == 2
+      assert piece2.version_number == 2
     end
   end
 
   describe "approve_version action" do
-    test "sets approved_version_id on the piece", %{sequence: sequence} do
-      {:ok, piece} =
-        Storybox.Stories.ScenePiece
+    test "sets approved_version_id on the view", %{treatment_view: treatment_view} do
+      {:ok, view} =
+        Storybox.Stories.ScriptView
         |> Ash.Changeset.for_create(:create, %{
           title: "Test Scene",
           position: 1,
-          sequence_piece_id: sequence.id
+          treatment_view_id: treatment_view.id
         })
         |> Ash.create()
 
-      {:ok, version} =
-        Storybox.Stories.ScenePiece
+      {:ok, piece} =
+        Storybox.Stories.ScriptView
         |> Ash.ActionInput.for_action(:create_version, %{
-          scene_piece_id: piece.id,
+          script_view_id: view.id,
           content: "Approved content"
         })
         |> Ash.run_action()
 
-      assert {:ok, updated_piece} =
-               piece
-               |> Ash.Changeset.for_update(:approve_version, %{version_id: version.id})
+      assert {:ok, updated_view} =
+               view
+               |> Ash.Changeset.for_update(:approve_version, %{version_id: piece.id})
                |> Ash.update()
 
-      assert updated_piece.approved_version_id == version.id
+      assert updated_view.approved_version_id == piece.id
     end
   end
 
-  describe "set_weights action on SceneVersion" do
-    test "sets weights map on a version with empty weights and persists it", %{sequence: sequence} do
-      {:ok, piece} =
-        Storybox.Stories.ScenePiece
+  describe "set_weights action on ScriptPiece" do
+    test "sets weights map on a piece with empty weights and persists it", %{
+      treatment_view: treatment_view
+    } do
+      {:ok, view} =
+        Storybox.Stories.ScriptView
         |> Ash.Changeset.for_create(:create, %{
           title: "Test Scene",
           position: 1,
-          sequence_piece_id: sequence.id
+          treatment_view_id: treatment_view.id
         })
         |> Ash.create()
 
-      {:ok, version} =
-        Storybox.Stories.SceneVersion
+      {:ok, piece} =
+        Storybox.Stories.ScriptPiece
         |> Ash.Changeset.for_create(:create, %{
-          scene_piece_id: piece.id,
+          script_view_id: view.id,
           content_uri: "storybox://test/scene/v1",
           version_number: 1,
           weights: %{}
@@ -176,34 +181,34 @@ defmodule Storybox.Stories.ScenePieceTest do
         |> Ash.create()
 
       assert {:ok, updated} =
-               version
+               piece
                |> Ash.Changeset.for_update(:set_weights, %{weights: %{"preference" => 0.6}})
                |> Ash.update()
 
       assert updated.weights == %{"preference" => 0.6}
 
       reloaded =
-        Storybox.Stories.SceneVersion
-        |> Ash.Query.filter(id == ^version.id)
+        Storybox.Stories.ScriptPiece
+        |> Ash.Query.filter(id == ^piece.id)
         |> Ash.read_one!(authorize?: false)
 
       assert reloaded.weights == %{"preference" => 0.6}
     end
 
-    test "replacing weights removes keys not in the new map", %{sequence: sequence} do
-      {:ok, piece} =
-        Storybox.Stories.ScenePiece
+    test "replacing weights removes keys not in the new map", %{treatment_view: treatment_view} do
+      {:ok, view} =
+        Storybox.Stories.ScriptView
         |> Ash.Changeset.for_create(:create, %{
           title: "Test Scene 2",
           position: 2,
-          sequence_piece_id: sequence.id
+          treatment_view_id: treatment_view.id
         })
         |> Ash.create()
 
-      {:ok, version} =
-        Storybox.Stories.SceneVersion
+      {:ok, piece} =
+        Storybox.Stories.ScriptPiece
         |> Ash.Changeset.for_create(:create, %{
-          scene_piece_id: piece.id,
+          script_view_id: view.id,
           content_uri: "storybox://test/scene/v2",
           version_number: 1,
           weights: %{"preference" => 0.9, "theme" => 0.7}
@@ -211,7 +216,7 @@ defmodule Storybox.Stories.ScenePieceTest do
         |> Ash.create()
 
       assert {:ok, updated} =
-               version
+               piece
                |> Ash.Changeset.for_update(:set_weights, %{weights: %{"preference" => 0.4}})
                |> Ash.update()
 
@@ -221,29 +226,29 @@ defmodule Storybox.Stories.ScenePieceTest do
   end
 
   describe "read" do
-    test "returns all scene_pieces", %{sequence: sequence} do
-      {:ok, piece1} =
-        Storybox.Stories.ScenePiece
+    test "returns all script_views", %{treatment_view: treatment_view} do
+      {:ok, view1} =
+        Storybox.Stories.ScriptView
         |> Ash.Changeset.for_create(:create, %{
           title: "Scene 1",
           position: 1,
-          sequence_piece_id: sequence.id
+          treatment_view_id: treatment_view.id
         })
         |> Ash.create()
 
-      {:ok, piece2} =
-        Storybox.Stories.ScenePiece
+      {:ok, view2} =
+        Storybox.Stories.ScriptView
         |> Ash.Changeset.for_create(:create, %{
           title: "Scene 2",
           position: 2,
-          sequence_piece_id: sequence.id
+          treatment_view_id: treatment_view.id
         })
         |> Ash.create()
 
-      assert {:ok, pieces} = Storybox.Stories.ScenePiece |> Ash.read()
-      ids = Enum.map(pieces, & &1.id)
-      assert piece1.id in ids
-      assert piece2.id in ids
+      assert {:ok, views} = Storybox.Stories.ScriptView |> Ash.read()
+      ids = Enum.map(views, & &1.id)
+      assert view1.id in ids
+      assert view2.id in ids
     end
   end
 end

--- a/test/storybox/stories/synopsis_view_test.exs
+++ b/test/storybox/stories/synopsis_view_test.exs
@@ -1,4 +1,4 @@
-defmodule Storybox.Stories.SynopsisVersionTest do
+defmodule Storybox.Stories.SynopsisViewTest do
   use Storybox.DataCase
 
   setup do
@@ -20,9 +20,9 @@ defmodule Storybox.Stories.SynopsisVersionTest do
   end
 
   describe "create" do
-    test "creates a synopsis version with all required fields", %{story: story} do
-      assert {:ok, version} =
-               Storybox.Stories.SynopsisVersion
+    test "creates a synopsis view with all required fields", %{story: story} do
+      assert {:ok, view} =
+               Storybox.Stories.SynopsisView
                |> Ash.Changeset.for_create(:create, %{
                  story_id: story.id,
                  content_uri: "storybox://stories/#{story.id}/synopsis/v1",
@@ -30,14 +30,14 @@ defmodule Storybox.Stories.SynopsisVersionTest do
                })
                |> Ash.create()
 
-      assert version.story_id == story.id
-      assert version.content_uri == "storybox://stories/#{story.id}/synopsis/v1"
-      assert version.version_number == 1
+      assert view.story_id == story.id
+      assert view.content_uri == "storybox://stories/#{story.id}/synopsis/v1"
+      assert view.version_number == 1
     end
 
-    test "creates multiple versions for the same story (append-only)", %{story: story} do
+    test "creates multiple views for the same story (append-only)", %{story: story} do
       {:ok, _v1} =
-        Storybox.Stories.SynopsisVersion
+        Storybox.Stories.SynopsisView
         |> Ash.Changeset.for_create(:create, %{
           story_id: story.id,
           content_uri: "storybox://stories/#{story.id}/synopsis/v1",
@@ -46,7 +46,7 @@ defmodule Storybox.Stories.SynopsisVersionTest do
         |> Ash.create()
 
       {:ok, _v2} =
-        Storybox.Stories.SynopsisVersion
+        Storybox.Stories.SynopsisView
         |> Ash.Changeset.for_create(:create, %{
           story_id: story.id,
           content_uri: "storybox://stories/#{story.id}/synopsis/v2",
@@ -54,15 +54,15 @@ defmodule Storybox.Stories.SynopsisVersionTest do
         })
         |> Ash.create()
 
-      assert {:ok, versions} = Storybox.Stories.SynopsisVersion |> Ash.read()
-      version_numbers = Enum.map(versions, & &1.version_number)
+      assert {:ok, views} = Storybox.Stories.SynopsisView |> Ash.read()
+      version_numbers = Enum.map(views, & &1.version_number)
       assert 1 in version_numbers
       assert 2 in version_numbers
     end
 
     test "fails without story_id" do
       assert {:error, %Ash.Error.Invalid{}} =
-               Storybox.Stories.SynopsisVersion
+               Storybox.Stories.SynopsisView
                |> Ash.Changeset.for_create(:create, %{
                  content_uri: "storybox://stories/123/synopsis/v1",
                  version_number: 1
@@ -72,7 +72,7 @@ defmodule Storybox.Stories.SynopsisVersionTest do
 
     test "fails without content_uri", %{story: story} do
       assert {:error, %Ash.Error.Invalid{}} =
-               Storybox.Stories.SynopsisVersion
+               Storybox.Stories.SynopsisView
                |> Ash.Changeset.for_create(:create, %{
                  story_id: story.id,
                  version_number: 1
@@ -82,7 +82,7 @@ defmodule Storybox.Stories.SynopsisVersionTest do
 
     test "fails without version_number", %{story: story} do
       assert {:error, %Ash.Error.Invalid{}} =
-               Storybox.Stories.SynopsisVersion
+               Storybox.Stories.SynopsisView
                |> Ash.Changeset.for_create(:create, %{
                  story_id: story.id,
                  content_uri: "storybox://stories/#{story.id}/synopsis/v1"
@@ -92,9 +92,9 @@ defmodule Storybox.Stories.SynopsisVersionTest do
   end
 
   describe "read" do
-    test "returns created synopsis versions", %{story: story} do
-      {:ok, version} =
-        Storybox.Stories.SynopsisVersion
+    test "returns created synopsis views", %{story: story} do
+      {:ok, view} =
+        Storybox.Stories.SynopsisView
         |> Ash.Changeset.for_create(:create, %{
           story_id: story.id,
           content_uri: "storybox://stories/#{story.id}/synopsis/v1",
@@ -102,29 +102,29 @@ defmodule Storybox.Stories.SynopsisVersionTest do
         })
         |> Ash.create()
 
-      assert {:ok, versions} = Storybox.Stories.SynopsisVersion |> Ash.read()
-      assert Enum.any?(versions, &(&1.id == version.id))
+      assert {:ok, views} = Storybox.Stories.SynopsisView |> Ash.read()
+      assert Enum.any?(views, &(&1.id == view.id))
     end
   end
 
   describe "create_version action" do
     test "creates first version with version_number 1 and correct URI", %{story: story} do
-      assert {:ok, version} =
-               Storybox.Stories.SynopsisVersion
+      assert {:ok, view} =
+               Storybox.Stories.SynopsisView
                |> Ash.ActionInput.for_action(:create_version, %{
                  story_id: story.id,
                  content: "A detective story about memory."
                })
                |> Ash.run_action()
 
-      assert version.story_id == story.id
-      assert version.version_number == 1
-      assert version.content_uri == Storybox.Storage.uri_for_synopsis(story.id, 1)
+      assert view.story_id == story.id
+      assert view.version_number == 1
+      assert view.content_uri == Storybox.Storage.uri_for_synopsis(story.id, 1)
     end
 
     test "increments version_number for subsequent versions", %{story: story} do
       {:ok, _v1} =
-        Storybox.Stories.SynopsisVersion
+        Storybox.Stories.SynopsisView
         |> Ash.ActionInput.for_action(:create_version, %{
           story_id: story.id,
           content: "First synopsis draft."
@@ -132,7 +132,7 @@ defmodule Storybox.Stories.SynopsisVersionTest do
         |> Ash.run_action()
 
       assert {:ok, v2} =
-               Storybox.Stories.SynopsisVersion
+               Storybox.Stories.SynopsisView
                |> Ash.ActionInput.for_action(:create_version, %{
                  story_id: story.id,
                  content: "Second synopsis draft."

--- a/test/storybox/stories/treatment_view_test.exs
+++ b/test/storybox/stories/treatment_view_test.exs
@@ -1,4 +1,4 @@
-defmodule Storybox.Stories.SequencePieceTest do
+defmodule Storybox.Stories.TreatmentViewTest do
   use Storybox.DataCase
 
   require Ash.Query
@@ -21,10 +21,10 @@ defmodule Storybox.Stories.SequencePieceTest do
     %{story: story, user: user}
   end
 
-  describe "create sequence_piece" do
-    test "creates a sequence_piece with required fields", %{story: story} do
-      assert {:ok, piece} =
-               Storybox.Stories.SequencePiece
+  describe "create treatment_view" do
+    test "creates a treatment_view with required fields", %{story: story} do
+      assert {:ok, view} =
+               Storybox.Stories.TreatmentView
                |> Ash.Changeset.for_create(:create, %{
                  title: "Act 1 Intro",
                  position: 1,
@@ -32,15 +32,15 @@ defmodule Storybox.Stories.SequencePieceTest do
                })
                |> Ash.create()
 
-      assert piece.title == "Act 1 Intro"
-      assert piece.position == 1
-      assert piece.story_id == story.id
-      assert is_nil(piece.approved_version_id)
+      assert view.title == "Act 1 Intro"
+      assert view.position == 1
+      assert view.story_id == story.id
+      assert is_nil(view.approved_version_id)
     end
 
-    test "creates a sequence_piece with optional act", %{story: story} do
-      assert {:ok, piece} =
-               Storybox.Stories.SequencePiece
+    test "creates a treatment_view with optional act", %{story: story} do
+      assert {:ok, view} =
+               Storybox.Stories.TreatmentView
                |> Ash.Changeset.for_create(:create, %{
                  title: "Intro",
                  position: 1,
@@ -49,12 +49,12 @@ defmodule Storybox.Stories.SequencePieceTest do
                })
                |> Ash.create()
 
-      assert piece.act == "Act 1"
+      assert view.act == "Act 1"
     end
 
     test "fails without title", %{story: story} do
       assert {:error, %Ash.Error.Invalid{}} =
-               Storybox.Stories.SequencePiece
+               Storybox.Stories.TreatmentView
                |> Ash.Changeset.for_create(:create, %{
                  position: 1,
                  story_id: story.id
@@ -64,7 +64,7 @@ defmodule Storybox.Stories.SequencePieceTest do
 
     test "fails without story_id" do
       assert {:error, %Ash.Error.Invalid{}} =
-               Storybox.Stories.SequencePiece
+               Storybox.Stories.TreatmentView
                |> Ash.Changeset.for_create(:create, %{
                  title: "Test",
                  position: 1
@@ -75,8 +75,8 @@ defmodule Storybox.Stories.SequencePieceTest do
 
   describe "create_version action" do
     test "creates first version with version_number 1", %{story: story} do
-      {:ok, piece} =
-        Storybox.Stories.SequencePiece
+      {:ok, view} =
+        Storybox.Stories.TreatmentView
         |> Ash.Changeset.for_create(:create, %{
           title: "First Act",
           position: 1,
@@ -84,96 +84,96 @@ defmodule Storybox.Stories.SequencePieceTest do
         })
         |> Ash.create()
 
-      assert {:ok, version} =
-               Storybox.Stories.SequencePiece
+      assert {:ok, piece} =
+               Storybox.Stories.TreatmentView
                |> Ash.ActionInput.for_action(:create_version, %{
-                 sequence_piece_id: piece.id,
+                 treatment_view_id: view.id,
                  content: "INT. COFFEE SHOP - DAY"
                })
                |> Ash.run_action()
 
-      assert version.version_number == 1
-      assert version.upstream_status == :current
-      assert version.weights == %{}
-      assert version.sequence_piece_id == piece.id
+      assert piece.version_number == 1
+      assert piece.upstream_status == :current
+      assert piece.weights == %{}
+      assert piece.treatment_view_id == view.id
 
-      assert version.content_uri ==
-               Storybox.Storage.uri_for_sequence(story.id, piece.id, 1)
+      assert piece.content_uri ==
+               Storybox.Storage.uri_for_sequence(story.id, view.id, 1)
     end
 
     test "increments version_number for subsequent versions", %{story: story} do
-      {:ok, piece} =
-        Storybox.Stories.SequencePiece
+      {:ok, view} =
+        Storybox.Stories.TreatmentView
         |> Ash.Changeset.for_create(:create, %{
-          title: "Test Piece",
+          title: "Test View",
           position: 1,
           story_id: story.id
         })
         |> Ash.create()
 
-      {:ok, _version1} =
-        Storybox.Stories.SequencePiece
+      {:ok, _piece1} =
+        Storybox.Stories.TreatmentView
         |> Ash.ActionInput.for_action(:create_version, %{
-          sequence_piece_id: piece.id,
+          treatment_view_id: view.id,
           content: "Version one content"
         })
         |> Ash.run_action()
 
-      assert {:ok, version2} =
-               Storybox.Stories.SequencePiece
+      assert {:ok, piece2} =
+               Storybox.Stories.TreatmentView
                |> Ash.ActionInput.for_action(:create_version, %{
-                 sequence_piece_id: piece.id,
+                 treatment_view_id: view.id,
                  content: "Version two content"
                })
                |> Ash.run_action()
 
-      assert version2.version_number == 2
+      assert piece2.version_number == 2
     end
   end
 
   describe "approve_version action" do
-    test "sets approved_version_id on the piece", %{story: story} do
-      {:ok, piece} =
-        Storybox.Stories.SequencePiece
+    test "sets approved_version_id on the view", %{story: story} do
+      {:ok, view} =
+        Storybox.Stories.TreatmentView
         |> Ash.Changeset.for_create(:create, %{
-          title: "Test Piece",
+          title: "Test View",
           position: 1,
           story_id: story.id
         })
         |> Ash.create()
 
-      {:ok, version} =
-        Storybox.Stories.SequencePiece
+      {:ok, piece} =
+        Storybox.Stories.TreatmentView
         |> Ash.ActionInput.for_action(:create_version, %{
-          sequence_piece_id: piece.id,
+          treatment_view_id: view.id,
           content: "Approved content"
         })
         |> Ash.run_action()
 
-      assert {:ok, updated_piece} =
-               piece
-               |> Ash.Changeset.for_update(:approve_version, %{version_id: version.id})
+      assert {:ok, updated_view} =
+               view
+               |> Ash.Changeset.for_update(:approve_version, %{version_id: piece.id})
                |> Ash.update()
 
-      assert updated_piece.approved_version_id == version.id
+      assert updated_view.approved_version_id == piece.id
     end
   end
 
-  describe "set_weights action on SequenceVersion" do
-    test "sets weights map on a version with empty weights and persists it", %{story: story} do
-      {:ok, piece} =
-        Storybox.Stories.SequencePiece
+  describe "set_weights action on TreatmentPiece" do
+    test "sets weights map on a piece with empty weights and persists it", %{story: story} do
+      {:ok, view} =
+        Storybox.Stories.TreatmentView
         |> Ash.Changeset.for_create(:create, %{
-          title: "Test Piece",
+          title: "Test View",
           position: 1,
           story_id: story.id
         })
         |> Ash.create()
 
-      {:ok, version} =
-        Storybox.Stories.SequenceVersion
+      {:ok, piece} =
+        Storybox.Stories.TreatmentPiece
         |> Ash.Changeset.for_create(:create, %{
-          sequence_piece_id: piece.id,
+          treatment_view_id: view.id,
           content_uri: "storybox://test/v1",
           version_number: 1,
           weights: %{}
@@ -181,34 +181,34 @@ defmodule Storybox.Stories.SequencePieceTest do
         |> Ash.create()
 
       assert {:ok, updated} =
-               version
+               piece
                |> Ash.Changeset.for_update(:set_weights, %{weights: %{"preference" => 0.8}})
                |> Ash.update()
 
       assert updated.weights == %{"preference" => 0.8}
 
       reloaded =
-        Storybox.Stories.SequenceVersion
-        |> Ash.Query.filter(id == ^version.id)
+        Storybox.Stories.TreatmentPiece
+        |> Ash.Query.filter(id == ^piece.id)
         |> Ash.read_one!(authorize?: false)
 
       assert reloaded.weights == %{"preference" => 0.8}
     end
 
     test "replacing weights removes keys not in the new map", %{story: story} do
-      {:ok, piece} =
-        Storybox.Stories.SequencePiece
+      {:ok, view} =
+        Storybox.Stories.TreatmentView
         |> Ash.Changeset.for_create(:create, %{
-          title: "Test Piece",
+          title: "Test View",
           position: 2,
           story_id: story.id
         })
         |> Ash.create()
 
-      {:ok, version} =
-        Storybox.Stories.SequenceVersion
+      {:ok, piece} =
+        Storybox.Stories.TreatmentPiece
         |> Ash.Changeset.for_create(:create, %{
-          sequence_piece_id: piece.id,
+          treatment_view_id: view.id,
           content_uri: "storybox://test/v2",
           version_number: 1,
           weights: %{"preference" => 0.9, "theme" => 0.7}
@@ -216,7 +216,7 @@ defmodule Storybox.Stories.SequencePieceTest do
         |> Ash.create()
 
       assert {:ok, updated} =
-               version
+               piece
                |> Ash.Changeset.for_update(:set_weights, %{weights: %{"preference" => 0.5}})
                |> Ash.update()
 
@@ -226,29 +226,29 @@ defmodule Storybox.Stories.SequencePieceTest do
   end
 
   describe "read" do
-    test "returns all sequence_pieces", %{story: story} do
-      {:ok, piece1} =
-        Storybox.Stories.SequencePiece
+    test "returns all treatment_views", %{story: story} do
+      {:ok, view1} =
+        Storybox.Stories.TreatmentView
         |> Ash.Changeset.for_create(:create, %{
-          title: "Piece 1",
+          title: "View 1",
           position: 1,
           story_id: story.id
         })
         |> Ash.create()
 
-      {:ok, piece2} =
-        Storybox.Stories.SequencePiece
+      {:ok, view2} =
+        Storybox.Stories.TreatmentView
         |> Ash.Changeset.for_create(:create, %{
-          title: "Piece 2",
+          title: "View 2",
           position: 2,
           story_id: story.id
         })
         |> Ash.create()
 
-      assert {:ok, pieces} = Storybox.Stories.SequencePiece |> Ash.read()
-      ids = Enum.map(pieces, & &1.id)
-      assert piece1.id in ids
-      assert piece2.id in ids
+      assert {:ok, views} = Storybox.Stories.TreatmentView |> Ash.read()
+      ids = Enum.map(views, & &1.id)
+      assert view1.id in ids
+      assert view2.id in ids
     end
   end
 end

--- a/test/storybox/stories/upstream_change_propagation_test.exs
+++ b/test/storybox/stories/upstream_change_propagation_test.exs
@@ -5,10 +5,10 @@ defmodule Storybox.Stories.UpstreamChangePropagationTest do
 
   alias Storybox.Stories.{
     Character,
-    ScenePiece,
-    SceneVersion,
-    SequencePiece,
-    SequenceVersion,
+    ScriptPiece,
+    ScriptView,
+    TreatmentPiece,
+    TreatmentView,
     Story,
     UpstreamChange,
     World
@@ -39,34 +39,34 @@ defmodule Storybox.Stories.UpstreamChangePropagationTest do
       |> Ash.Changeset.for_create(:create, %{history: "Ancient times", story_id: story.id})
       |> Ash.create()
 
-    {:ok, sequence} =
-      SequencePiece
+    {:ok, treatment_view} =
+      TreatmentView
       |> Ash.Changeset.for_create(:create, %{title: "Act 1", position: 1, story_id: story.id})
       |> Ash.create()
 
-    {:ok, sequence_version} =
-      SequenceVersion
+    {:ok, treatment_piece} =
+      TreatmentPiece
       |> Ash.Changeset.for_create(:create, %{
-        sequence_piece_id: sequence.id,
-        content_uri: "storybox://stories/#{story.id}/sequences/#{sequence.id}/v1",
+        treatment_view_id: treatment_view.id,
+        content_uri: "storybox://stories/#{story.id}/sequences/#{treatment_view.id}/v1",
         version_number: 1
       })
       |> Ash.create()
 
-    {:ok, scene} =
-      ScenePiece
+    {:ok, script_view} =
+      ScriptView
       |> Ash.Changeset.for_create(:create, %{
         title: "Scene 1",
         position: 1,
-        sequence_piece_id: sequence.id
+        treatment_view_id: treatment_view.id
       })
       |> Ash.create()
 
-    {:ok, scene_version} =
-      SceneVersion
+    {:ok, script_piece} =
+      ScriptPiece
       |> Ash.Changeset.for_create(:create, %{
-        scene_piece_id: scene.id,
-        content_uri: "storybox://stories/#{story.id}/scenes/#{scene.id}/v1",
+        script_view_id: script_view.id,
+        content_uri: "storybox://stories/#{story.id}/scenes/#{script_view.id}/v1",
         version_number: 1
       })
       |> Ash.create()
@@ -75,37 +75,37 @@ defmodule Storybox.Stories.UpstreamChangePropagationTest do
       story: story,
       character: character,
       world: world,
-      sequence_version: sequence_version,
-      scene_version: scene_version
+      treatment_piece: treatment_piece,
+      script_piece: script_piece
     }
   end
 
   describe "story update propagation" do
-    test "marks all sequence_versions stale", %{story: story, sequence_version: sv} do
-      assert sv.upstream_status == :current
+    test "marks all treatment_pieces stale", %{story: story, treatment_piece: tp} do
+      assert tp.upstream_status == :current
 
       story
       |> Ash.Changeset.for_update(:update, %{title: "Updated Title"})
       |> Ash.update!()
 
-      updated = Ash.get!(SequenceVersion, sv.id)
+      updated = Ash.get!(TreatmentPiece, tp.id)
       assert updated.upstream_status == :stale
     end
 
-    test "marks all scene_versions stale", %{story: story, scene_version: sv} do
-      assert sv.upstream_status == :current
+    test "marks all script_pieces stale", %{story: story, script_piece: sp} do
+      assert sp.upstream_status == :current
 
       story
       |> Ash.Changeset.for_update(:update, %{title: "Updated Title"})
       |> Ash.update!()
 
-      updated = Ash.get!(SceneVersion, sv.id)
+      updated = Ash.get!(ScriptPiece, sp.id)
       assert updated.upstream_status == :stale
     end
 
-    test "creates UpstreamChange for sequence_version with component_type :story", %{
+    test "creates UpstreamChange for treatment_piece with component_type :story", %{
       story: story,
-      sequence_version: sv
+      treatment_piece: tp
     } do
       story
       |> Ash.Changeset.for_update(:update, %{logline: "New logline"})
@@ -114,7 +114,7 @@ defmodule Storybox.Stories.UpstreamChangePropagationTest do
       assert {:ok, [change]} =
                UpstreamChange
                |> Ash.Query.filter(
-                 piece_version_type == :sequence_version and piece_version_id == ^sv.id
+                 piece_version_type == :treatment_piece and piece_version_id == ^tp.id
                )
                |> Ash.read()
 
@@ -126,9 +126,9 @@ defmodule Storybox.Stories.UpstreamChangePropagationTest do
       assert change.version_before != change.version_after
     end
 
-    test "creates UpstreamChange for scene_version with component_type :story", %{
+    test "creates UpstreamChange for script_piece with component_type :story", %{
       story: story,
-      scene_version: sv
+      script_piece: sp
     } do
       story
       |> Ash.Changeset.for_update(:update, %{logline: "New logline"})
@@ -137,7 +137,7 @@ defmodule Storybox.Stories.UpstreamChangePropagationTest do
       assert {:ok, [change]} =
                UpstreamChange
                |> Ash.Query.filter(
-                 piece_version_type == :scene_version and piece_version_id == ^sv.id
+                 piece_version_type == :script_piece and piece_version_id == ^sp.id
                )
                |> Ash.read()
 
@@ -147,27 +147,27 @@ defmodule Storybox.Stories.UpstreamChangePropagationTest do
   end
 
   describe "character update propagation" do
-    test "marks sequence_versions stale", %{character: character, sequence_version: sv} do
+    test "marks treatment_pieces stale", %{character: character, treatment_piece: tp} do
       character
       |> Ash.Changeset.for_update(:update, %{essence: "Brave"})
       |> Ash.update!()
 
-      updated = Ash.get!(SequenceVersion, sv.id)
+      updated = Ash.get!(TreatmentPiece, tp.id)
       assert updated.upstream_status == :stale
     end
 
-    test "marks scene_versions stale", %{character: character, scene_version: sv} do
+    test "marks script_pieces stale", %{character: character, script_piece: sp} do
       character
       |> Ash.Changeset.for_update(:update, %{essence: "Brave"})
       |> Ash.update!()
 
-      updated = Ash.get!(SceneVersion, sv.id)
+      updated = Ash.get!(ScriptPiece, sp.id)
       assert updated.upstream_status == :stale
     end
 
     test "creates UpstreamChange with component_type :character", %{
       character: character,
-      sequence_version: sv
+      treatment_piece: tp
     } do
       character
       |> Ash.Changeset.for_update(:update, %{essence: "Brave"})
@@ -176,7 +176,7 @@ defmodule Storybox.Stories.UpstreamChangePropagationTest do
       assert {:ok, [change]} =
                UpstreamChange
                |> Ash.Query.filter(
-                 piece_version_type == :sequence_version and piece_version_id == ^sv.id
+                 piece_version_type == :treatment_piece and piece_version_id == ^tp.id
                )
                |> Ash.read()
 
@@ -186,27 +186,27 @@ defmodule Storybox.Stories.UpstreamChangePropagationTest do
   end
 
   describe "world update propagation" do
-    test "marks sequence_versions stale", %{world: world, sequence_version: sv} do
+    test "marks treatment_pieces stale", %{world: world, treatment_piece: tp} do
       world
       |> Ash.Changeset.for_update(:update, %{rules: "Magic is real"})
       |> Ash.update!()
 
-      updated = Ash.get!(SequenceVersion, sv.id)
+      updated = Ash.get!(TreatmentPiece, tp.id)
       assert updated.upstream_status == :stale
     end
 
-    test "marks scene_versions stale", %{world: world, scene_version: sv} do
+    test "marks script_pieces stale", %{world: world, script_piece: sp} do
       world
       |> Ash.Changeset.for_update(:update, %{rules: "Magic is real"})
       |> Ash.update!()
 
-      updated = Ash.get!(SceneVersion, sv.id)
+      updated = Ash.get!(ScriptPiece, sp.id)
       assert updated.upstream_status == :stale
     end
 
     test "creates UpstreamChange with component_type :world", %{
       world: world,
-      scene_version: sv
+      script_piece: sp
     } do
       world
       |> Ash.Changeset.for_update(:update, %{rules: "Magic is real"})
@@ -215,7 +215,7 @@ defmodule Storybox.Stories.UpstreamChangePropagationTest do
       assert {:ok, [change]} =
                UpstreamChange
                |> Ash.Query.filter(
-                 piece_version_type == :scene_version and piece_version_id == ^sv.id
+                 piece_version_type == :script_piece and piece_version_id == ^sp.id
                )
                |> Ash.read()
 

--- a/test/storybox/stories/upstream_change_test.exs
+++ b/test/storybox/stories/upstream_change_test.exs
@@ -16,8 +16,8 @@ defmodule Storybox.Stories.UpstreamChangeTest do
       |> Ash.Changeset.for_create(:create, %{title: "Test Story", user_id: user.id})
       |> Ash.create()
 
-    {:ok, sequence} =
-      Storybox.Stories.SequencePiece
+    {:ok, treatment_view} =
+      Storybox.Stories.TreatmentView
       |> Ash.Changeset.for_create(:create, %{
         title: "Act 1",
         position: 1,
@@ -25,50 +25,50 @@ defmodule Storybox.Stories.UpstreamChangeTest do
       })
       |> Ash.create()
 
-    {:ok, sequence_version} =
-      Storybox.Stories.SequenceVersion
+    {:ok, treatment_piece} =
+      Storybox.Stories.TreatmentPiece
       |> Ash.Changeset.for_create(:create, %{
-        sequence_piece_id: sequence.id,
-        content_uri: "storybox://stories/#{story.id}/sequences/#{sequence.id}/v1",
+        treatment_view_id: treatment_view.id,
+        content_uri: "storybox://stories/#{story.id}/sequences/#{treatment_view.id}/v1",
         version_number: 1
       })
       |> Ash.create()
 
-    {:ok, scene} =
-      Storybox.Stories.ScenePiece
+    {:ok, script_view} =
+      Storybox.Stories.ScriptView
       |> Ash.Changeset.for_create(:create, %{
         title: "Scene 1",
         position: 1,
-        sequence_piece_id: sequence.id
+        treatment_view_id: treatment_view.id
       })
       |> Ash.create()
 
-    {:ok, scene_version} =
-      Storybox.Stories.SceneVersion
+    {:ok, script_piece} =
+      Storybox.Stories.ScriptPiece
       |> Ash.Changeset.for_create(:create, %{
-        scene_piece_id: scene.id,
-        content_uri: "storybox://stories/#{story.id}/scenes/#{scene.id}/v1",
+        script_view_id: script_view.id,
+        content_uri: "storybox://stories/#{story.id}/scenes/#{script_view.id}/v1",
         version_number: 1
       })
       |> Ash.create()
 
     %{
       story: story,
-      sequence_version: sequence_version,
-      scene_version: scene_version
+      treatment_piece: treatment_piece,
+      script_piece: script_piece
     }
   end
 
   describe "create" do
-    test "creates an UpstreamChange for a sequence_version target", %{
+    test "creates an UpstreamChange for a treatment_piece target", %{
       story: story,
-      sequence_version: sequence_version
+      treatment_piece: treatment_piece
     } do
       assert {:ok, change} =
                Storybox.Stories.UpstreamChange
                |> Ash.Changeset.for_create(:create, %{
-                 piece_version_type: :sequence_version,
-                 piece_version_id: sequence_version.id,
+                 piece_version_type: :treatment_piece,
+                 piece_version_id: treatment_piece.id,
                  component_type: :story,
                  component_id: story.id,
                  version_before: "2026-01-01T00:00:00Z",
@@ -76,8 +76,8 @@ defmodule Storybox.Stories.UpstreamChangeTest do
                })
                |> Ash.create()
 
-      assert change.piece_version_type == :sequence_version
-      assert change.piece_version_id == sequence_version.id
+      assert change.piece_version_type == :treatment_piece
+      assert change.piece_version_id == treatment_piece.id
       assert change.component_type == :story
       assert change.component_id == story.id
       assert change.version_before == "2026-01-01T00:00:00Z"
@@ -85,33 +85,33 @@ defmodule Storybox.Stories.UpstreamChangeTest do
       assert change.acknowledged == false
     end
 
-    test "creates an UpstreamChange for a scene_version target", %{
+    test "creates an UpstreamChange for a script_piece target", %{
       story: story,
-      scene_version: scene_version
+      script_piece: script_piece
     } do
       assert {:ok, change} =
                Storybox.Stories.UpstreamChange
                |> Ash.Changeset.for_create(:create, %{
-                 piece_version_type: :scene_version,
-                 piece_version_id: scene_version.id,
+                 piece_version_type: :script_piece,
+                 piece_version_id: script_piece.id,
                  component_type: :character,
                  component_id: story.id
                })
                |> Ash.create()
 
-      assert change.piece_version_type == :scene_version
+      assert change.piece_version_type == :script_piece
       assert change.component_type == :character
       assert change.acknowledged == false
       assert is_nil(change.version_before)
       assert is_nil(change.version_after)
     end
 
-    test "defaults acknowledged to false", %{story: story, scene_version: scene_version} do
+    test "defaults acknowledged to false", %{story: story, script_piece: script_piece} do
       assert {:ok, change} =
                Storybox.Stories.UpstreamChange
                |> Ash.Changeset.for_create(:create, %{
-                 piece_version_type: :scene_version,
-                 piece_version_id: scene_version.id,
+                 piece_version_type: :script_piece,
+                 piece_version_id: script_piece.id,
                  component_type: :world,
                  component_id: story.id
                })
@@ -120,24 +120,24 @@ defmodule Storybox.Stories.UpstreamChangeTest do
       assert change.acknowledged == false
     end
 
-    test "fails with invalid piece_version_type", %{story: story, scene_version: scene_version} do
+    test "fails with invalid piece_version_type", %{story: story, script_piece: script_piece} do
       assert {:error, %Ash.Error.Invalid{}} =
                Storybox.Stories.UpstreamChange
                |> Ash.Changeset.for_create(:create, %{
                  piece_version_type: :bad_type,
-                 piece_version_id: scene_version.id,
+                 piece_version_id: script_piece.id,
                  component_type: :story,
                  component_id: story.id
                })
                |> Ash.create()
     end
 
-    test "fails with invalid component_type", %{story: story, scene_version: scene_version} do
+    test "fails with invalid component_type", %{story: story, script_piece: script_piece} do
       assert {:error, %Ash.Error.Invalid{}} =
                Storybox.Stories.UpstreamChange
                |> Ash.Changeset.for_create(:create, %{
-                 piece_version_type: :scene_version,
-                 piece_version_id: scene_version.id,
+                 piece_version_type: :script_piece,
+                 piece_version_id: script_piece.id,
                  component_type: :invalid,
                  component_id: story.id
                })
@@ -153,12 +153,12 @@ defmodule Storybox.Stories.UpstreamChangeTest do
   end
 
   describe "acknowledge" do
-    test "sets acknowledged to true", %{story: story, scene_version: scene_version} do
+    test "sets acknowledged to true", %{story: story, script_piece: script_piece} do
       {:ok, change} =
         Storybox.Stories.UpstreamChange
         |> Ash.Changeset.for_create(:create, %{
-          piece_version_type: :scene_version,
-          piece_version_id: scene_version.id,
+          piece_version_type: :script_piece,
+          piece_version_id: script_piece.id,
           component_type: :story,
           component_id: story.id
         })
@@ -174,12 +174,12 @@ defmodule Storybox.Stories.UpstreamChangeTest do
   end
 
   describe "read" do
-    test "filters by component_type", %{story: story, scene_version: scene_version} do
+    test "filters by component_type", %{story: story, script_piece: script_piece} do
       {:ok, _} =
         Storybox.Stories.UpstreamChange
         |> Ash.Changeset.for_create(:create, %{
-          piece_version_type: :scene_version,
-          piece_version_id: scene_version.id,
+          piece_version_type: :script_piece,
+          piece_version_id: script_piece.id,
           component_type: :story,
           component_id: story.id
         })
@@ -188,8 +188,8 @@ defmodule Storybox.Stories.UpstreamChangeTest do
       {:ok, _} =
         Storybox.Stories.UpstreamChange
         |> Ash.Changeset.for_create(:create, %{
-          piece_version_type: :scene_version,
-          piece_version_id: scene_version.id,
+          piece_version_type: :script_piece,
+          piece_version_id: script_piece.id,
           component_type: :character,
           component_id: story.id
         })

--- a/test/storybox_web/controllers/piece_versions_test.exs
+++ b/test/storybox_web/controllers/piece_versions_test.exs
@@ -5,11 +5,11 @@ defmodule StoryboxWeb.PieceVersionsTest do
 
   # Shared setup creates:
   #
-  #   user ──── story ──── seq_1 ──── seq_v1 (v1, existing)
-  #          │              └───── scene_1 ── scene_v1 (v1, existing)
-  #          └── other_story ── other_seq ── other_scene
+  #   user ──── story ──── tv_1 ──── tp_v1 (v1, existing)
+  #          │              └───── sv_1 ── sp_v1 (v1, existing)
+  #          └── other_story ── other_tv ── other_sv
   #
-  # raw_token is scoped to story. other_seq/other_scene are used for cross-story 404 tests.
+  # raw_token is scoped to story. other_tv/other_sv are used for cross-story 404 tests.
 
   setup do
     {:ok, user} =
@@ -33,30 +33,30 @@ defmodule StoryboxWeb.PieceVersionsTest do
 
     {:ok, raw_token, _} = ApiToken.generate(%{story_id: story.id, user_id: user.id})
 
-    {:ok, seq_1} =
-      Storybox.Stories.SequencePiece
+    {:ok, tv_1} =
+      Storybox.Stories.TreatmentView
       |> Ash.Changeset.for_create(:create, %{
-        title: "Seq",
+        title: "Act I",
         act: "Act I",
         position: 1,
         story_id: story.id
       })
       |> Ash.create(authorize?: false)
 
-    {:ok, scene_1} =
-      Storybox.Stories.ScenePiece
+    {:ok, sv_1} =
+      Storybox.Stories.ScriptView
       |> Ash.Changeset.for_create(:create, %{
         title: "Scene",
         position: 1,
-        sequence_piece_id: seq_1.id
+        treatment_view_id: tv_1.id
       })
       |> Ash.create(authorize?: false)
 
     # Existing v1 records created directly (bypasses MinIO in setup)
-    {:ok, _seq_v1} =
-      Storybox.Stories.SequenceVersion
+    {:ok, _tp_v1} =
+      Storybox.Stories.TreatmentPiece
       |> Ash.Changeset.for_create(:create, %{
-        sequence_piece_id: seq_1.id,
+        treatment_view_id: tv_1.id,
         content_uri: "storybox://test/seq/v1.fountain",
         version_number: 1,
         upstream_status: :current,
@@ -64,10 +64,10 @@ defmodule StoryboxWeb.PieceVersionsTest do
       })
       |> Ash.create(authorize?: false)
 
-    {:ok, _scene_v1} =
-      Storybox.Stories.SceneVersion
+    {:ok, _sp_v1} =
+      Storybox.Stories.ScriptPiece
       |> Ash.Changeset.for_create(:create, %{
-        scene_piece_id: scene_1.id,
+        script_view_id: sv_1.id,
         content_uri: "storybox://test/scene/v1.fountain",
         version_number: 1,
         upstream_status: :current,
@@ -75,30 +75,30 @@ defmodule StoryboxWeb.PieceVersionsTest do
       })
       |> Ash.create(authorize?: false)
 
-    {:ok, other_seq} =
-      Storybox.Stories.SequencePiece
+    {:ok, other_tv} =
+      Storybox.Stories.TreatmentView
       |> Ash.Changeset.for_create(:create, %{
-        title: "Other Seq",
+        title: "Other Act",
         position: 1,
         story_id: other_story.id
       })
       |> Ash.create(authorize?: false)
 
-    {:ok, other_scene} =
-      Storybox.Stories.ScenePiece
+    {:ok, other_sv} =
+      Storybox.Stories.ScriptView
       |> Ash.Changeset.for_create(:create, %{
         title: "Other Scene",
         position: 1,
-        sequence_piece_id: other_seq.id
+        treatment_view_id: other_tv.id
       })
       |> Ash.create(authorize?: false)
 
     %{
       story: story,
-      seq_1: seq_1,
-      scene_1: scene_1,
-      other_seq: other_seq,
-      other_scene: other_scene,
+      tv_1: tv_1,
+      sv_1: sv_1,
+      other_tv: other_tv,
+      other_sv: other_sv,
       raw_token: raw_token
     }
   end
@@ -107,13 +107,13 @@ defmodule StoryboxWeb.PieceVersionsTest do
     test "creates a new version and returns 201", %{
       conn: conn,
       story: story,
-      seq_1: seq_1,
+      tv_1: tv_1,
       raw_token: raw_token
     } do
       conn =
         conn
         |> put_req_header("authorization", "Bearer #{raw_token}")
-        |> post("/api/stories/#{story.id}/sequences/#{seq_1.id}/versions", %{
+        |> post("/api/stories/#{story.id}/sequences/#{tv_1.id}/versions", %{
           "content" => "EXT. PARK - DAY\nSomething happens."
         })
 
@@ -127,13 +127,13 @@ defmodule StoryboxWeb.PieceVersionsTest do
     test "returns version_number 2 when a prior version already exists", %{
       conn: conn,
       story: story,
-      seq_1: seq_1,
+      tv_1: tv_1,
       raw_token: raw_token
     } do
       conn =
         conn
         |> put_req_header("authorization", "Bearer #{raw_token}")
-        |> post("/api/stories/#{story.id}/sequences/#{seq_1.id}/versions", %{
+        |> post("/api/stories/#{story.id}/sequences/#{tv_1.id}/versions", %{
           "content" => "EXT. PARK - DAY\nNew content."
         })
 
@@ -143,13 +143,13 @@ defmodule StoryboxWeb.PieceVersionsTest do
     test "returns 400 when content is missing", %{
       conn: conn,
       story: story,
-      seq_1: seq_1,
+      tv_1: tv_1,
       raw_token: raw_token
     } do
       conn =
         conn
         |> put_req_header("authorization", "Bearer #{raw_token}")
-        |> post("/api/stories/#{story.id}/sequences/#{seq_1.id}/versions", %{})
+        |> post("/api/stories/#{story.id}/sequences/#{tv_1.id}/versions", %{})
 
       assert json_response(conn, 400)["error"] == "content is required"
     end
@@ -157,13 +157,13 @@ defmodule StoryboxWeb.PieceVersionsTest do
     test "returns 400 when content is empty string", %{
       conn: conn,
       story: story,
-      seq_1: seq_1,
+      tv_1: tv_1,
       raw_token: raw_token
     } do
       conn =
         conn
         |> put_req_header("authorization", "Bearer #{raw_token}")
-        |> post("/api/stories/#{story.id}/sequences/#{seq_1.id}/versions", %{"content" => ""})
+        |> post("/api/stories/#{story.id}/sequences/#{tv_1.id}/versions", %{"content" => ""})
 
       assert json_response(conn, 400)["error"] == "content is required"
     end
@@ -171,13 +171,13 @@ defmodule StoryboxWeb.PieceVersionsTest do
     test "returns 404 when sequence belongs to a different story", %{
       conn: conn,
       story: story,
-      other_seq: other_seq,
+      other_tv: other_tv,
       raw_token: raw_token
     } do
       conn =
         conn
         |> put_req_header("authorization", "Bearer #{raw_token}")
-        |> post("/api/stories/#{story.id}/sequences/#{other_seq.id}/versions", %{
+        |> post("/api/stories/#{story.id}/sequences/#{other_tv.id}/versions", %{
           "content" => "Some content."
         })
 
@@ -207,13 +207,13 @@ defmodule StoryboxWeb.PieceVersionsTest do
     test "creates a new scene version and returns 201", %{
       conn: conn,
       story: story,
-      scene_1: scene_1,
+      sv_1: sv_1,
       raw_token: raw_token
     } do
       conn =
         conn
         |> put_req_header("authorization", "Bearer #{raw_token}")
-        |> post("/api/stories/#{story.id}/scenes/#{scene_1.id}/versions", %{
+        |> post("/api/stories/#{story.id}/scenes/#{sv_1.id}/versions", %{
           "content" => "INT. OFFICE - NIGHT\nThey argue."
         })
 
@@ -227,13 +227,13 @@ defmodule StoryboxWeb.PieceVersionsTest do
     test "returns version_number 2 when a prior version already exists", %{
       conn: conn,
       story: story,
-      scene_1: scene_1,
+      sv_1: sv_1,
       raw_token: raw_token
     } do
       conn =
         conn
         |> put_req_header("authorization", "Bearer #{raw_token}")
-        |> post("/api/stories/#{story.id}/scenes/#{scene_1.id}/versions", %{
+        |> post("/api/stories/#{story.id}/scenes/#{sv_1.id}/versions", %{
           "content" => "INT. OFFICE - NIGHT\nNew content."
         })
 
@@ -243,13 +243,13 @@ defmodule StoryboxWeb.PieceVersionsTest do
     test "returns 400 when content is missing", %{
       conn: conn,
       story: story,
-      scene_1: scene_1,
+      sv_1: sv_1,
       raw_token: raw_token
     } do
       conn =
         conn
         |> put_req_header("authorization", "Bearer #{raw_token}")
-        |> post("/api/stories/#{story.id}/scenes/#{scene_1.id}/versions", %{})
+        |> post("/api/stories/#{story.id}/scenes/#{sv_1.id}/versions", %{})
 
       assert json_response(conn, 400)["error"] == "content is required"
     end
@@ -257,13 +257,13 @@ defmodule StoryboxWeb.PieceVersionsTest do
     test "returns 404 when scene's parent sequence belongs to a different story", %{
       conn: conn,
       story: story,
-      other_scene: other_scene,
+      other_sv: other_sv,
       raw_token: raw_token
     } do
       conn =
         conn
         |> put_req_header("authorization", "Bearer #{raw_token}")
-        |> post("/api/stories/#{story.id}/scenes/#{other_scene.id}/versions", %{
+        |> post("/api/stories/#{story.id}/scenes/#{other_sv.id}/versions", %{
           "content" => "Some content."
         })
 

--- a/test/storybox_web/controllers/script_view_test.exs
+++ b/test/storybox_web/controllers/script_view_test.exs
@@ -3,13 +3,13 @@ defmodule StoryboxWeb.ScriptViewTest do
 
   alias Storybox.Accounts.ApiToken
 
-  # Shared setup creates the following structure (see plan for diagram):
+  # Shared setup creates the following structure:
   #
-  #   story → seq_1 (Act I) → scene_1 → v1 (EXT. PARK...), v2 (INT. OFFICE...) ★ approved
-  #                          → scene_2 → v3 (EXT. STREET...)   no approved version
-  #         → seq_2 (Act II) → scene_3 → v4 (INT. KITCHEN...) ★ approved
-  #                           → scene_4   (no versions)
-  #   snapshot: entries = {scene_1 → v1}  (pins scene_1 to old v1; others not listed)
+  #   story → tv_1 (Act I) → sv_1 → sp_v1 (EXT. PARK...), sp_v2 (INT. OFFICE...) ★ approved
+  #                         → sv_2 → sp_v3 (EXT. STREET...)   no approved version
+  #         → tv_2 (Act II) → sv_3 → sp_v4 (INT. KITCHEN...) ★ approved
+  #                          → sv_4   (no versions)
+  #   snapshot: entries = {sv_1 → sp_v1}  (pins sv_1 to old v1; others not listed)
   #   other_story: for token isolation tests
 
   setup do
@@ -38,8 +38,8 @@ defmodule StoryboxWeb.ScriptViewTest do
 
     {:ok, raw_token, _} = ApiToken.generate(%{story_id: story.id, user_id: user.id})
 
-    {:ok, seq_1} =
-      Storybox.Stories.SequencePiece
+    {:ok, tv_1} =
+      Storybox.Stories.TreatmentView
       |> Ash.Changeset.for_create(:create, %{
         title: "Opening",
         act: "Act I",
@@ -48,8 +48,8 @@ defmodule StoryboxWeb.ScriptViewTest do
       })
       |> Ash.create(authorize?: false)
 
-    {:ok, seq_2} =
-      Storybox.Stories.SequencePiece
+    {:ok, tv_2} =
+      Storybox.Stories.TreatmentView
       |> Ash.Changeset.for_create(:create, %{
         title: "Confrontation",
         act: "Act II",
@@ -58,91 +58,91 @@ defmodule StoryboxWeb.ScriptViewTest do
       })
       |> Ash.create(authorize?: false)
 
-    {:ok, scene_1} =
-      Storybox.Stories.ScenePiece
+    {:ok, sv_1} =
+      Storybox.Stories.ScriptView
       |> Ash.Changeset.for_create(:create, %{
         title: "Cold open",
         position: 1,
-        sequence_piece_id: seq_1.id
+        treatment_view_id: tv_1.id
       })
       |> Ash.create(authorize?: false)
 
-    {:ok, scene_2} =
-      Storybox.Stories.ScenePiece
+    {:ok, sv_2} =
+      Storybox.Stories.ScriptView
       |> Ash.Changeset.for_create(:create, %{
         title: "Inciting incident",
         position: 2,
-        sequence_piece_id: seq_1.id
+        treatment_view_id: tv_1.id
       })
       |> Ash.create(authorize?: false)
 
-    {:ok, scene_3} =
-      Storybox.Stories.ScenePiece
+    {:ok, sv_3} =
+      Storybox.Stories.ScriptView
       |> Ash.Changeset.for_create(:create, %{
         title: "The argument",
         position: 1,
-        sequence_piece_id: seq_2.id
+        treatment_view_id: tv_2.id
       })
       |> Ash.create(authorize?: false)
 
-    {:ok, scene_4} =
-      Storybox.Stories.ScenePiece
+    {:ok, sv_4} =
+      Storybox.Stories.ScriptView
       |> Ash.Changeset.for_create(:create, %{
         title: "Aftermath",
         position: 2,
-        sequence_piece_id: seq_2.id
+        treatment_view_id: tv_2.id
       })
       |> Ash.create(authorize?: false)
 
-    {:ok, v1} =
-      Storybox.Stories.ScenePiece
+    {:ok, sp_v1} =
+      Storybox.Stories.ScriptView
       |> Ash.ActionInput.for_action(:create_version, %{
-        scene_piece_id: scene_1.id,
+        script_view_id: sv_1.id,
         content: "EXT. PARK - DAY\n\nFirst draft."
       })
       |> Ash.run_action(authorize?: false)
 
-    {:ok, v2} =
-      Storybox.Stories.ScenePiece
+    {:ok, sp_v2} =
+      Storybox.Stories.ScriptView
       |> Ash.ActionInput.for_action(:create_version, %{
-        scene_piece_id: scene_1.id,
+        script_view_id: sv_1.id,
         content: "INT. OFFICE - NIGHT\n\nRevised."
       })
       |> Ash.run_action(authorize?: false)
 
-    {:ok, scene_1} =
-      scene_1
-      |> Ash.Changeset.for_update(:approve_version, %{version_id: v2.id})
+    {:ok, sv_1} =
+      sv_1
+      |> Ash.Changeset.for_update(:approve_version, %{version_id: sp_v2.id})
       |> Ash.update(authorize?: false)
 
-    {:ok, v3} =
-      Storybox.Stories.ScenePiece
+    {:ok, sp_v3} =
+      Storybox.Stories.ScriptView
       |> Ash.ActionInput.for_action(:create_version, %{
-        scene_piece_id: scene_2.id,
+        script_view_id: sv_2.id,
         content: "EXT. STREET - DAY\n\nSomething happens."
       })
       |> Ash.run_action(authorize?: false)
 
-    {:ok, v4} =
-      Storybox.Stories.ScenePiece
+    {:ok, sp_v4} =
+      Storybox.Stories.ScriptView
       |> Ash.ActionInput.for_action(:create_version, %{
-        scene_piece_id: scene_3.id,
+        script_view_id: sv_3.id,
         content: "INT. KITCHEN - DAY\n\nThey argue."
       })
       |> Ash.run_action(authorize?: false)
 
-    {:ok, scene_3} =
-      scene_3
-      |> Ash.Changeset.for_update(:approve_version, %{version_id: v4.id})
+    {:ok, sv_3} =
+      sv_3
+      |> Ash.Changeset.for_update(:approve_version, %{version_id: sp_v4.id})
       |> Ash.update(authorize?: false)
 
-    # Snapshot pins scene_1 to v1 (its old version, not the currently approved v2)
+    # Snapshot pins sv_1 to sp_v1 (its old version, not the currently approved sp_v2)
     {:ok, snapshot} =
       Storybox.Stories.ScriptSnapshot
       |> Ash.Changeset.for_create(:create, %{
         name: "Test snapshot",
         story_id: story.id,
-        entries: %{to_string(scene_1.id) => to_string(v1.id)}
+        entries: %{to_string(sv_1.id) => to_string(sp_v1.id)}
       })
       |> Ash.create(authorize?: false)
 
@@ -150,16 +150,16 @@ defmodule StoryboxWeb.ScriptViewTest do
       story: story,
       other_story: other_story,
       raw_token: raw_token,
-      seq_1: seq_1,
-      seq_2: seq_2,
-      scene_1: scene_1,
-      scene_2: scene_2,
-      scene_3: scene_3,
-      scene_4: scene_4,
-      v1: v1,
-      v2: v2,
-      v3: v3,
-      v4: v4,
+      tv_1: tv_1,
+      tv_2: tv_2,
+      sv_1: sv_1,
+      sv_2: sv_2,
+      sv_3: sv_3,
+      sv_4: sv_4,
+      sp_v1: sp_v1,
+      sp_v2: sp_v2,
+      sp_v3: sp_v3,
+      sp_v4: sp_v4,
       snapshot: snapshot
     }
   end
@@ -218,13 +218,13 @@ defmodule StoryboxWeb.ScriptViewTest do
       conn: conn,
       story: story,
       raw_token: raw_token,
-      scene_4: scene_4
+      sv_4: sv_4
     } do
       conn = get_script(conn, story, raw_token, %{mode: "latest"})
       confrontation = find_sequence(json_response(conn, 200), "Confrontation")
       aftermath = find_scene(confrontation, "Aftermath")
 
-      assert aftermath["id"] == scene_4.id
+      assert aftermath["id"] == sv_4.id
       assert aftermath["version"] == nil
       assert aftermath["content"] == nil
     end
@@ -271,7 +271,7 @@ defmodule StoryboxWeb.ScriptViewTest do
   # ── mode=snapshot ────────────────────────────────────────────────────────────
 
   describe "GET /api/stories/:story_id/views/script?mode=snapshot" do
-    test "resolves scene_1 to v1 via the snapshot entries map, not the current approved v2", %{
+    test "resolves sv_1 to sp_v1 via the snapshot entries map, not the current approved sp_v2", %{
       conn: conn,
       story: story,
       raw_token: raw_token,
@@ -296,7 +296,7 @@ defmodule StoryboxWeb.ScriptViewTest do
       conn = get_script(conn, story, raw_token, %{mode: "snapshot", snapshot_id: snapshot.id})
       body = json_response(conn, 200)
 
-      # scene_2, scene_3, scene_4 are not in the snapshot
+      # sv_2, sv_3, sv_4 are not in the snapshot
       inciting = body |> find_sequence("Opening") |> find_scene("Inciting incident")
       assert inciting["version"] == nil
       assert inciting["content"] == nil
@@ -375,21 +375,21 @@ defmodule StoryboxWeb.ScriptViewTest do
       conn: conn,
       story: story,
       raw_token: raw_token,
-      scene_1: scene_1
+      sv_1: sv_1
     } do
       {:ok, bad_version} =
-        Storybox.Stories.SceneVersion
+        Storybox.Stories.ScriptPiece
         |> Ash.Changeset.for_create(:create, %{
-          scene_piece_id: scene_1.id,
+          script_view_id: sv_1.id,
           content_uri:
-            "storybox://stories/#{story.id}/scenes/#{scene_1.id}/v999_nonexistent.fountain",
+            "storybox://stories/#{story.id}/scenes/#{sv_1.id}/v999_nonexistent.fountain",
           version_number: 99,
           upstream_status: :current,
           weights: %{}
         })
         |> Ash.create(authorize?: false)
 
-      scene_1
+      sv_1
       |> Ash.Changeset.for_update(:approve_version, %{version_id: bad_version.id})
       |> Ash.update(authorize?: false)
 

--- a/test/storybox_web/controllers/synopsis_view_test.exs
+++ b/test/storybox_web/controllers/synopsis_view_test.exs
@@ -52,7 +52,7 @@ defmodule StoryboxWeb.SynopsisViewTest do
       raw_token: raw_token
     } do
       {:ok, _v1} =
-        Storybox.Stories.SynopsisVersion
+        Storybox.Stories.SynopsisView
         |> Ash.ActionInput.for_action(:create_version, %{
           story_id: story.id,
           content: "First synopsis draft."
@@ -60,7 +60,7 @@ defmodule StoryboxWeb.SynopsisViewTest do
         |> Ash.run_action()
 
       {:ok, _v2} =
-        Storybox.Stories.SynopsisVersion
+        Storybox.Stories.SynopsisView
         |> Ash.ActionInput.for_action(:create_version, %{
           story_id: story.id,
           content: "Second synopsis draft."
@@ -90,7 +90,7 @@ defmodule StoryboxWeb.SynopsisViewTest do
       raw_token: raw_token
     } do
       {:ok, _version} =
-        Storybox.Stories.SynopsisVersion
+        Storybox.Stories.SynopsisView
         |> Ash.Changeset.for_create(:create, %{
           story_id: story.id,
           content_uri: "storybox://stories/#{story.id}/synopsis/v999_nonexistent.fountain",
@@ -114,7 +114,7 @@ defmodule StoryboxWeb.SynopsisViewTest do
       content = "Frank carries something back \u2014 something that has no name."
 
       {:ok, _v} =
-        Storybox.Stories.SynopsisVersion
+        Storybox.Stories.SynopsisView
         |> Ash.ActionInput.for_action(:create_version, %{
           story_id: story.id,
           content: content

--- a/test/storybox_web/controllers/treatment_diff_test.exs
+++ b/test/storybox_web/controllers/treatment_diff_test.exs
@@ -29,7 +29,7 @@ defmodule StoryboxWeb.TreatmentDiffTest do
 
     # v1 — "Act II: The conflict grows." will appear as a del
     {:ok, _sv1} =
-      Storybox.Stories.SynopsisVersion
+      Storybox.Stories.SynopsisView
       |> Ash.ActionInput.for_action(:create_version, %{
         story_id: story.id,
         content: "Act I: The hero begins.\nAct II: The conflict grows."
@@ -38,7 +38,7 @@ defmodule StoryboxWeb.TreatmentDiffTest do
 
     # v2 — replaces the Act II line, adds Act III
     {:ok, _sv2} =
-      Storybox.Stories.SynopsisVersion
+      Storybox.Stories.SynopsisView
       |> Ash.ActionInput.for_action(:create_version, %{
         story_id: story.id,
         content: "Act I: The hero begins.\nAct II: The conflict escalates.\nAct III: Resolution."
@@ -47,7 +47,7 @@ defmodule StoryboxWeb.TreatmentDiffTest do
 
     # "Opening" — has a current approved version (upstream_status: :current)
     {:ok, opening} =
-      Storybox.Stories.SequencePiece
+      Storybox.Stories.TreatmentView
       |> Ash.Changeset.for_create(:create, %{
         title: "Opening",
         act: "Act I",
@@ -57,9 +57,9 @@ defmodule StoryboxWeb.TreatmentDiffTest do
       |> Ash.create(authorize?: false)
 
     {:ok, opening_v} =
-      Storybox.Stories.SequencePiece
+      Storybox.Stories.TreatmentView
       |> Ash.ActionInput.for_action(:create_version, %{
-        sequence_piece_id: opening.id,
+        treatment_view_id: opening.id,
         content: "EXT. PARK - DAY\n\nThe hero walks alone."
       })
       |> Ash.run_action(authorize?: false)
@@ -71,7 +71,7 @@ defmodule StoryboxWeb.TreatmentDiffTest do
 
     # "Midpoint" — has a stale approved version (upstream_status: :stale)
     {:ok, midpoint} =
-      Storybox.Stories.SequencePiece
+      Storybox.Stories.TreatmentView
       |> Ash.Changeset.for_create(:create, %{
         title: "Midpoint",
         act: "Act II",
@@ -81,9 +81,9 @@ defmodule StoryboxWeb.TreatmentDiffTest do
       |> Ash.create(authorize?: false)
 
     {:ok, stale_v} =
-      Storybox.Stories.SequenceVersion
+      Storybox.Stories.TreatmentPiece
       |> Ash.Changeset.for_create(:create, %{
-        sequence_piece_id: midpoint.id,
+        treatment_view_id: midpoint.id,
         content_uri: "storybox://stories/#{story.id}/sequences/#{midpoint.id}/v1.fountain",
         version_number: 1,
         upstream_status: :stale,
@@ -98,7 +98,7 @@ defmodule StoryboxWeb.TreatmentDiffTest do
 
     # "Draft" — no approved version
     {:ok, _draft} =
-      Storybox.Stories.SequencePiece
+      Storybox.Stories.TreatmentView
       |> Ash.Changeset.for_create(:create, %{
         title: "Draft",
         act: "Act I",

--- a/test/storybox_web/controllers/treatment_view_test.exs
+++ b/test/storybox_web/controllers/treatment_view_test.exs
@@ -36,31 +36,31 @@ defmodule StoryboxWeb.TreatmentViewTest do
     put_req_header(conn, "authorization", "Bearer #{raw_token}")
   end
 
-  defp create_piece(story, attrs) do
-    {:ok, piece} =
-      Storybox.Stories.SequencePiece
+  defp create_treatment_view(story, attrs) do
+    {:ok, view} =
+      Storybox.Stories.TreatmentView
       |> Ash.Changeset.for_create(:create, Map.put(attrs, :story_id, story.id))
       |> Ash.create(authorize?: false)
 
-    piece
+    view
   end
 
-  defp create_version(piece, content) do
-    {:ok, version} =
-      Storybox.Stories.SequencePiece
+  defp create_version(view, content) do
+    {:ok, piece} =
+      Storybox.Stories.TreatmentView
       |> Ash.ActionInput.for_action(:create_version, %{
-        sequence_piece_id: piece.id,
+        treatment_view_id: view.id,
         content: content
       })
       |> Ash.run_action(authorize?: false)
 
-    version
+    piece
   end
 
-  defp approve_version(piece, version) do
+  defp approve_version(view, piece) do
     {:ok, updated} =
-      piece
-      |> Ash.Changeset.for_update(:approve_version, %{version_id: version.id})
+      view
+      |> Ash.Changeset.for_update(:approve_version, %{version_id: piece.id})
       |> Ash.update(authorize?: false)
 
     updated
@@ -87,15 +87,15 @@ defmodule StoryboxWeb.TreatmentViewTest do
       story: story,
       raw_token: raw_token
     } do
-      p1 = create_piece(story, %{title: "Opening", act: "Act I", position: 1})
+      p1 = create_treatment_view(story, %{title: "Opening", act: "Act I", position: 1})
       v1 = create_version(p1, "EXT. PARK - DAY\n\nThe story begins.")
       approve_version(p1, v1)
 
-      # Second piece in Act I — no approved version
-      create_piece(story, %{title: "Complication", act: "Act I", position: 2})
+      # Second view in Act I — no approved version
+      create_treatment_view(story, %{title: "Complication", act: "Act I", position: 2})
 
-      # Piece in Act II — with approved version
-      p3 = create_piece(story, %{title: "Midpoint", act: "Act II", position: 1})
+      # View in Act II — with approved version
+      p3 = create_treatment_view(story, %{title: "Midpoint", act: "Act II", position: 1})
       v3 = create_version(p3, "INT. ROOM - NIGHT\n\nThe midpoint shift.")
       approve_version(p3, v3)
 
@@ -128,8 +128,8 @@ defmodule StoryboxWeb.TreatmentViewTest do
       story: story,
       raw_token: raw_token
     } do
-      create_piece(story, %{title: "Unassigned", act: nil, position: 1})
-      create_piece(story, %{title: "First Act", act: "Act I", position: 1})
+      create_treatment_view(story, %{title: "Unassigned", act: nil, position: 1})
+      create_treatment_view(story, %{title: "First Act", act: "Act I", position: 1})
 
       conn = conn |> authed(raw_token) |> get("/api/stories/#{story.id}/views/treatment")
 
@@ -145,9 +145,9 @@ defmodule StoryboxWeb.TreatmentViewTest do
       story: story,
       raw_token: raw_token
     } do
-      create_piece(story, %{title: "Third", act: "Act I", position: 3})
-      create_piece(story, %{title: "First", act: "Act I", position: 1})
-      create_piece(story, %{title: "Second", act: "Act I", position: 2})
+      create_treatment_view(story, %{title: "Third", act: "Act I", position: 3})
+      create_treatment_view(story, %{title: "First", act: "Act I", position: 1})
+      create_treatment_view(story, %{title: "Second", act: "Act I", position: 2})
 
       conn = conn |> authed(raw_token) |> get("/api/stories/#{story.id}/views/treatment")
 
@@ -160,7 +160,7 @@ defmodule StoryboxWeb.TreatmentViewTest do
       story: story,
       raw_token: raw_token
     } do
-      p = create_piece(story, %{title: "Scene", act: "Act I", position: 1})
+      p = create_treatment_view(story, %{title: "Scene", act: "Act I", position: 1})
       v = create_version(p, "content")
       approve_version(p, v)
 
@@ -213,7 +213,7 @@ defmodule StoryboxWeb.TreatmentViewTest do
         })
         |> Ash.create(authorize?: false)
 
-      p = create_piece(story, %{title: "Opening", act: "Act I", position: 1})
+      p = create_treatment_view(story, %{title: "Opening", act: "Act I", position: 1})
       v = create_version(p, "EXT. FOREST - DAY\n\nJane walks alone.")
       approve_version(p, v)
 
@@ -246,7 +246,7 @@ defmodule StoryboxWeb.TreatmentViewTest do
       story: story,
       raw_token: raw_token
     } do
-      p = create_piece(story, %{title: "Draft", act: "Act I", position: 1})
+      p = create_treatment_view(story, %{title: "Draft", act: "Act I", position: 1})
       create_version(p, "First draft content.")
       create_version(p, "Second draft content.")
 
@@ -266,12 +266,12 @@ defmodule StoryboxWeb.TreatmentViewTest do
       other_story: other_story,
       raw_token: raw_token
     } do
-      other_piece = create_piece(other_story, %{title: "Foreign", act: nil, position: 1})
+      other_view = create_treatment_view(other_story, %{title: "Foreign", act: nil, position: 1})
 
       conn =
         conn
         |> authed(raw_token)
-        |> get("/api/stories/#{story.id}/sequences/#{other_piece.id}")
+        |> get("/api/stories/#{story.id}/sequences/#{other_view.id}")
 
       assert json_response(conn, 404)["error"] == "not found"
     end
@@ -281,7 +281,7 @@ defmodule StoryboxWeb.TreatmentViewTest do
       story: story,
       raw_token: raw_token
     } do
-      p = create_piece(story, %{title: "Empty", act: nil, position: 1})
+      p = create_treatment_view(story, %{title: "Empty", act: nil, position: 1})
 
       conn =
         conn
@@ -296,12 +296,12 @@ defmodule StoryboxWeb.TreatmentViewTest do
       story: story,
       raw_token: raw_token
     } do
-      p = create_piece(story, %{title: "Broken", act: nil, position: 1})
+      p = create_treatment_view(story, %{title: "Broken", act: nil, position: 1})
 
       {:ok, bad_version} =
-        Storybox.Stories.SequenceVersion
+        Storybox.Stories.TreatmentPiece
         |> Ash.Changeset.for_create(:create, %{
-          sequence_piece_id: p.id,
+          treatment_view_id: p.id,
           content_uri:
             "storybox://stories/#{story.id}/sequences/#{p.id}/v999_nonexistent.fountain",
           version_number: 1,

--- a/test/storybox_web/controllers/upstream_changes_test.exs
+++ b/test/storybox_web/controllers/upstream_changes_test.exs
@@ -5,9 +5,9 @@ defmodule StoryboxWeb.UpstreamChangesTest do
 
   # Shared setup creates:
   #
-  #   user ──── story ──── seq_1 ──── seq_v1 ──► UC1 (acknowledged: false, component_type: :character)
-  #                         └─── scene_1 ── scene_v1 ──► UC2 (acknowledged: true,  component_type: :world)
-  #          └── other_story ──── other_seq ──── other_seq_v1 ──► other_UC (acknowledged: false)
+  #   user ──── story ──── tv_1 ──── tp_v1 ──► UC1 (acknowledged: false, component_type: :character)
+  #                         └─── sv_1 ── sp_v1 ──► UC2 (acknowledged: true,  component_type: :world)
+  #          └── other_story ──── other_tv ──── other_tp_v1 ──► other_UC (acknowledged: false)
   #
   # raw_token is scoped to story.
   # UC1 must appear in responses; UC2 must not (acknowledged). other_UC must not (wrong story).
@@ -34,20 +34,20 @@ defmodule StoryboxWeb.UpstreamChangesTest do
 
     {:ok, raw_token, _} = ApiToken.generate(%{story_id: story.id, user_id: user.id})
 
-    {:ok, seq_1} =
-      Storybox.Stories.SequencePiece
+    {:ok, tv_1} =
+      Storybox.Stories.TreatmentView
       |> Ash.Changeset.for_create(:create, %{
-        title: "Act I Seq",
+        title: "Act I",
         act: "Act I",
         position: 1,
         story_id: story.id
       })
       |> Ash.create(authorize?: false)
 
-    {:ok, seq_v1} =
-      Storybox.Stories.SequenceVersion
+    {:ok, tp_v1} =
+      Storybox.Stories.TreatmentPiece
       |> Ash.Changeset.for_create(:create, %{
-        sequence_piece_id: seq_1.id,
+        treatment_view_id: tv_1.id,
         content_uri: "storybox://test/seq/v1.fountain",
         version_number: 1,
         upstream_status: :stale,
@@ -55,19 +55,19 @@ defmodule StoryboxWeb.UpstreamChangesTest do
       })
       |> Ash.create(authorize?: false)
 
-    {:ok, scene_1} =
-      Storybox.Stories.ScenePiece
+    {:ok, sv_1} =
+      Storybox.Stories.ScriptView
       |> Ash.Changeset.for_create(:create, %{
         title: "Scene 1",
         position: 1,
-        sequence_piece_id: seq_1.id
+        treatment_view_id: tv_1.id
       })
       |> Ash.create(authorize?: false)
 
-    {:ok, scene_v1} =
-      Storybox.Stories.SceneVersion
+    {:ok, sp_v1} =
+      Storybox.Stories.ScriptPiece
       |> Ash.Changeset.for_create(:create, %{
-        scene_piece_id: scene_1.id,
+        script_view_id: sv_1.id,
         content_uri: "storybox://test/scene/v1.fountain",
         version_number: 1,
         upstream_status: :stale,
@@ -75,12 +75,12 @@ defmodule StoryboxWeb.UpstreamChangesTest do
       })
       |> Ash.create(authorize?: false)
 
-    # UC1 — unacknowledged, on seq_v1 (should appear in responses)
+    # UC1 — unacknowledged, on tp_v1 (should appear in responses)
     {:ok, uc1} =
       Storybox.Stories.UpstreamChange
       |> Ash.Changeset.for_create(:create, %{
-        piece_version_type: :sequence_version,
-        piece_version_id: seq_v1.id,
+        piece_version_type: :treatment_piece,
+        piece_version_id: tp_v1.id,
         component_type: :character,
         component_id: story.id,
         version_before: "v1",
@@ -88,12 +88,12 @@ defmodule StoryboxWeb.UpstreamChangesTest do
       })
       |> Ash.create(authorize?: false)
 
-    # UC2 — acknowledged, on scene_v1 (must NOT appear in responses)
+    # UC2 — acknowledged, on sp_v1 (must NOT appear in responses)
     {:ok, uc2} =
       Storybox.Stories.UpstreamChange
       |> Ash.Changeset.for_create(:create, %{
-        piece_version_type: :scene_version,
-        piece_version_id: scene_v1.id,
+        piece_version_type: :script_piece,
+        piece_version_id: sp_v1.id,
         component_type: :world,
         component_id: story.id
       })
@@ -105,19 +105,19 @@ defmodule StoryboxWeb.UpstreamChangesTest do
       |> Ash.update(authorize?: false)
 
     # other_UC — unacknowledged, but belongs to other_story's version (must NOT appear)
-    {:ok, other_seq} =
-      Storybox.Stories.SequencePiece
+    {:ok, other_tv} =
+      Storybox.Stories.TreatmentView
       |> Ash.Changeset.for_create(:create, %{
-        title: "Other Seq",
+        title: "Other Act",
         position: 1,
         story_id: other_story.id
       })
       |> Ash.create(authorize?: false)
 
-    {:ok, other_seq_v1} =
-      Storybox.Stories.SequenceVersion
+    {:ok, other_tp_v1} =
+      Storybox.Stories.TreatmentPiece
       |> Ash.Changeset.for_create(:create, %{
-        sequence_piece_id: other_seq.id,
+        treatment_view_id: other_tv.id,
         content_uri: "storybox://test/other/v1.fountain",
         version_number: 1,
         upstream_status: :stale,
@@ -128,8 +128,8 @@ defmodule StoryboxWeb.UpstreamChangesTest do
     {:ok, _other_uc} =
       Storybox.Stories.UpstreamChange
       |> Ash.Changeset.for_create(:create, %{
-        piece_version_type: :sequence_version,
-        piece_version_id: other_seq_v1.id,
+        piece_version_type: :treatment_piece,
+        piece_version_id: other_tp_v1.id,
         component_type: :story,
         component_id: other_story.id
       })
@@ -137,7 +137,7 @@ defmodule StoryboxWeb.UpstreamChangesTest do
 
     %{
       story: story,
-      seq_v1: seq_v1,
+      tp_v1: tp_v1,
       uc1: uc1,
       raw_token: raw_token
     }
@@ -179,7 +179,7 @@ defmodule StoryboxWeb.UpstreamChangesTest do
       conn: conn,
       story: story,
       uc1: uc1,
-      seq_v1: seq_v1,
+      tp_v1: tp_v1,
       raw_token: raw_token
     } do
       conn =
@@ -190,8 +190,8 @@ defmodule StoryboxWeb.UpstreamChangesTest do
       [change] = json_response(conn, 200)["changes"]
 
       assert change["id"] == uc1.id
-      assert change["piece_version_type"] == "sequence_version"
-      assert change["piece_version_id"] == seq_v1.id
+      assert change["piece_version_type"] == "treatment_piece"
+      assert change["piece_version_id"] == tp_v1.id
       assert change["component_type"] == "character"
       assert change["version_before"] == "v1"
       assert change["version_after"] == "v2"

--- a/test/storybox_web/live/scene_compare_live_test.exs
+++ b/test/storybox_web/live/scene_compare_live_test.exs
@@ -55,7 +55,7 @@ defmodule StoryboxWeb.SceneCompareLiveTest do
       |> Ash.create()
 
     {:ok, seq} =
-      Storybox.Stories.SequencePiece
+      Storybox.Stories.TreatmentView
       |> Ash.Changeset.for_create(:create, %{
         title: "Seq One",
         position: 1,
@@ -65,18 +65,18 @@ defmodule StoryboxWeb.SceneCompareLiveTest do
 
     # Scene Alpha — two versions, approved → v1
     {:ok, scene_alpha} =
-      Storybox.Stories.ScenePiece
+      Storybox.Stories.ScriptView
       |> Ash.Changeset.for_create(:create, %{
         title: "Scene Alpha",
         position: 1,
-        sequence_piece_id: seq.id
+        treatment_view_id: seq.id
       })
       |> Ash.create()
 
     {:ok, sv1} =
-      Storybox.Stories.SceneVersion
+      Storybox.Stories.ScriptPiece
       |> Ash.Changeset.for_create(:create, %{
-        scene_piece_id: scene_alpha.id,
+        script_view_id: scene_alpha.id,
         content_uri: "storybox://test/alpha/v1",
         version_number: 1,
         upstream_status: :current,
@@ -85,9 +85,9 @@ defmodule StoryboxWeb.SceneCompareLiveTest do
       |> Ash.create()
 
     {:ok, sv2} =
-      Storybox.Stories.SceneVersion
+      Storybox.Stories.ScriptPiece
       |> Ash.Changeset.for_create(:create, %{
-        scene_piece_id: scene_alpha.id,
+        script_view_id: scene_alpha.id,
         content_uri: "storybox://test/alpha/v2",
         version_number: 2,
         upstream_status: :stale,
@@ -102,18 +102,18 @@ defmodule StoryboxWeb.SceneCompareLiveTest do
 
     # Scene Beta — one version, no approved pointer
     {:ok, scene_beta} =
-      Storybox.Stories.ScenePiece
+      Storybox.Stories.ScriptView
       |> Ash.Changeset.for_create(:create, %{
         title: "Scene Beta",
         position: 2,
-        sequence_piece_id: seq.id
+        treatment_view_id: seq.id
       })
       |> Ash.create()
 
     {:ok, sv3} =
-      Storybox.Stories.SceneVersion
+      Storybox.Stories.ScriptPiece
       |> Ash.Changeset.for_create(:create, %{
-        scene_piece_id: scene_beta.id,
+        script_view_id: scene_beta.id,
         content_uri: "storybox://test/beta/v1",
         version_number: 1,
         upstream_status: :current,
@@ -123,11 +123,11 @@ defmodule StoryboxWeb.SceneCompareLiveTest do
 
     # Scene Gamma — no versions
     {:ok, scene_gamma} =
-      Storybox.Stories.ScenePiece
+      Storybox.Stories.ScriptView
       |> Ash.Changeset.for_create(:create, %{
         title: "Scene Gamma",
         position: 3,
-        sequence_piece_id: seq.id
+        treatment_view_id: seq.id
       })
       |> Ash.create()
 
@@ -311,7 +311,7 @@ defmodule StoryboxWeb.SceneCompareLiveTest do
 
       # DB pointer is updated
       updated =
-        Storybox.Stories.ScenePiece
+        Storybox.Stories.ScriptView
         |> Ash.Query.filter(id == ^scene.id)
         |> Ash.read_one!(authorize?: false)
 

--- a/test/storybox_web/live/script_live_test.exs
+++ b/test/storybox_web/live/script_live_test.exs
@@ -8,12 +8,12 @@ defmodule StoryboxWeb.ScriptLiveTest do
   # Seed data graph:
   #
   #   alice ──► "The Illusionist"  (through_lines: ["preference"])
-  #               └── Sequence "Act 1"  pos 1
-  #                     ├── Scene "Opening"  pos 1  approved → nil
-  #                     │     ├── v1  weights: {}      status: current
-  #                     │     └── v2  weights: {}      status: current
-  #                     └── Scene "Confrontation"  pos 2  approved → v1
-  #                           └── v1  weights: {preference→0.9}  status: current  [approved]
+  #               └── TreatmentView "Act 1"  pos 1
+  #                     ├── ScriptView "Opening"  pos 1  approved → nil
+  #                     │     ├── sp_v1  weights: {}      status: current
+  #                     │     └── sp_v2  weights: {}      status: current
+  #                     └── ScriptView "Confrontation"  pos 2  approved → sp_v1
+  #                           └── sp_v1  weights: {preference→0.9}  status: current  [approved]
 
   setup do
     {:ok, alice} =
@@ -34,8 +34,8 @@ defmodule StoryboxWeb.ScriptLiveTest do
       })
       |> Ash.create()
 
-    {:ok, sequence} =
-      Storybox.Stories.SequencePiece
+    {:ok, treatment_view} =
+      Storybox.Stories.TreatmentView
       |> Ash.Changeset.for_create(:create, %{
         title: "Act 1",
         position: 1,
@@ -43,20 +43,20 @@ defmodule StoryboxWeb.ScriptLiveTest do
       })
       |> Ash.create()
 
-    # Scene "Opening" — two versions, no approved
-    {:ok, scene_opening} =
-      Storybox.Stories.ScenePiece
+    # ScriptView "Opening" — two versions, no approved
+    {:ok, sv_opening} =
+      Storybox.Stories.ScriptView
       |> Ash.Changeset.for_create(:create, %{
         title: "Opening",
         position: 1,
-        sequence_piece_id: sequence.id
+        treatment_view_id: treatment_view.id
       })
       |> Ash.create()
 
     {:ok, opening_v1} =
-      Storybox.Stories.SceneVersion
+      Storybox.Stories.ScriptPiece
       |> Ash.Changeset.for_create(:create, %{
-        scene_piece_id: scene_opening.id,
+        script_view_id: sv_opening.id,
         content_uri: "storybox://test/opening/v1",
         version_number: 1,
         upstream_status: :current,
@@ -65,9 +65,9 @@ defmodule StoryboxWeb.ScriptLiveTest do
       |> Ash.create()
 
     {:ok, opening_v2} =
-      Storybox.Stories.SceneVersion
+      Storybox.Stories.ScriptPiece
       |> Ash.Changeset.for_create(:create, %{
-        scene_piece_id: scene_opening.id,
+        script_view_id: sv_opening.id,
         content_uri: "storybox://test/opening/v2",
         version_number: 2,
         upstream_status: :current,
@@ -75,20 +75,20 @@ defmodule StoryboxWeb.ScriptLiveTest do
       })
       |> Ash.create()
 
-    # Scene "Confrontation" — one version, approved, already reviewed
-    {:ok, scene_confrontation} =
-      Storybox.Stories.ScenePiece
+    # ScriptView "Confrontation" — one version, approved, already reviewed
+    {:ok, sv_confrontation} =
+      Storybox.Stories.ScriptView
       |> Ash.Changeset.for_create(:create, %{
         title: "Confrontation",
         position: 2,
-        sequence_piece_id: sequence.id
+        treatment_view_id: treatment_view.id
       })
       |> Ash.create()
 
     {:ok, confrontation_v1} =
-      Storybox.Stories.SceneVersion
+      Storybox.Stories.ScriptPiece
       |> Ash.Changeset.for_create(:create, %{
-        scene_piece_id: scene_confrontation.id,
+        script_view_id: sv_confrontation.id,
         content_uri: "storybox://test/confrontation/v1",
         version_number: 1,
         upstream_status: :current,
@@ -96,19 +96,19 @@ defmodule StoryboxWeb.ScriptLiveTest do
       })
       |> Ash.create()
 
-    {:ok, scene_confrontation} =
-      scene_confrontation
+    {:ok, sv_confrontation} =
+      sv_confrontation
       |> Ash.Changeset.for_update(:approve_version, %{version_id: confrontation_v1.id})
       |> Ash.update()
 
     %{
       alice: alice,
       story: story,
-      sequence: sequence,
-      scene_opening: scene_opening,
+      treatment_view: treatment_view,
+      sv_opening: sv_opening,
       opening_v1: opening_v1,
       opening_v2: opening_v2,
-      scene_confrontation: scene_confrontation,
+      sv_confrontation: sv_confrontation,
       confrontation_v1: confrontation_v1
     }
   end
@@ -118,10 +118,12 @@ defmodule StoryboxWeb.ScriptLiveTest do
       conn: conn,
       alice: alice,
       story: story,
-      sequence: sequence
+      treatment_view: treatment_view
     } do
       conn = log_in_user(conn, alice)
-      {:ok, _view, html} = live(conn, "/stories/#{story.id}/sequences/#{sequence.id}/script")
+
+      {:ok, _view, html} =
+        live(conn, "/stories/#{story.id}/sequences/#{treatment_view.id}/script")
 
       assert html =~ "ring-warning"
     end
@@ -130,11 +132,13 @@ defmodule StoryboxWeb.ScriptLiveTest do
       conn: conn,
       alice: alice,
       story: story,
-      sequence: sequence,
+      treatment_view: treatment_view,
       opening_v2: opening_v2
     } do
       conn = log_in_user(conn, alice)
-      {:ok, view, _html} = live(conn, "/stories/#{story.id}/sequences/#{sequence.id}/script")
+
+      {:ok, view, _html} =
+        live(conn, "/stories/#{story.id}/sequences/#{treatment_view.id}/script")
 
       html =
         view
@@ -151,11 +155,13 @@ defmodule StoryboxWeb.ScriptLiveTest do
       conn: conn,
       alice: alice,
       story: story,
-      sequence: sequence,
+      treatment_view: treatment_view,
       opening_v2: opening_v2
     } do
       conn = log_in_user(conn, alice)
-      {:ok, view, _html} = live(conn, "/stories/#{story.id}/sequences/#{sequence.id}/script")
+
+      {:ok, view, _html} =
+        live(conn, "/stories/#{story.id}/sequences/#{treatment_view.id}/script")
 
       # Open the form on the latest version (v2)
       view
@@ -175,7 +181,7 @@ defmodule StoryboxWeb.ScriptLiveTest do
 
       # Persisted in DB
       updated =
-        Storybox.Stories.SceneVersion
+        Storybox.Stories.ScriptPiece
         |> Ash.Query.filter(id == ^opening_v2.id)
         |> Ash.read_one!(authorize?: false)
 

--- a/test/storybox_web/live/story_overview_live_test.exs
+++ b/test/storybox_web/live/story_overview_live_test.exs
@@ -75,7 +75,7 @@ defmodule StoryboxWeb.StoryOverviewLiveTest do
       |> Ash.create()
 
     {:ok, sv1} =
-      Storybox.Stories.SynopsisVersion
+      Storybox.Stories.SynopsisView
       |> Ash.Changeset.for_create(:create, %{
         story_id: story.id,
         content_uri: "storybox://stories/#{story.id}/synopsis/v1",
@@ -84,7 +84,7 @@ defmodule StoryboxWeb.StoryOverviewLiveTest do
       |> Ash.create()
 
     {:ok, sv2} =
-      Storybox.Stories.SynopsisVersion
+      Storybox.Stories.SynopsisView
       |> Ash.Changeset.for_create(:create, %{
         story_id: story.id,
         content_uri: "storybox://stories/#{story.id}/synopsis/v2",

--- a/test/storybox_web/live/treatment_live_test.exs
+++ b/test/storybox_web/live/treatment_live_test.exs
@@ -61,7 +61,7 @@ defmodule StoryboxWeb.TreatmentLiveTest do
 
     # Act 1 — "The Reveal" (pos 1), approved → v1
     {:ok, piece_reveal} =
-      Storybox.Stories.SequencePiece
+      Storybox.Stories.TreatmentView
       |> Ash.Changeset.for_create(:create, %{
         title: "The Reveal",
         act: "Act 1",
@@ -71,9 +71,9 @@ defmodule StoryboxWeb.TreatmentLiveTest do
       |> Ash.create()
 
     {:ok, reveal_v1} =
-      Storybox.Stories.SequenceVersion
+      Storybox.Stories.TreatmentPiece
       |> Ash.Changeset.for_create(:create, %{
-        sequence_piece_id: piece_reveal.id,
+        treatment_view_id: piece_reveal.id,
         content_uri: "storybox://test/reveal/v1",
         version_number: 1,
         upstream_status: :current,
@@ -82,9 +82,9 @@ defmodule StoryboxWeb.TreatmentLiveTest do
       |> Ash.create()
 
     {:ok, reveal_v2} =
-      Storybox.Stories.SequenceVersion
+      Storybox.Stories.TreatmentPiece
       |> Ash.Changeset.for_create(:create, %{
-        sequence_piece_id: piece_reveal.id,
+        treatment_view_id: piece_reveal.id,
         content_uri: "storybox://test/reveal/v2",
         version_number: 2,
         upstream_status: :stale,
@@ -99,7 +99,7 @@ defmodule StoryboxWeb.TreatmentLiveTest do
 
     # Act 1 — "The Escape" (pos 2), no approved version
     {:ok, piece_escape} =
-      Storybox.Stories.SequencePiece
+      Storybox.Stories.TreatmentView
       |> Ash.Changeset.for_create(:create, %{
         title: "The Escape",
         act: "Act 1",
@@ -109,9 +109,9 @@ defmodule StoryboxWeb.TreatmentLiveTest do
       |> Ash.create()
 
     {:ok, escape_v1} =
-      Storybox.Stories.SequenceVersion
+      Storybox.Stories.TreatmentPiece
       |> Ash.Changeset.for_create(:create, %{
-        sequence_piece_id: piece_escape.id,
+        treatment_view_id: piece_escape.id,
         content_uri: "storybox://test/escape/v1",
         version_number: 1,
         upstream_status: :current,
@@ -121,7 +121,7 @@ defmodule StoryboxWeb.TreatmentLiveTest do
 
     # Act 2 — "Fallout" (pos 3), approved → v3
     {:ok, piece_fallout} =
-      Storybox.Stories.SequencePiece
+      Storybox.Stories.TreatmentView
       |> Ash.Changeset.for_create(:create, %{
         title: "Fallout",
         act: "Act 2",
@@ -131,9 +131,9 @@ defmodule StoryboxWeb.TreatmentLiveTest do
       |> Ash.create()
 
     {:ok, fallout_v3} =
-      Storybox.Stories.SequenceVersion
+      Storybox.Stories.TreatmentPiece
       |> Ash.Changeset.for_create(:create, %{
-        sequence_piece_id: piece_fallout.id,
+        treatment_view_id: piece_fallout.id,
         content_uri: "storybox://test/fallout/v3",
         version_number: 3,
         upstream_status: :current,
@@ -148,7 +148,7 @@ defmodule StoryboxWeb.TreatmentLiveTest do
 
     # No act — "Coda" (pos 4), no versions
     {:ok, piece_coda} =
-      Storybox.Stories.SequencePiece
+      Storybox.Stories.TreatmentView
       |> Ash.Changeset.for_create(:create, %{
         title: "Coda",
         act: nil,
@@ -357,7 +357,7 @@ defmodule StoryboxWeb.TreatmentLiveTest do
 
       # v2 is now marked approved in DB
       updated_piece =
-        Storybox.Stories.SequencePiece
+        Storybox.Stories.TreatmentView
         |> Ash.Query.filter(id == ^piece_reveal.id)
         |> Ash.read_one!(authorize?: false)
 
@@ -384,7 +384,7 @@ defmodule StoryboxWeb.TreatmentLiveTest do
       |> render_click()
 
       updated_fallout =
-        Storybox.Stories.SequencePiece
+        Storybox.Stories.TreatmentView
         |> Ash.Query.filter(id == ^piece_fallout.id)
         |> Ash.read_one!(authorize?: false)
 
@@ -465,7 +465,7 @@ defmodule StoryboxWeb.TreatmentLiveTest do
 
       # Weights persisted in DB
       updated =
-        Storybox.Stories.SequenceVersion
+        Storybox.Stories.TreatmentPiece
         |> Ash.Query.filter(id == ^reveal_v2.id)
         |> Ash.read_one!(authorize?: false)
 


### PR DESCRIPTION
## Summary

- Renames all Ash resources to align with the M5 two-level model: `ScenePiece` → `ScriptView`, `SceneVersion` → `ScriptPiece`, `SequencePiece` → `TreatmentView`, `SequenceVersion` → `TreatmentPiece`, `SynopsisVersion` → `SynopsisView`
- Hand-crafted Ecto migration renames the 5 tables and 3 FK columns in place (no drop/recreate)
- Updates `UpstreamChange.piece_version_type` constraint atoms from `:sequence_version`/`:scene_version` to `:treatment_piece`/`:script_piece`
- All 34 affected files updated: Ash resources, notifier, web/live controllers, all tests, seeds, and `docs/data_model.md`

## Test plan

- [x] `mix precommit` passes — 231 tests, 0 failures
- [x] Live scene manually tested by user
- [ ] Verify `mix setup` (seeds) runs cleanly against a fresh DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)