### PR TITLE
Story-init bootstrap: default Sequence + skeletal TreatmentVV/SynopsisVV (#99)

### DIFF
--- a/lib/storybox/stories/changes/bootstrap_story.ex
+++ b/lib/storybox/stories/changes/bootstrap_story.ex
@@ -1,0 +1,63 @@
+defmodule Storybox.Stories.Changes.BootstrapStory do
+  use Ash.Resource.Change
+
+  alias Storybox.Stories.{
+    Sequence,
+    TreatmentView,
+    TreatmentViewVersion,
+    SynopsisView,
+    SynopsisViewVersion
+  }
+
+  # Registers an after_action hook that runs inside Ash's transaction for
+  # Story.create, atomically bootstrapping the skeletal Story-wide structure.
+  # Any {:error, _} returned by bootstrap/2 propagates up and causes Ash to
+  # roll back the entire transaction.
+  def change(changeset, _opts, _context) do
+    Ash.Changeset.after_action(changeset, &bootstrap/2)
+  end
+
+  defp bootstrap(_changeset, story) do
+    with {:ok, _seq} <- create_default_sequence(story.id),
+         {:ok, tv} <- ensure_treatment_view(story.id),
+         {:ok, _tvv} <- cut_treatment_view_version(tv.id),
+         {:ok, sv} <- ensure_synopsis_view(story.id),
+         {:ok, _svv} <- cut_synopsis_view_version(sv.id) do
+      {:ok, story}
+    end
+  end
+
+  defp create_default_sequence(story_id) do
+    Sequence
+    |> Ash.Changeset.for_create(:create, %{
+      story_id: story_id,
+      name: "Sequence 1",
+      slug: "sequence-1"
+    })
+    |> Ash.create(authorize?: false)
+  end
+
+  defp ensure_treatment_view(story_id) do
+    TreatmentView
+    |> Ash.ActionInput.for_action(:ensure_for_story, %{story_id: story_id})
+    |> Ash.run_action(authorize?: false)
+  end
+
+  defp cut_treatment_view_version(treatment_view_id) do
+    TreatmentViewVersion
+    |> Ash.ActionInput.for_action(:cut, %{treatment_view_id: treatment_view_id})
+    |> Ash.run_action(authorize?: false)
+  end
+
+  defp ensure_synopsis_view(story_id) do
+    SynopsisView
+    |> Ash.ActionInput.for_action(:ensure_for_story, %{story_id: story_id})
+    |> Ash.run_action(authorize?: false)
+  end
+
+  defp cut_synopsis_view_version(synopsis_view_id) do
+    SynopsisViewVersion
+    |> Ash.ActionInput.for_action(:cut, %{synopsis_view_id: synopsis_view_id})
+    |> Ash.run_action(authorize?: false)
+  end
+end

--- a/lib/storybox/stories/story.ex
+++ b/lib/storybox/stories/story.ex
@@ -39,6 +39,7 @@ defmodule Storybox.Stories.Story do
 
     create :create do
       accept [:title, :logline, :controlling_idea, :through_lines, :user_id]
+      change Storybox.Stories.Changes.BootstrapStory
     end
 
     update :update do

--- a/lib/storybox/stories/synopsis_view.ex
+++ b/lib/storybox/stories/synopsis_view.ex
@@ -27,7 +27,7 @@ defmodule Storybox.Stories.SynopsisView do
   end
 
   actions do
-    defaults [:read]
+    defaults [:read, :destroy]
 
     create :create do
       accept [:story_id]

--- a/lib/storybox/stories/synopsis_view_version.ex
+++ b/lib/storybox/stories/synopsis_view_version.ex
@@ -32,7 +32,7 @@ defmodule Storybox.Stories.SynopsisViewVersion do
   end
 
   actions do
-    defaults [:read]
+    defaults [:read, :destroy]
 
     create :create do
       accept [:synopsis_view_id, :version_number]

--- a/test/storybox/stories/sequence_test.exs
+++ b/test/storybox/stories/sequence_test.exs
@@ -144,7 +144,7 @@ defmodule Storybox.Stories.SequenceTest do
       {:ok, story_a_loaded} = Ash.load(story_a, :sequences)
 
       sequence_names = story_a_loaded.sequences |> Enum.map(& &1.name) |> Enum.sort()
-      assert sequence_names == ["Cottage", "Prologue"]
+      assert sequence_names == ["Cottage", "Prologue", "Sequence 1"]
       assert Enum.all?(story_a_loaded.sequences, &(&1.story_id == story_a.id))
     end
   end

--- a/test/storybox/stories/story_test.exs
+++ b/test/storybox/stories/story_test.exs
@@ -1,6 +1,8 @@
 defmodule Storybox.Stories.StoryTest do
   use Storybox.DataCase
 
+  require Ash.Query
+
   setup do
     {:ok, user} =
       Storybox.Accounts.User
@@ -38,6 +40,94 @@ defmodule Storybox.Stories.StoryTest do
                Storybox.Stories.Story
                |> Ash.Changeset.for_create(:create, %{title: "No User Story"})
                |> Ash.create()
+    end
+  end
+
+  describe "bootstrap" do
+    test "creates 1 default Sequence, 1 TreatmentView + TVV v1, 1 SynopsisView + SVV v1", %{
+      user: user
+    } do
+      assert {:ok, story} =
+               Storybox.Stories.Story
+               |> Ash.Changeset.for_create(:create, %{title: "Bootstrap Test", user_id: user.id})
+               |> Ash.create()
+
+      sequences =
+        Storybox.Stories.Sequence
+        |> Ash.Query.filter(story_id == ^story.id)
+        |> Ash.read!(authorize?: false)
+
+      assert length(sequences) == 1
+      [default_seq] = sequences
+      assert default_seq.name == "Sequence 1"
+      assert default_seq.slug == "sequence-1"
+
+      {:ok, treatment_view} =
+        Storybox.Stories.TreatmentView
+        |> Ash.Query.filter(story_id == ^story.id)
+        |> Ash.read_one(authorize?: false)
+
+      assert treatment_view != nil
+
+      tvvs =
+        Storybox.Stories.TreatmentViewVersion
+        |> Ash.Query.filter(treatment_view_id == ^treatment_view.id)
+        |> Ash.read!(authorize?: false)
+
+      assert length(tvvs) == 1
+      [tvv] = tvvs
+      assert tvv.version_number == 1
+
+      tvv_segments =
+        Storybox.Stories.Segment
+        |> Ash.Query.filter(view_version_id == ^tvv.id and view_version_type == :treatment_vv)
+        |> Ash.read!(authorize?: false)
+
+      assert length(tvv_segments) == 1
+      [tvv_seg] = tvv_segments
+      assert tvv_seg.pin_id == nil
+      assert tvv_seg.pin_type == nil
+      assert tvv_seg.sequence_id == default_seq.id
+
+      {:ok, synopsis_view} =
+        Storybox.Stories.SynopsisView
+        |> Ash.Query.filter(story_id == ^story.id)
+        |> Ash.read_one(authorize?: false)
+
+      assert synopsis_view != nil
+
+      svvs =
+        Storybox.Stories.SynopsisViewVersion
+        |> Ash.Query.filter(synopsis_view_id == ^synopsis_view.id)
+        |> Ash.read!(authorize?: false)
+
+      assert length(svvs) == 1
+      [svv] = svvs
+      assert svv.version_number == 1
+
+      svv_segments =
+        Storybox.Stories.Segment
+        |> Ash.Query.filter(view_version_id == ^svv.id and view_version_type == :synopsis_vv)
+        |> Ash.read!(authorize?: false)
+
+      assert length(svv_segments) == 1
+      [svv_seg] = svv_segments
+      assert svv_seg.pin_id == nil
+      assert svv_seg.pin_type == nil
+      assert svv_seg.sequence_id == default_seq.id
+    end
+
+    # Rollback on mid-bootstrap failure is guaranteed by Ash's after_action semantics:
+    # the callback runs inside the transaction Ash opens for Story.create, so any
+    # {:error, _} returned by bootstrap/2 causes Ash to roll back the whole transaction,
+    # leaving zero Story, Sequence, SynopsisView, and TreatmentView rows.
+    test "Story.create without a title returns error with no partial rows", %{user: user} do
+      assert {:error, %Ash.Error.Invalid{}} =
+               Storybox.Stories.Story
+               |> Ash.Changeset.for_create(:create, %{user_id: user.id})
+               |> Ash.create()
+
+      assert Storybox.Stories.Story |> Ash.read!() == []
     end
   end
 

--- a/test/storybox/stories/synopsis_view_test.exs
+++ b/test/storybox/stories/synopsis_view_test.exs
@@ -24,13 +24,15 @@ defmodule Storybox.Stories.SynopsisViewTest do
   end
 
   describe "create" do
-    test "creates a synopsis view for a story", %{story: story} do
-      assert {:ok, view} =
+    # Story.create now bootstraps a SynopsisView automatically. Calling :create
+    # directly on a story that already has a SynopsisView must fail.
+    test "fails when a SynopsisView already exists for the story (bootstrap creates one)", %{
+      story: story
+    } do
+      assert {:error, _} =
                SynopsisView
                |> Ash.Changeset.for_create(:create, %{story_id: story.id})
                |> Ash.create()
-
-      assert view.story_id == story.id
     end
 
     test "fails without story_id" do
@@ -39,22 +41,10 @@ defmodule Storybox.Stories.SynopsisViewTest do
                |> Ash.Changeset.for_create(:create, %{})
                |> Ash.create()
     end
-
-    test "enforces unique constraint — second create for same story fails", %{story: story} do
-      {:ok, _first} =
-        SynopsisView
-        |> Ash.Changeset.for_create(:create, %{story_id: story.id})
-        |> Ash.create()
-
-      assert {:error, _} =
-               SynopsisView
-               |> Ash.Changeset.for_create(:create, %{story_id: story.id})
-               |> Ash.create()
-    end
   end
 
   describe "ensure_for_story action" do
-    test "creates a SynopsisView when none exists for the story", %{story: story} do
+    test "returns the bootstrap SynopsisView for the story", %{story: story} do
       assert {:ok, view} =
                SynopsisView
                |> Ash.ActionInput.for_action(:ensure_for_story, %{story_id: story.id})
@@ -87,14 +77,9 @@ defmodule Storybox.Stories.SynopsisViewTest do
   end
 
   describe "read" do
-    test "returns the synopsis view for a story", %{story: story} do
-      {:ok, view} =
-        SynopsisView
-        |> Ash.Changeset.for_create(:create, %{story_id: story.id})
-        |> Ash.create()
-
+    test "returns the bootstrap synopsis view for a story", %{story: story} do
       assert {:ok, views} = SynopsisView |> Ash.read()
-      assert Enum.any?(views, &(&1.id == view.id))
+      assert Enum.any?(views, &(&1.story_id == story.id))
     end
   end
 end

--- a/test/storybox/stories/synopsis_view_version_test.exs
+++ b/test/storybox/stories/synopsis_view_version_test.exs
@@ -90,8 +90,36 @@ defmodule Storybox.Stories.SynopsisViewVersionTest do
       |> Ash.ActionInput.for_action(:ensure_for_story, %{story_id: story.id})
       |> Ash.run_action()
 
+    # Fetch the bootstrap default sequence for use in order assertions
+    seq0 =
+      Storybox.Stories.Sequence
+      |> Ash.Query.filter(story_id == ^story.id and slug == "sequence-1")
+      |> Ash.read_one!(authorize?: false)
+
+    # Destroy bootstrap TVV so SVV cuts fall back to all sequences by inserted_at
+    # (the bootstrap TVV only knows about seq0; destroying it lets cut/1 discover
+    # all 4 sequences: seq0, seq1, seq2, seq3).
+    Storybox.Stories.TreatmentView
+    |> Ash.Query.filter(story_id == ^story.id)
+    |> Ash.read_one!(authorize?: false)
+    |> then(fn tv ->
+      if tv do
+        TreatmentViewVersion
+        |> Ash.Query.filter(treatment_view_id == ^tv.id)
+        |> Ash.read!(authorize?: false)
+        |> Enum.each(&Ash.destroy!(&1, authorize?: false))
+      end
+    end)
+
+    # Destroy bootstrap SVV so the first user-initiated cut creates version 1
+    SynopsisViewVersion
+    |> Ash.Query.filter(synopsis_view_id == ^synopsis_view.id)
+    |> Ash.read!(authorize?: false)
+    |> Enum.each(&Ash.destroy!(&1, authorize?: false))
+
     %{
       story: story,
+      seq0: seq0,
       seq1: seq1,
       seq2: seq2,
       seq3: seq3,
@@ -115,7 +143,9 @@ defmodule Storybox.Stories.SynopsisViewVersionTest do
       assert vv.version_number == 1
     end
 
-    test "creates exactly 3 Segments — one per Sequence", %{synopsis_view: synopsis_view} do
+    test "creates exactly 4 Segments — one per Sequence (including the bootstrap default)", %{
+      synopsis_view: synopsis_view
+    } do
       {:ok, vv} =
         SynopsisViewVersion
         |> Ash.ActionInput.for_action(:cut, %{synopsis_view_id: synopsis_view.id})
@@ -126,7 +156,7 @@ defmodule Storybox.Stories.SynopsisViewVersionTest do
         |> Ash.Query.filter(view_version_id == ^vv.id and view_version_type == :synopsis_vv)
         |> Ash.read!(authorize?: false)
 
-      assert length(segments) == 3
+      assert length(segments) == 4
     end
 
     test "prologue Segment pins prologue-v2 (latest piece)", %{
@@ -271,12 +301,14 @@ defmodule Storybox.Stories.SynopsisViewVersionTest do
   end
 
   describe "cut order source" do
-    test "with no TreatmentView, falls back to story.sequences ordered by inserted_at", %{
-      synopsis_view: synopsis_view,
-      seq1: seq1,
-      seq2: seq2,
-      seq3: seq3
-    } do
+    test "with no TreatmentViewVersion, falls back to story.sequences ordered by inserted_at",
+         %{
+           synopsis_view: synopsis_view,
+           seq0: seq0,
+           seq1: seq1,
+           seq2: seq2,
+           seq3: seq3
+         } do
       {:ok, vv} =
         SynopsisViewVersion
         |> Ash.ActionInput.for_action(:cut, %{synopsis_view_id: synopsis_view.id})
@@ -289,7 +321,7 @@ defmodule Storybox.Stories.SynopsisViewVersionTest do
         |> Ash.read!(authorize?: false)
         |> Enum.map(& &1.sequence_id)
 
-      assert ordered_seq_ids == [seq1.id, seq2.id, seq3.id]
+      assert ordered_seq_ids == [seq0.id, seq1.id, seq2.id, seq3.id]
     end
 
     test "reads sequence order from latest TVV's segments (reversed natural order)", %{

--- a/test/storybox/stories/treatment_view_test.exs
+++ b/test/storybox/stories/treatment_view_test.exs
@@ -126,6 +126,14 @@ defmodule Storybox.Stories.TreatmentViewTest do
         |> Ash.ActionInput.for_action(:ensure_for_story, %{story_id: story.id})
         |> Ash.run_action()
 
+      # Destroy the bootstrap TVV so cut tests exercise first-cut semantics
+      # (falls back to all sequences by inserted_at, producing 4 segments: the
+      # bootstrap "Sequence 1" plus the 3 test sequences added in setup).
+      Storybox.Stories.TreatmentViewVersion
+      |> Ash.Query.filter(treatment_view_id == ^tv.id)
+      |> Ash.read!(authorize?: false)
+      |> Enum.each(&Ash.destroy!(&1, authorize?: false))
+
       %{tv: tv}
     end
 
@@ -139,7 +147,7 @@ defmodule Storybox.Stories.TreatmentViewTest do
       assert vv.version_number == 1
     end
 
-    test "creates exactly 3 Segments — one per Sequence", %{tv: tv} do
+    test "creates exactly 4 Segments — one per Sequence", %{tv: tv} do
       {:ok, vv} =
         Storybox.Stories.TreatmentViewVersion
         |> Ash.ActionInput.for_action(:cut, %{treatment_view_id: tv.id})
@@ -150,7 +158,7 @@ defmodule Storybox.Stories.TreatmentViewTest do
         |> Ash.Query.filter(view_version_id == ^vv.id and view_version_type == :treatment_vv)
         |> Ash.read!()
 
-      assert length(segments) == 3
+      assert length(segments) == 4
     end
 
     test "prologue Segment pins prologue-v2", %{tv: tv, seq1: seq1, p1b: p1b} do

--- a/test/storybox_web/controllers/synopsis_view_test.exs
+++ b/test/storybox_web/controllers/synopsis_view_test.exs
@@ -3,6 +3,8 @@ defmodule StoryboxWeb.SynopsisViewTest do
 
   alias Storybox.Accounts.ApiToken
 
+  require Ash.Query
+
   setup do
     {:ok, user} =
       Storybox.Accounts.User
@@ -38,6 +40,19 @@ defmodule StoryboxWeb.SynopsisViewTest do
       story: story,
       raw_token: raw_token
     } do
+      # Remove the bootstrap SV (and its SVV) to reach the "no synopsis" state
+      sv =
+        Storybox.Stories.SynopsisView
+        |> Ash.Query.filter(story_id == ^story.id)
+        |> Ash.read_one!(authorize?: false)
+
+      Storybox.Stories.SynopsisViewVersion
+      |> Ash.Query.filter(synopsis_view_id == ^sv.id)
+      |> Ash.read!(authorize?: false)
+      |> Enum.each(&Ash.destroy!(&1, authorize?: false))
+
+      Ash.destroy!(sv, authorize?: false)
+
       conn =
         conn
         |> authed(raw_token)
@@ -51,10 +66,16 @@ defmodule StoryboxWeb.SynopsisViewTest do
       story: story,
       raw_token: raw_token
     } do
-      {:ok, _sv} =
+      # Remove the bootstrap SVV to reach the "no versions" state
+      sv =
         Storybox.Stories.SynopsisView
-        |> Ash.ActionInput.for_action(:ensure_for_story, %{story_id: story.id})
-        |> Ash.run_action()
+        |> Ash.Query.filter(story_id == ^story.id)
+        |> Ash.read_one!(authorize?: false)
+
+      Storybox.Stories.SynopsisViewVersion
+      |> Ash.Query.filter(synopsis_view_id == ^sv.id)
+      |> Ash.read!(authorize?: false)
+      |> Enum.each(&Ash.destroy!(&1, authorize?: false))
 
       conn =
         conn
@@ -74,11 +95,7 @@ defmodule StoryboxWeb.SynopsisViewTest do
         |> Ash.ActionInput.for_action(:ensure_for_story, %{story_id: story.id})
         |> Ash.run_action()
 
-      {:ok, _vv1} =
-        Storybox.Stories.SynopsisViewVersion
-        |> Ash.Changeset.for_create(:create, %{synopsis_view_id: sv.id, version_number: 1})
-        |> Ash.create()
-
+      # Bootstrap already created v1; create v2 to test that the latest is returned
       {:ok, _vv2} =
         Storybox.Stories.SynopsisViewVersion
         |> Ash.Changeset.for_create(:create, %{synopsis_view_id: sv.id, version_number: 2})

--- a/test/storybox_web/live/story_overview_live_test.exs
+++ b/test/storybox_web/live/story_overview_live_test.exs
@@ -84,7 +84,7 @@ defmodule StoryboxWeb.StoryOverviewLiveTest do
       Storybox.Stories.SynopsisViewVersion
       |> Ash.Changeset.for_create(:create, %{
         synopsis_view_id: synopsis_view.id,
-        version_number: 1
+        version_number: 2
       })
       |> Ash.create()
 
@@ -92,7 +92,7 @@ defmodule StoryboxWeb.StoryOverviewLiveTest do
       Storybox.Stories.SynopsisViewVersion
       |> Ash.Changeset.for_create(:create, %{
         synopsis_view_id: synopsis_view.id,
-        version_number: 2
+        version_number: 3
       })
       |> Ash.create()
 
@@ -253,11 +253,11 @@ defmodule StoryboxWeb.StoryOverviewLiveTest do
   end
 
   describe "synopsis section" do
-    test "shows v2 as the latest version", %{conn: conn, alice: alice, story: story} do
+    test "shows v3 as the latest version", %{conn: conn, alice: alice, story: story} do
       conn = log_in_user(conn, alice)
       {:ok, _view, html} = live(conn, "/stories/#{story.id}")
 
-      assert html =~ "v2"
+      assert html =~ "v3"
       assert html =~ "Latest"
     end
 
@@ -268,7 +268,7 @@ defmodule StoryboxWeb.StoryOverviewLiveTest do
       assert html =~ "v1"
     end
 
-    test "shows no synopsis empty state for a story with no synopsis versions", %{
+    test "shows the bootstrap synopsis version (v1) for a freshly created story", %{
       conn: conn,
       alice: alice
     } do
@@ -280,7 +280,8 @@ defmodule StoryboxWeb.StoryOverviewLiveTest do
       conn = log_in_user(conn, alice)
       {:ok, _view, html} = live(conn, "/stories/#{bare_story.id}")
 
-      assert html =~ "No synopsis versions yet."
+      assert html =~ "v1"
+      refute html =~ "No synopsis versions yet."
     end
   end
 


### PR DESCRIPTION
## Summary

- Adds `Storybox.Stories.Changes.BootstrapStory`, an `after_action` change that atomically creates 5 structural records on every `Story.create`: default Sequence (`"Sequence 1"` / `"sequence-1"`), TreatmentView + TVV v1 (1 unresolvable Segment), SynopsisView + SVV v1 (1 unresolvable Segment)
- Wires `BootstrapStory` into the `:create` action on `Story`
- All bootstrap inserts run inside Ash's transaction — any failure rolls back the entire Story creation
- Adds `:destroy` action to `SynopsisView` and `SynopsisViewVersion` (needed for test teardown)
- Updates all tests broken by the bootstrap Sequence: `story_test`, `synopsis_view_test`, `synopsis_view_version_test`, `treatment_view_test`, `sequence_test`, `synopsis_view_controller_test`, `story_overview_live_test`

Closes #99

## Test plan

- [x] `mix precommit` passes (220 tests, 0 failures)
- [x] `Story.create` produces exactly 1 Sequence, 1 TreatmentView + TVV v1, 1 SynopsisView + SVV v1
- [x] Both bootstrap Segments are unresolvable (`pin_id IS NULL`) and carry `sequence_id = default_seq.id`
- [x] Rollback on `Story.create` failure (missing title) leaves zero partial rows
- [x] All pre-existing tests updated with exact counts for the bootstrap Sequence

🤖 Generated with [Claude Code](https://claude.com/claude-code)