### PR TITLE
fix: repair Ash resource snapshot drift on main (#105)

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ POST /api/stories/:id/views/script/scenes/:scene_id/versions
 ## Dev Setup
 
 ```bash
-podman-compose up -d
+podman compose -f podman-compose.yml up -d
 ```
 
 Services: `app` (Phoenix on :4000), `db` (PostgreSQL on :5432), `minio` (S3 on :9000, console on :9001).

--- a/docs/dev_setup.md
+++ b/docs/dev_setup.md
@@ -2,13 +2,13 @@
 
 ## Prerequisites
 
-- [Podman](https://podman.io/) + podman-compose
+- [Podman](https://podman.io/) v5+ (the built-in `podman compose` subcommand replaces the legacy `podman-compose` Python wrapper; commands below pass `-f podman-compose.yml` because the file uses that name rather than the default `compose.yml`)
 - (The Elixir app runs inside the container — no local Elixir install needed)
 
 ## Start Services
 
 ```bash
-podman-compose up -d
+podman compose -f podman-compose.yml up -d
 ```
 
 This starts three services:
@@ -40,8 +40,8 @@ password: storybox
 ## App Setup (once scaffolded)
 
 ```bash
-podman-compose run app mix setup
-podman-compose run app mix phx.server
+podman compose -f podman-compose.yml run app mix setup
+podman compose -f podman-compose.yml run app mix phx.server
 ```
 
 ## Environment Variables

--- a/priv/repo/migrations/20260429110942_sync_snapshot_drift.exs
+++ b/priv/repo/migrations/20260429110942_sync_snapshot_drift.exs
@@ -1,0 +1,27 @@
+defmodule Storybox.Repo.Migrations.SyncSnapshotDrift do
+  @moduledoc """
+  Snapshot reconciliation only — see issue #105.
+
+  Codegen wanted to emit FK constraint renames (treatment_views, treatment_pieces,
+  synopsis_views, script_pieces) and a `script_views` column swap (drop position +
+  treatment_view_id, add scene_id). The DB already has all of those changes,
+  applied by:
+
+    - 20260426090910_scene_component        (FK renames; script_views columns)
+    - 20260426120000_rename_piece_version_vocabulary
+                                            (table renames; PG auto-renamed FK identifiers)
+
+  This migration exists only so the regenerated snapshots have an applied
+  timestamp to anchor against. It is intentionally a no-op.
+  """
+
+  use Ecto.Migration
+
+  def up do
+    :ok
+  end
+
+  def down do
+    :ok
+  end
+end

--- a/priv/resource_snapshots/repo/script_pieces/20260429110943.json
+++ b/priv/resource_snapshots/repo/script_pieces/20260429110943.json
@@ -21,7 +21,7 @@
       "references": null,
       "scale": null,
       "size": null,
-      "source": "title",
+      "source": "content_uri",
       "type": "text"
     },
     {
@@ -33,20 +33,32 @@
       "references": null,
       "scale": null,
       "size": null,
-      "source": "position",
+      "source": "version_number",
       "type": "bigint"
     },
     {
       "allow_nil?": true,
-      "default": "nil",
+      "default": "%{}",
       "generated?": false,
       "precision": null,
       "primary_key?": false,
       "references": null,
       "scale": null,
       "size": null,
-      "source": "approved_version_id",
-      "type": "uuid"
+      "source": "weights",
+      "type": "map"
+    },
+    {
+      "allow_nil?": false,
+      "default": "\"current\"",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "upstream_status",
+      "type": "text"
     },
     {
       "allow_nil?": false,
@@ -58,18 +70,6 @@
       "scale": null,
       "size": null,
       "source": "inserted_at",
-      "type": "utc_datetime_usec"
-    },
-    {
-      "allow_nil?": false,
-      "default": "fragment(\"(now() AT TIME ZONE 'utc')\")",
-      "generated?": false,
-      "precision": null,
-      "primary_key?": false,
-      "references": null,
-      "scale": null,
-      "size": null,
-      "source": "updated_at",
       "type": "utc_datetime_usec"
     },
     {
@@ -91,16 +91,16 @@
           "global": null,
           "strategy": null
         },
-        "name": "scene_pieces_sequence_piece_id_fkey",
+        "name": "script_pieces_script_view_id_fkey",
         "on_delete": null,
         "on_update": null,
         "primary_key?": true,
         "schema": "public",
-        "table": "sequence_pieces"
+        "table": "script_views"
       },
       "scale": null,
       "size": null,
-      "source": "sequence_piece_id",
+      "source": "script_view_id",
       "type": "uuid"
     }
   ],
@@ -110,7 +110,7 @@
   "custom_indexes": [],
   "custom_statements": [],
   "has_create_action": true,
-  "hash": "028A3D4517D95D96D4C7837E9638727771738FB6B322BDC40E5A5380A062C702",
+  "hash": "4A29E902FB737716391D052F13CC5EA6C7131A55381835AD4B0DBA19C7BF71D4",
   "identities": [],
   "multitenancy": {
     "attribute": null,
@@ -119,5 +119,5 @@
   },
   "repo": "Elixir.Storybox.Repo",
   "schema": null,
-  "table": "scene_pieces"
+  "table": "script_pieces"
 }

--- a/priv/resource_snapshots/repo/script_views/20260429110944.json
+++ b/priv/resource_snapshots/repo/script_views/20260429110944.json
@@ -21,11 +21,11 @@
       "references": null,
       "scale": null,
       "size": null,
-      "source": "content_uri",
+      "source": "title",
       "type": "text"
     },
     {
-      "allow_nil?": false,
+      "allow_nil?": true,
       "default": "nil",
       "generated?": false,
       "precision": null,
@@ -33,32 +33,8 @@
       "references": null,
       "scale": null,
       "size": null,
-      "source": "version_number",
-      "type": "bigint"
-    },
-    {
-      "allow_nil?": true,
-      "default": "%{}",
-      "generated?": false,
-      "precision": null,
-      "primary_key?": false,
-      "references": null,
-      "scale": null,
-      "size": null,
-      "source": "weights",
-      "type": "map"
-    },
-    {
-      "allow_nil?": false,
-      "default": "\"current\"",
-      "generated?": false,
-      "precision": null,
-      "primary_key?": false,
-      "references": null,
-      "scale": null,
-      "size": null,
-      "source": "upstream_status",
-      "type": "text"
+      "source": "approved_version_id",
+      "type": "uuid"
     },
     {
       "allow_nil?": false,
@@ -70,6 +46,18 @@
       "scale": null,
       "size": null,
       "source": "inserted_at",
+      "type": "utc_datetime_usec"
+    },
+    {
+      "allow_nil?": false,
+      "default": "fragment(\"(now() AT TIME ZONE 'utc')\")",
+      "generated?": false,
+      "precision": null,
+      "primary_key?": false,
+      "references": null,
+      "scale": null,
+      "size": null,
+      "source": "updated_at",
       "type": "utc_datetime_usec"
     },
     {
@@ -91,16 +79,16 @@
           "global": null,
           "strategy": null
         },
-        "name": "scene_versions_scene_piece_id_fkey",
+        "name": "script_views_scene_id_fkey",
         "on_delete": null,
         "on_update": null,
         "primary_key?": true,
         "schema": "public",
-        "table": "scene_pieces"
+        "table": "scenes"
       },
       "scale": null,
       "size": null,
-      "source": "scene_piece_id",
+      "source": "scene_id",
       "type": "uuid"
     }
   ],
@@ -110,7 +98,7 @@
   "custom_indexes": [],
   "custom_statements": [],
   "has_create_action": true,
-  "hash": "2C9DAB15C9B9ADCF73B295FFD22B785D641D53EB0BFB65B312D6E04F489E301E",
+  "hash": "D941C52563245ED8C6B35F2CAAB4BDEE3FFE9F8A61C53D84AFC80A2BBFB7DB3C",
   "identities": [],
   "multitenancy": {
     "attribute": null,
@@ -119,5 +107,5 @@
   },
   "repo": "Elixir.Storybox.Repo",
   "schema": null,
-  "table": "scene_versions"
+  "table": "script_views"
 }

--- a/priv/resource_snapshots/repo/synopsis_views/20260429110945.json
+++ b/priv/resource_snapshots/repo/synopsis_views/20260429110945.json
@@ -67,7 +67,7 @@
           "global": null,
           "strategy": null
         },
-        "name": "synopsis_versions_story_id_fkey",
+        "name": "synopsis_views_story_id_fkey",
         "on_delete": null,
         "on_update": null,
         "primary_key?": true,
@@ -86,7 +86,7 @@
   "custom_indexes": [],
   "custom_statements": [],
   "has_create_action": true,
-  "hash": "183C01507D46139153D524B6F2A4B15C0FAB9C3D0EB9AD526CC044D387AA8C18",
+  "hash": "1F48062AAF5A364D133A1763E3D848EB9768221D781879364B33F1D69BFCB580",
   "identities": [],
   "multitenancy": {
     "attribute": null,
@@ -95,5 +95,5 @@
   },
   "repo": "Elixir.Storybox.Repo",
   "schema": null,
-  "table": "synopsis_versions"
+  "table": "synopsis_views"
 }

--- a/priv/resource_snapshots/repo/treatment_pieces/20260429110946.json
+++ b/priv/resource_snapshots/repo/treatment_pieces/20260429110946.json
@@ -91,16 +91,16 @@
           "global": null,
           "strategy": null
         },
-        "name": "sequence_versions_sequence_piece_id_fkey",
+        "name": "treatment_pieces_treatment_view_id_fkey",
         "on_delete": null,
         "on_update": null,
         "primary_key?": true,
         "schema": "public",
-        "table": "sequence_pieces"
+        "table": "treatment_views"
       },
       "scale": null,
       "size": null,
-      "source": "sequence_piece_id",
+      "source": "treatment_view_id",
       "type": "uuid"
     }
   ],
@@ -110,7 +110,7 @@
   "custom_indexes": [],
   "custom_statements": [],
   "has_create_action": true,
-  "hash": "D66039EEC8712BED0C2DE6058A3B7D80A9B156832ACDEBBBA7EE7CAC6E6227F3",
+  "hash": "A0CD2A60689D8F3F27700646A8BC7CB674220A002F42A0C2D2845D1E8075322F",
   "identities": [],
   "multitenancy": {
     "attribute": null,
@@ -119,5 +119,5 @@
   },
   "repo": "Elixir.Storybox.Repo",
   "schema": null,
-  "table": "sequence_versions"
+  "table": "treatment_pieces"
 }

--- a/priv/resource_snapshots/repo/treatment_views/20260429110947.json
+++ b/priv/resource_snapshots/repo/treatment_views/20260429110947.json
@@ -103,7 +103,7 @@
           "global": null,
           "strategy": null
         },
-        "name": "sequence_pieces_story_id_fkey",
+        "name": "treatment_views_story_id_fkey",
         "on_delete": null,
         "on_update": null,
         "primary_key?": true,
@@ -122,7 +122,7 @@
   "custom_indexes": [],
   "custom_statements": [],
   "has_create_action": true,
-  "hash": "3A5F4359E23922EA9ED41653B3F7B1B2420B817B02F6721B01C5ED7E80ED146B",
+  "hash": "4DF0BE95655448E7061258638A71C9CC16B51A38491EBA952DAC07183B3994DD",
   "identities": [],
   "multitenancy": {
     "attribute": null,
@@ -131,5 +131,5 @@
   },
   "repo": "Elixir.Storybox.Repo",
   "schema": null,
-  "table": "sequence_pieces"
+  "table": "treatment_views"
 }


### PR DESCRIPTION
## Summary
- Reconciles `priv/resource_snapshots/` with the actual Postgres schema produced by all migrations through `20260426120000`. After this lands, `mix ash.codegen <anything>` against a clean DB produces "No changes detected".
- Pure repo hygiene — no production behaviour changes. The Postgres schema is unchanged; only the snapshot JSONs and a no-op marker migration are new.
- Drive-by: switches docs from the legacy `podman-compose` Python wrapper to Podman v5's built-in `podman compose` subcommand (separate commit).

## What was drifted
1. **Five orphan snapshot directories** for resources renamed in `20260426120000_rename_piece_version_vocabulary` — the new directories were created but the old ones were never deleted: `sequence_pieces/`, `sequence_versions/`, `scene_pieces/`, `scene_versions/`, `synopsis_versions/`.
2. **Stale FK constraint names** in four current snapshots — Postgres carried the old constraint identifiers across the `20260426120000` table renames; `20260426090910_scene_component` then explicitly renamed them. Snapshots never caught up.
3. **`script_views` schema drift** — `20260426090910_scene_component` (PR #75) replaced `position` + `treatment_view_id` with `scene_id`. Resource module reflected it; the snapshot didn't.

## Approach
Followed the Ash-blessed pattern: let `mix ash.codegen sync_snapshot_drift` rewrite the snapshots, review the emitted migration, then convert it to a no-op because the actual DB is already at the target state. Running the no-op marks the new snapshot timestamp as applied so future codegen runs use it as the diff base. The migration's `@moduledoc` documents which prior migrations did the work.

Trade-off considered: hand-editing the snapshot JSONs would have skipped the no-op migration entirely, but the snapshot format includes computed fields and timestamps that codegen sets correctly and humans don't.

## Test plan
- [x] `mix precommit` — compile-as-errors, format, unused-deps, full test suite — passes with 245 tests, 0 failures
- [x] `mix ash.migrate` applies the no-op migration cleanly against a DB with all prior migrations
- [x] `mix ash.codegen verify_no_drift` → "No changes detected" (the canonical no-drift signal)
- [x] All five orphan snapshot directories absent from `priv/resource_snapshots/repo/`
- [x] `script_views/<new>.json` records `scene_id` FK (no `position`, no `treatment_view_id`)
- [x] Renamed FK identifiers (`treatment_views_story_id_fkey`, `treatment_pieces_treatment_view_id_fkey`, `synopsis_views_story_id_fkey`, `script_pieces_script_view_id_fkey`) recorded in the new snapshots

closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)