### PR TITLE
Add Character/World View+Piece pattern

### DIFF
--- a/lib/storybox/storage.ex
+++ b/lib/storybox/storage.ex
@@ -17,6 +17,14 @@ defmodule Storybox.Storage do
     "storybox://stories/#{story_id}/sequences/#{sequence_id}/synopsis/v#{version_number}.fountain"
   end
 
+  def uri_for_character_piece(character_id, version_number) do
+    "storybox://characters/#{character_id}/v#{version_number}"
+  end
+
+  def uri_for_world_piece(world_id, version_number) do
+    "storybox://worlds/#{world_id}/v#{version_number}"
+  end
+
   def uri_to_path("storybox://" <> path), do: path
 
   def put_content(uri, content) do

--- a/lib/storybox/stories.ex
+++ b/lib/storybox/stories.ex
@@ -4,9 +4,15 @@ defmodule Storybox.Stories do
   resources do
     resource Storybox.Stories.Story
     resource Storybox.Stories.Character
+    resource Storybox.Stories.CharacterPiece
+    resource Storybox.Stories.CharacterView
+    resource Storybox.Stories.CharacterViewVersion
     resource Storybox.Stories.Sequence
     resource Storybox.Stories.Segment
     resource Storybox.Stories.World
+    resource Storybox.Stories.WorldPiece
+    resource Storybox.Stories.WorldView
+    resource Storybox.Stories.WorldViewVersion
     resource Storybox.Stories.SynopsisView
     resource Storybox.Stories.SynopsisViewVersion
     resource Storybox.Stories.SynopsisPiece

--- a/lib/storybox/stories/character.ex
+++ b/lib/storybox/stories/character.ex
@@ -12,26 +12,25 @@ defmodule Storybox.Stories.Character do
     uuid_primary_key :id
 
     attribute :name, :string, allow_nil?: false, public?: true
-    attribute :essence, :string, allow_nil?: true, public?: true
-    attribute :contradictions, {:array, :string}, allow_nil?: true, public?: true
-    attribute :voice, :string, allow_nil?: true, public?: true
 
     timestamps()
   end
 
   relationships do
     belongs_to :story, Storybox.Stories.Story, allow_nil?: false, public?: true
+    has_many :character_pieces, Storybox.Stories.CharacterPiece, public?: true
+    has_one :character_view, Storybox.Stories.CharacterView, public?: true
   end
 
   actions do
     defaults [:read, :destroy]
 
     create :create do
-      accept [:name, :essence, :contradictions, :voice, :story_id]
+      accept [:name, :story_id]
     end
 
     update :update do
-      accept [:name, :essence, :contradictions, :voice]
+      accept [:name]
     end
   end
 end

--- a/lib/storybox/stories/character_piece.ex
+++ b/lib/storybox/stories/character_piece.ex
@@ -1,0 +1,70 @@
+defmodule Storybox.Stories.CharacterPiece do
+  use Ash.Resource,
+    domain: Storybox.Stories,
+    data_layer: AshPostgres.DataLayer
+
+  require Ash.Query
+
+  postgres do
+    table "character_pieces"
+    repo Storybox.Repo
+  end
+
+  attributes do
+    uuid_primary_key :id
+
+    attribute :content_uri, :string, allow_nil?: false, public?: true
+    attribute :version_number, :integer, allow_nil?: false, public?: true
+
+    create_timestamp :inserted_at
+  end
+
+  relationships do
+    belongs_to :character, Storybox.Stories.Character, allow_nil?: false, public?: true
+  end
+
+  identities do
+    identity :unique_version_per_character, [:character_id, :version_number]
+  end
+
+  actions do
+    defaults [:read]
+
+    create :create do
+      accept [:character_id, :content_uri, :version_number]
+    end
+
+    action :create_version, :struct do
+      constraints instance_of: Storybox.Stories.CharacterPiece
+      argument :character_id, :uuid, allow_nil?: false
+      argument :content, :string, allow_nil?: false
+
+      run fn input, _context ->
+        character_id = input.arguments.character_id
+
+        existing =
+          Storybox.Stories.CharacterPiece
+          |> Ash.Query.filter(character_id == ^character_id)
+          |> Ash.read!(authorize?: false)
+
+        next_version =
+          existing
+          |> Enum.map(& &1.version_number)
+          |> Enum.max(fn -> 0 end)
+          |> Kernel.+(1)
+
+        uri = Storybox.Storage.uri_for_character_piece(character_id, next_version)
+
+        with {:ok, _} <- Storybox.Storage.put_content(uri, input.arguments.content) do
+          Storybox.Stories.CharacterPiece
+          |> Ash.Changeset.for_create(:create, %{
+            character_id: character_id,
+            content_uri: uri,
+            version_number: next_version
+          })
+          |> Ash.create(authorize?: false)
+        end
+      end
+    end
+  end
+end

--- a/lib/storybox/stories/character_view.ex
+++ b/lib/storybox/stories/character_view.ex
@@ -1,0 +1,61 @@
+defmodule Storybox.Stories.CharacterView do
+  use Ash.Resource,
+    domain: Storybox.Stories,
+    data_layer: AshPostgres.DataLayer
+
+  require Ash.Query
+
+  postgres do
+    table "character_views"
+    repo Storybox.Repo
+  end
+
+  attributes do
+    uuid_primary_key :id
+    create_timestamp :inserted_at
+  end
+
+  relationships do
+    belongs_to :character, Storybox.Stories.Character, allow_nil?: false, public?: true
+    has_many :character_view_versions, Storybox.Stories.CharacterViewVersion, public?: true
+  end
+
+  identities do
+    identity :unique_character, [:character_id]
+  end
+
+  actions do
+    defaults [:read, :destroy]
+
+    create :create do
+      accept [:character_id]
+    end
+
+    action :ensure_for_character, :struct do
+      constraints instance_of: Storybox.Stories.CharacterView
+      argument :character_id, :uuid, allow_nil?: false
+
+      run fn input, _context ->
+        character_id = input.arguments.character_id
+
+        existing =
+          Storybox.Stories.CharacterView
+          |> Ash.Query.filter(character_id == ^character_id)
+          |> Ash.read_one(authorize?: false)
+
+        case existing do
+          {:ok, nil} ->
+            Storybox.Stories.CharacterView
+            |> Ash.Changeset.for_create(:create, %{character_id: character_id})
+            |> Ash.create(authorize?: false)
+
+          {:ok, record} ->
+            {:ok, record}
+
+          {:error, error} ->
+            {:error, error}
+        end
+      end
+    end
+  end
+end

--- a/lib/storybox/stories/character_view_version.ex
+++ b/lib/storybox/stories/character_view_version.ex
@@ -1,0 +1,97 @@
+defmodule Storybox.Stories.CharacterViewVersion do
+  use Ash.Resource,
+    domain: Storybox.Stories,
+    data_layer: AshPostgres.DataLayer
+
+  require Ash.Query
+
+  postgres do
+    table "character_view_versions"
+    repo Storybox.Repo
+  end
+
+  attributes do
+    uuid_primary_key :id
+    attribute :version_number, :integer, allow_nil?: false, public?: true
+    create_timestamp :inserted_at
+  end
+
+  relationships do
+    belongs_to :character_view, Storybox.Stories.CharacterView, allow_nil?: false, public?: true
+
+    has_many :segments, Storybox.Stories.Segment,
+      destination_attribute: :view_version_id,
+      filter: [view_version_type: :character_vv],
+      public?: true
+  end
+
+  identities do
+    identity :unique_version_per_view, [:character_view_id, :version_number]
+  end
+
+  actions do
+    defaults [:read]
+
+    create :create do
+      accept [:character_view_id, :version_number]
+    end
+
+    action :cut, :struct do
+      constraints instance_of: Storybox.Stories.CharacterViewVersion
+      argument :character_view_id, :uuid, allow_nil?: false
+
+      run fn input, _context ->
+        character_view_id = input.arguments.character_view_id
+
+        character_view =
+          Storybox.Stories.CharacterView
+          |> Ash.Query.filter(id == ^character_view_id)
+          |> Ash.read_one!(authorize?: false)
+
+        character_id = character_view.character_id
+
+        latest_piece =
+          Storybox.Stories.CharacterPiece
+          |> Ash.Query.filter(character_id == ^character_id)
+          |> Ash.Query.sort(version_number: :desc)
+          |> Ash.Query.limit(1)
+          |> Ash.read!(authorize?: false)
+          |> List.first()
+
+        existing_versions =
+          Storybox.Stories.CharacterViewVersion
+          |> Ash.Query.filter(character_view_id == ^character_view_id)
+          |> Ash.read!(authorize?: false)
+
+        next_version_number =
+          existing_versions
+          |> Enum.map(& &1.version_number)
+          |> Enum.max(fn -> 0 end)
+          |> Kernel.+(1)
+
+        {:ok, vv} =
+          Storybox.Stories.CharacterViewVersion
+          |> Ash.Changeset.for_create(:create, %{
+            character_view_id: character_view_id,
+            version_number: next_version_number
+          })
+          |> Ash.create(authorize?: false)
+
+        if latest_piece do
+          Storybox.Stories.Segment
+          |> Ash.Changeset.for_create(:create, %{
+            view_version_id: vv.id,
+            view_version_type: :character_vv,
+            position: 1,
+            pin_id: latest_piece.id,
+            pin_type: :character_piece,
+            pin_version_at_creation: latest_piece.version_number
+          })
+          |> Ash.create!(authorize?: false)
+        end
+
+        {:ok, vv}
+      end
+    end
+  end
+end

--- a/lib/storybox/stories/segment.ex
+++ b/lib/storybox/stories/segment.ex
@@ -216,6 +216,34 @@ defmodule Storybox.Stories.Segment do
     |> Enum.max(fn -> nil end)
   end
 
+  def pin_target_latest_version(%{pin_type: :character_piece, pin_id: pin_id})
+      when not is_nil(pin_id) do
+    pinned =
+      Storybox.Stories.CharacterPiece
+      |> Ash.Query.filter(id == ^pin_id)
+      |> Ash.read_one!(authorize?: false)
+
+    Storybox.Stories.CharacterPiece
+    |> Ash.Query.filter(character_id == ^pinned.character_id)
+    |> Ash.read!(authorize?: false)
+    |> Enum.map(& &1.version_number)
+    |> Enum.max(fn -> nil end)
+  end
+
+  def pin_target_latest_version(%{pin_type: :world_piece, pin_id: pin_id})
+      when not is_nil(pin_id) do
+    pinned =
+      Storybox.Stories.WorldPiece
+      |> Ash.Query.filter(id == ^pin_id)
+      |> Ash.read_one!(authorize?: false)
+
+    Storybox.Stories.WorldPiece
+    |> Ash.Query.filter(world_id == ^pinned.world_id)
+    |> Ash.read!(authorize?: false)
+    |> Enum.map(& &1.version_number)
+    |> Enum.max(fn -> nil end)
+  end
+
   def pin_target_latest_version(%{pin_type: pin_type}) do
     raise ArgumentError,
           "pin_target_latest_version/1 is not yet implemented for pin_type #{inspect(pin_type)}"
@@ -226,6 +254,8 @@ defmodule Storybox.Stories.Segment do
   defp pin_module!(:sequence_piece), do: Storybox.Stories.SequencePiece
   defp pin_module!(:script_vv), do: Storybox.Stories.ScriptViewVersion
   defp pin_module!(:sequence_vv), do: Storybox.Stories.SequenceViewVersion
+  defp pin_module!(:character_piece), do: Storybox.Stories.CharacterPiece
+  defp pin_module!(:world_piece), do: Storybox.Stories.WorldPiece
 
   defp pin_module!(pin_type) when pin_type in @pin_types do
     raise ArgumentError,

--- a/lib/storybox/stories/world.ex
+++ b/lib/storybox/stories/world.ex
@@ -11,26 +11,24 @@ defmodule Storybox.Stories.World do
   attributes do
     uuid_primary_key :id
 
-    attribute :history, :string, allow_nil?: true, public?: true
-    attribute :rules, :string, allow_nil?: true, public?: true
-    attribute :subtext, :string, allow_nil?: true, public?: true
-
     timestamps()
   end
 
   relationships do
     belongs_to :story, Storybox.Stories.Story, allow_nil?: false, public?: true
+    has_many :world_pieces, Storybox.Stories.WorldPiece, public?: true
+    has_one :world_view, Storybox.Stories.WorldView, public?: true
   end
 
   actions do
     defaults [:read, :destroy]
 
     create :create do
-      accept [:history, :rules, :subtext, :story_id]
+      accept [:story_id]
     end
 
     update :update do
-      accept [:history, :rules, :subtext]
+      accept []
     end
   end
 end

--- a/lib/storybox/stories/world_piece.ex
+++ b/lib/storybox/stories/world_piece.ex
@@ -1,0 +1,70 @@
+defmodule Storybox.Stories.WorldPiece do
+  use Ash.Resource,
+    domain: Storybox.Stories,
+    data_layer: AshPostgres.DataLayer
+
+  require Ash.Query
+
+  postgres do
+    table "world_pieces"
+    repo Storybox.Repo
+  end
+
+  attributes do
+    uuid_primary_key :id
+
+    attribute :content_uri, :string, allow_nil?: false, public?: true
+    attribute :version_number, :integer, allow_nil?: false, public?: true
+
+    create_timestamp :inserted_at
+  end
+
+  relationships do
+    belongs_to :world, Storybox.Stories.World, allow_nil?: false, public?: true
+  end
+
+  identities do
+    identity :unique_version_per_world, [:world_id, :version_number]
+  end
+
+  actions do
+    defaults [:read]
+
+    create :create do
+      accept [:world_id, :content_uri, :version_number]
+    end
+
+    action :create_version, :struct do
+      constraints instance_of: Storybox.Stories.WorldPiece
+      argument :world_id, :uuid, allow_nil?: false
+      argument :content, :string, allow_nil?: false
+
+      run fn input, _context ->
+        world_id = input.arguments.world_id
+
+        existing =
+          Storybox.Stories.WorldPiece
+          |> Ash.Query.filter(world_id == ^world_id)
+          |> Ash.read!(authorize?: false)
+
+        next_version =
+          existing
+          |> Enum.map(& &1.version_number)
+          |> Enum.max(fn -> 0 end)
+          |> Kernel.+(1)
+
+        uri = Storybox.Storage.uri_for_world_piece(world_id, next_version)
+
+        with {:ok, _} <- Storybox.Storage.put_content(uri, input.arguments.content) do
+          Storybox.Stories.WorldPiece
+          |> Ash.Changeset.for_create(:create, %{
+            world_id: world_id,
+            content_uri: uri,
+            version_number: next_version
+          })
+          |> Ash.create(authorize?: false)
+        end
+      end
+    end
+  end
+end

--- a/lib/storybox/stories/world_view.ex
+++ b/lib/storybox/stories/world_view.ex
@@ -1,0 +1,61 @@
+defmodule Storybox.Stories.WorldView do
+  use Ash.Resource,
+    domain: Storybox.Stories,
+    data_layer: AshPostgres.DataLayer
+
+  require Ash.Query
+
+  postgres do
+    table "world_views"
+    repo Storybox.Repo
+  end
+
+  attributes do
+    uuid_primary_key :id
+    create_timestamp :inserted_at
+  end
+
+  relationships do
+    belongs_to :world, Storybox.Stories.World, allow_nil?: false, public?: true
+    has_many :world_view_versions, Storybox.Stories.WorldViewVersion, public?: true
+  end
+
+  identities do
+    identity :unique_world, [:world_id]
+  end
+
+  actions do
+    defaults [:read, :destroy]
+
+    create :create do
+      accept [:world_id]
+    end
+
+    action :ensure_for_world, :struct do
+      constraints instance_of: Storybox.Stories.WorldView
+      argument :world_id, :uuid, allow_nil?: false
+
+      run fn input, _context ->
+        world_id = input.arguments.world_id
+
+        existing =
+          Storybox.Stories.WorldView
+          |> Ash.Query.filter(world_id == ^world_id)
+          |> Ash.read_one(authorize?: false)
+
+        case existing do
+          {:ok, nil} ->
+            Storybox.Stories.WorldView
+            |> Ash.Changeset.for_create(:create, %{world_id: world_id})
+            |> Ash.create(authorize?: false)
+
+          {:ok, record} ->
+            {:ok, record}
+
+          {:error, error} ->
+            {:error, error}
+        end
+      end
+    end
+  end
+end

--- a/lib/storybox/stories/world_view_version.ex
+++ b/lib/storybox/stories/world_view_version.ex
@@ -1,0 +1,97 @@
+defmodule Storybox.Stories.WorldViewVersion do
+  use Ash.Resource,
+    domain: Storybox.Stories,
+    data_layer: AshPostgres.DataLayer
+
+  require Ash.Query
+
+  postgres do
+    table "world_view_versions"
+    repo Storybox.Repo
+  end
+
+  attributes do
+    uuid_primary_key :id
+    attribute :version_number, :integer, allow_nil?: false, public?: true
+    create_timestamp :inserted_at
+  end
+
+  relationships do
+    belongs_to :world_view, Storybox.Stories.WorldView, allow_nil?: false, public?: true
+
+    has_many :segments, Storybox.Stories.Segment,
+      destination_attribute: :view_version_id,
+      filter: [view_version_type: :world_vv],
+      public?: true
+  end
+
+  identities do
+    identity :unique_version_per_view, [:world_view_id, :version_number]
+  end
+
+  actions do
+    defaults [:read]
+
+    create :create do
+      accept [:world_view_id, :version_number]
+    end
+
+    action :cut, :struct do
+      constraints instance_of: Storybox.Stories.WorldViewVersion
+      argument :world_view_id, :uuid, allow_nil?: false
+
+      run fn input, _context ->
+        world_view_id = input.arguments.world_view_id
+
+        world_view =
+          Storybox.Stories.WorldView
+          |> Ash.Query.filter(id == ^world_view_id)
+          |> Ash.read_one!(authorize?: false)
+
+        world_id = world_view.world_id
+
+        latest_piece =
+          Storybox.Stories.WorldPiece
+          |> Ash.Query.filter(world_id == ^world_id)
+          |> Ash.Query.sort(version_number: :desc)
+          |> Ash.Query.limit(1)
+          |> Ash.read!(authorize?: false)
+          |> List.first()
+
+        existing_versions =
+          Storybox.Stories.WorldViewVersion
+          |> Ash.Query.filter(world_view_id == ^world_view_id)
+          |> Ash.read!(authorize?: false)
+
+        next_version_number =
+          existing_versions
+          |> Enum.map(& &1.version_number)
+          |> Enum.max(fn -> 0 end)
+          |> Kernel.+(1)
+
+        {:ok, vv} =
+          Storybox.Stories.WorldViewVersion
+          |> Ash.Changeset.for_create(:create, %{
+            world_view_id: world_view_id,
+            version_number: next_version_number
+          })
+          |> Ash.create(authorize?: false)
+
+        if latest_piece do
+          Storybox.Stories.Segment
+          |> Ash.Changeset.for_create(:create, %{
+            view_version_id: vv.id,
+            view_version_type: :world_vv,
+            position: 1,
+            pin_id: latest_piece.id,
+            pin_type: :world_piece,
+            pin_version_at_creation: latest_piece.version_number
+          })
+          |> Ash.create!(authorize?: false)
+        end
+
+        {:ok, vv}
+      end
+    end
+  end
+end

--- a/lib/storybox_web/live/story_overview_live.ex
+++ b/lib/storybox_web/live/story_overview_live.ex
@@ -28,10 +28,21 @@ defmodule StoryboxWeb.StoryOverviewLive do
               |> Ash.Query.filter(story_id == ^story.id)
               |> Ash.read!(authorize?: false)
 
+            characters_with_content =
+              for character <- characters do
+                {character, resolve_character_content(character.id)}
+              end
+
             world =
               Storybox.Stories.World
               |> Ash.Query.filter(story_id == ^story.id)
               |> Ash.read_one!(authorize?: false)
+
+            {world_content, world_vv_inserted_at} =
+              case world do
+                nil -> {nil, nil}
+                w -> resolve_world_content(w.id)
+              end
 
             synopsis_view =
               Storybox.Stories.SynopsisView
@@ -53,12 +64,62 @@ defmodule StoryboxWeb.StoryOverviewLive do
             {:ok,
              assign(socket,
                story: story,
-               characters: characters,
+               characters_with_content: characters_with_content,
                world: world,
+               world_content: world_content,
+               world_vv_inserted_at: world_vv_inserted_at,
                synopsis_view_versions: synopsis_view_versions,
                page_title: story.title
              )}
         end
+    end
+  end
+
+  defp resolve_character_content(character_id) do
+    character_view =
+      Storybox.Stories.CharacterView
+      |> Ash.Query.filter(character_id == ^character_id)
+      |> Ash.read_one!(authorize?: false)
+
+    with cv when not is_nil(cv) <- character_view,
+         [vv | _] <-
+           Storybox.Stories.CharacterViewVersion
+           |> Ash.Query.filter(character_view_id == ^cv.id)
+           |> Ash.Query.sort(version_number: :desc)
+           |> Ash.read!(authorize?: false),
+         [seg | _] <-
+           Storybox.Stories.Segment
+           |> Ash.Query.filter(view_version_id == ^vv.id and view_version_type == :character_vv)
+           |> Ash.read!(authorize?: false),
+         {:resolved, piece} <- Storybox.Stories.Segment.resolve_pin(seg),
+         {:ok, content} <- Storybox.Storage.get_content(piece.content_uri) do
+      content
+    else
+      _ -> nil
+    end
+  end
+
+  defp resolve_world_content(world_id) do
+    world_view =
+      Storybox.Stories.WorldView
+      |> Ash.Query.filter(world_id == ^world_id)
+      |> Ash.read_one!(authorize?: false)
+
+    with wv when not is_nil(wv) <- world_view,
+         [vv | _] <-
+           Storybox.Stories.WorldViewVersion
+           |> Ash.Query.filter(world_view_id == ^wv.id)
+           |> Ash.Query.sort(version_number: :desc)
+           |> Ash.read!(authorize?: false),
+         [seg | _] <-
+           Storybox.Stories.Segment
+           |> Ash.Query.filter(view_version_id == ^vv.id and view_version_type == :world_vv)
+           |> Ash.read!(authorize?: false),
+         {:resolved, piece} <- Storybox.Stories.Segment.resolve_pin(seg),
+         {:ok, content} <- Storybox.Storage.get_content(piece.content_uri) do
+      {content, vv.inserted_at}
+    else
+      _ -> {nil, nil}
     end
   end
 
@@ -90,35 +151,16 @@ defmodule StoryboxWeb.StoryOverviewLive do
 
         <section class="space-y-3">
           <h2 class="text-xl font-semibold">Characters</h2>
-          <%= if @characters == [] do %>
+          <%= if @characters_with_content == [] do %>
             <p class="text-base-content/60 text-sm">No characters defined yet.</p>
           <% else %>
             <ul class="space-y-2">
-              <%= for character <- @characters do %>
+              <%= for {character, content} <- @characters_with_content do %>
                 <li class="card bg-base-200 shadow-sm">
                   <div class="card-body py-3">
                     <h3 class="card-title text-base">{character.name}</h3>
-                    <%= if character.essence do %>
-                      <p class="text-base-content/70 text-sm">{character.essence}</p>
-                    <% end %>
-                    <%= if character.voice || character.contradictions not in [nil, []] do %>
-                      <details class="mt-1">
-                        <summary class="text-xs text-base-content/50 cursor-pointer select-none">
-                          Voice &amp; contradictions
-                        </summary>
-                        <div class="mt-2 space-y-2">
-                          <%= if character.voice do %>
-                            <p class="text-sm">{character.voice}</p>
-                          <% end %>
-                          <%= if character.contradictions not in [nil, []] do %>
-                            <div class="flex flex-wrap gap-1">
-                              <%= for c <- character.contradictions do %>
-                                <span class="badge badge-outline badge-sm">{c}</span>
-                              <% end %>
-                            </div>
-                          <% end %>
-                        </div>
-                      </details>
+                    <%= if content do %>
+                      <p class="text-base-content/70 text-sm whitespace-pre-line">{content}</p>
                     <% end %>
                   </div>
                 </li>
@@ -134,33 +176,14 @@ defmodule StoryboxWeb.StoryOverviewLive do
           <% else %>
             <div class="card bg-base-200 shadow-sm">
               <div class="card-body space-y-3">
-                <%= if @world.history do %>
-                  <div>
-                    <p class="text-xs font-semibold text-base-content/50 uppercase tracking-wide">
-                      History
-                    </p>
-                    <p class="text-sm mt-1">{@world.history}</p>
-                  </div>
+                <%= if @world_content do %>
+                  <p class="text-sm whitespace-pre-line">{@world_content}</p>
                 <% end %>
-                <%= if @world.rules do %>
-                  <div>
-                    <p class="text-xs font-semibold text-base-content/50 uppercase tracking-wide">
-                      Rules
-                    </p>
-                    <p class="text-sm mt-1">{@world.rules}</p>
-                  </div>
+                <%= if @world_vv_inserted_at do %>
+                  <p class="text-xs text-base-content/40">
+                    Last updated: {Calendar.strftime(@world_vv_inserted_at, "%B %-d, %Y")}
+                  </p>
                 <% end %>
-                <%= if @world.subtext do %>
-                  <div>
-                    <p class="text-xs font-semibold text-base-content/50 uppercase tracking-wide">
-                      Subtext
-                    </p>
-                    <p class="text-sm mt-1">{@world.subtext}</p>
-                  </div>
-                <% end %>
-                <p class="text-xs text-base-content/40">
-                  Last updated: {Calendar.strftime(@world.updated_at, "%B %-d, %Y")}
-                </p>
               </div>
             </div>
           <% end %>

--- a/priv/repo/migrations/20260505110000_add_character_world_view_piece.exs
+++ b/priv/repo/migrations/20260505110000_add_character_world_view_piece.exs
@@ -1,0 +1,201 @@
+defmodule Storybox.Repo.Migrations.AddCharacterWorldViewPiece do
+  use Ecto.Migration
+
+  def up do
+    create table(:character_pieces, primary_key: false) do
+      add :id, :uuid, null: false, default: fragment("gen_random_uuid()"), primary_key: true
+      add :content_uri, :text, null: false
+      add :version_number, :bigint, null: false
+
+      add :inserted_at, :utc_datetime_usec,
+        null: false,
+        default: fragment("(now() AT TIME ZONE 'utc')")
+
+      add :character_id,
+          references(:characters,
+            column: :id,
+            name: "character_pieces_character_id_fkey",
+            type: :uuid,
+            prefix: "public"
+          ),
+          null: false
+    end
+
+    create unique_index(:character_pieces, [:character_id, :version_number],
+             name: "character_pieces_unique_version_per_character_index"
+           )
+
+    create table(:character_views, primary_key: false) do
+      add :id, :uuid, null: false, default: fragment("gen_random_uuid()"), primary_key: true
+
+      add :inserted_at, :utc_datetime_usec,
+        null: false,
+        default: fragment("(now() AT TIME ZONE 'utc')")
+
+      add :character_id,
+          references(:characters,
+            column: :id,
+            name: "character_views_character_id_fkey",
+            type: :uuid,
+            prefix: "public"
+          ),
+          null: false
+    end
+
+    create unique_index(:character_views, [:character_id],
+             name: "character_views_unique_character_index"
+           )
+
+    create table(:character_view_versions, primary_key: false) do
+      add :id, :uuid, null: false, default: fragment("gen_random_uuid()"), primary_key: true
+      add :version_number, :bigint, null: false
+
+      add :inserted_at, :utc_datetime_usec,
+        null: false,
+        default: fragment("(now() AT TIME ZONE 'utc')")
+
+      add :character_view_id,
+          references(:character_views,
+            column: :id,
+            name: "character_view_versions_character_view_id_fkey",
+            type: :uuid,
+            prefix: "public"
+          ),
+          null: false
+    end
+
+    create unique_index(:character_view_versions, [:character_view_id, :version_number],
+             name: "character_view_versions_unique_version_per_view_index"
+           )
+
+    create table(:world_pieces, primary_key: false) do
+      add :id, :uuid, null: false, default: fragment("gen_random_uuid()"), primary_key: true
+      add :content_uri, :text, null: false
+      add :version_number, :bigint, null: false
+
+      add :inserted_at, :utc_datetime_usec,
+        null: false,
+        default: fragment("(now() AT TIME ZONE 'utc')")
+
+      add :world_id,
+          references(:worlds,
+            column: :id,
+            name: "world_pieces_world_id_fkey",
+            type: :uuid,
+            prefix: "public"
+          ),
+          null: false
+    end
+
+    create unique_index(:world_pieces, [:world_id, :version_number],
+             name: "world_pieces_unique_version_per_world_index"
+           )
+
+    create table(:world_views, primary_key: false) do
+      add :id, :uuid, null: false, default: fragment("gen_random_uuid()"), primary_key: true
+
+      add :inserted_at, :utc_datetime_usec,
+        null: false,
+        default: fragment("(now() AT TIME ZONE 'utc')")
+
+      add :world_id,
+          references(:worlds,
+            column: :id,
+            name: "world_views_world_id_fkey",
+            type: :uuid,
+            prefix: "public"
+          ),
+          null: false
+    end
+
+    create unique_index(:world_views, [:world_id], name: "world_views_unique_world_index")
+
+    create table(:world_view_versions, primary_key: false) do
+      add :id, :uuid, null: false, default: fragment("gen_random_uuid()"), primary_key: true
+      add :version_number, :bigint, null: false
+
+      add :inserted_at, :utc_datetime_usec,
+        null: false,
+        default: fragment("(now() AT TIME ZONE 'utc')")
+
+      add :world_view_id,
+          references(:world_views,
+            column: :id,
+            name: "world_view_versions_world_view_id_fkey",
+            type: :uuid,
+            prefix: "public"
+          ),
+          null: false
+    end
+
+    create unique_index(:world_view_versions, [:world_view_id, :version_number],
+             name: "world_view_versions_unique_version_per_view_index"
+           )
+
+    alter table(:characters) do
+      remove :essence
+      remove :voice
+      remove :contradictions
+    end
+
+    alter table(:worlds) do
+      remove :history
+      remove :rules
+      remove :subtext
+    end
+  end
+
+  def down do
+    alter table(:worlds) do
+      add :history, :text
+      add :rules, :text
+      add :subtext, :text
+    end
+
+    alter table(:characters) do
+      add :essence, :text
+      add :voice, :text
+      add :contradictions, {:array, :text}
+    end
+
+    drop_if_exists unique_index(:world_view_versions, [:world_view_id, :version_number],
+                     name: "world_view_versions_unique_version_per_view_index"
+                   )
+
+    drop constraint(:world_view_versions, "world_view_versions_world_view_id_fkey")
+    drop table(:world_view_versions)
+
+    drop_if_exists unique_index(:world_views, [:world_id], name: "world_views_unique_world_index")
+
+    drop constraint(:world_views, "world_views_world_id_fkey")
+    drop table(:world_views)
+
+    drop_if_exists unique_index(:world_pieces, [:world_id, :version_number],
+                     name: "world_pieces_unique_version_per_world_index"
+                   )
+
+    drop constraint(:world_pieces, "world_pieces_world_id_fkey")
+    drop table(:world_pieces)
+
+    drop_if_exists unique_index(:character_view_versions, [:character_view_id, :version_number],
+                     name: "character_view_versions_unique_version_per_view_index"
+                   )
+
+    drop constraint(:character_view_versions, "character_view_versions_character_view_id_fkey")
+    drop table(:character_view_versions)
+
+    drop_if_exists unique_index(:character_views, [:character_id],
+                     name: "character_views_unique_character_index"
+                   )
+
+    drop constraint(:character_views, "character_views_character_id_fkey")
+    drop table(:character_views)
+
+    drop_if_exists unique_index(:character_pieces, [:character_id, :version_number],
+                     name: "character_pieces_unique_version_per_character_index"
+                   )
+
+    drop constraint(:character_pieces, "character_pieces_character_id_fkey")
+    drop table(:character_pieces)
+  end
+end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -425,10 +425,7 @@ if little_witch = all_stories["Little Witch"] do
 
       {:ok, script_view} =
         Storybox.Stories.ScriptView
-        |> Ash.Changeset.for_create(:create, %{
-          title: title,
-          scene_id: scene.id
-        })
+        |> Ash.Changeset.for_create(:create, %{scene_id: scene.id})
         |> Ash.create(authorize?: false)
 
       if content do
@@ -445,9 +442,12 @@ if little_witch = all_stories["Little Witch"] do
           })
           |> Ash.create(authorize?: false)
 
-        script_view
-        |> Ash.Changeset.for_update(:approve_version, %{version_id: v1.id})
-        |> Ash.update!(authorize?: false)
+        Storybox.Stories.ScriptViewVersion
+        |> Ash.ActionInput.for_action(:cut, %{
+          script_view_id: script_view.id,
+          script_piece_id: v1.id
+        })
+        |> Ash.run_action!(authorize?: false)
       end
 
       {scene, script_view}

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -93,20 +93,61 @@ if little_witch = all_stories["Little Witch"] do
     |> Ash.Query.filter(story_id == ^little_witch.id)
     |> Ash.read_one!(authorize?: false)
 
-  if is_nil(existing_world) do
-    Storybox.Stories.World
-    |> Ash.Changeset.for_create(:create, %{
-      history:
-        "The Order of Flame trained healers and demon-binders for generations. They wrote the Chosen One prophecy as a political shield — it outlasted them. The Alderman rose through a war that destroyed the Order and inherited the prophecy, deciding it meant whoever controls the Chosen One controls the continent.",
-      rules:
-        "The threshold between discipline and consumption is the Order's most guarded knowledge. Unglamorous, dangerous work — years of it — before anyone was permitted near a demon. The Alderman's purge continues: wanted posters for witches line every garrison wall.",
-      subtext:
-        "The prophecy does not need to be true to be useful. The political machinery runs on belief, not fact. What Fleur did in the fire was real not because it was special — because it was work.",
-      story_id: little_witch.id
-    })
-    |> Ash.create!(authorize?: false)
+  world =
+    if is_nil(existing_world) do
+      w =
+        Storybox.Stories.World
+        |> Ash.Changeset.for_create(:create, %{story_id: little_witch.id})
+        |> Ash.create!(authorize?: false)
 
-    IO.puts("  Created world for Little Witch")
+      IO.puts("  Created world for Little Witch")
+      w
+    else
+      existing_world
+    end
+
+  existing_world_pieces =
+    Storybox.Stories.WorldPiece
+    |> Ash.Query.filter(world_id == ^world.id)
+    |> Ash.read!(authorize?: false)
+
+  if existing_world_pieces == [] do
+    world_content = """
+    History: The Order of Flame trained healers and demon-binders for generations. They wrote the Chosen One prophecy as a political shield — it outlasted them. The Alderman rose through a war that destroyed the Order and inherited the prophecy, deciding it meant whoever controls the Chosen One controls the continent.
+
+    Rules: The threshold between discipline and consumption is the Order's most guarded knowledge. Unglamorous, dangerous work — years of it — before anyone was permitted near a demon. The Alderman's purge continues: wanted posters for witches line every garrison wall.
+
+    Subtext: The prophecy does not need to be true to be useful. The political machinery runs on belief, not fact. What Fleur did in the fire was real not because it was special — because it was work.
+    """
+
+    Storybox.Stories.WorldPiece
+    |> Ash.ActionInput.for_action(:create_version, %{
+      world_id: world.id,
+      content: String.trim(world_content)
+    })
+    |> Ash.run_action!(authorize?: false)
+
+    IO.puts("  Created WorldPiece v1 for Little Witch")
+  end
+
+  {:ok, world_view} =
+    Storybox.Stories.WorldView
+    |> Ash.ActionInput.for_action(:ensure_for_world, %{world_id: world.id})
+    |> Ash.run_action(authorize?: false)
+
+  IO.puts("  WorldView ready for Little Witch")
+
+  existing_wvv =
+    Storybox.Stories.WorldViewVersion
+    |> Ash.Query.filter(world_view_id == ^world_view.id)
+    |> Ash.read!(authorize?: false)
+
+  if existing_wvv == [] do
+    Storybox.Stories.WorldViewVersion
+    |> Ash.ActionInput.for_action(:cut, %{world_view_id: world_view.id})
+    |> Ash.run_action!(authorize?: false)
+
+    IO.puts("  Cut WorldViewVersion v1 for Little Witch")
   end
 
   # -- Characters ------------------------------------------------------------
@@ -115,59 +156,114 @@ if little_witch = all_stories["Little Witch"] do
     Storybox.Stories.Character
     |> Ash.Query.filter(story_id == ^little_witch.id)
     |> Ash.read!(authorize?: false)
-    |> Enum.map(& &1.name)
 
-  for {name, attrs} <- [
-        {"Fleur",
-         %{
-           essence:
-             "A lonely orphan with half-finished training who mistakes the feeling of being chosen for the fact of it.",
-           voice:
-             "Genuine, service-oriented — her good impulses are what make her easy to weaponise.",
-           contradictions: ["capable yet unfinished", "grief-driven yet clear-eyed at the end"]
-         }},
-        {"Kestrel",
-         %{
-           essence:
-             "The Order's former war leader. Imprisoned for a decade. Has spent ten years constructing a picture of Silas's betrayal from incomplete evidence.",
-           voice: "Blade-like. Perceptive and strategic. Every word is a move.",
-           contradictions: ["honed yet wrong", "engineering revenge yet undoing it"]
-         }},
-        {"Silas",
-         %{
-           essence:
-             "Fleur's guardian. Never seen on screen after the prologue. The moral centre of the story in absentia.",
-           voice: "Quiet. Unglamorous. Her example is the lesson, not her words.",
-           contradictions: [
-             "careful yet afraid",
-             "protective yet the source of the vulnerability"
-           ]
-         }},
-        {"The Flame Demon",
-         %{
-           essence:
-             "A cunning elemental parasite who survives by becoming whatever his captor needs most.",
-           voice: "Warm, patient, precise. He does not invent hope. He locates it and feeds it.",
-           contradictions: ["charming yet consuming", "small yet growing"]
-         }},
-        {"The Alderman",
-         %{
-           essence:
-             "An expansionist ruler who genuinely believes the prophecy. This makes him more dangerous than a cynic.",
-           voice:
-             "Rational given his premise. He is collecting what he believes the world promised him.",
-           contradictions: ["sincere yet monstrous", "building peace yet burning people"]
-         }}
-      ],
-      name not in existing_characters do
-    Storybox.Stories.Character
-    |> Ash.Changeset.for_create(
-      :create,
-      Map.merge(attrs, %{name: name, story_id: little_witch.id})
-    )
-    |> Ash.create!(authorize?: false)
+  existing_character_names = Enum.map(existing_characters, & &1.name)
 
-    IO.puts("  Created character: #{name}")
+  characters_data = [
+    {"Fleur",
+     """
+     Essence: A lonely orphan with half-finished training who mistakes the feeling of being chosen for the fact of it.
+
+     Voice: Genuine, service-oriented — her good impulses are what make her easy to weaponise.
+
+     Contradictions:
+     - capable yet unfinished
+     - grief-driven yet clear-eyed at the end
+     """},
+    {"Kestrel",
+     """
+     Essence: The Order's former war leader. Imprisoned for a decade. Has spent ten years constructing a picture of Silas's betrayal from incomplete evidence.
+
+     Voice: Blade-like. Perceptive and strategic. Every word is a move.
+
+     Contradictions:
+     - honed yet wrong
+     - engineering revenge yet undoing it
+     """},
+    {"Silas",
+     """
+     Essence: Fleur's guardian. Never seen on screen after the prologue. The moral centre of the story in absentia.
+
+     Voice: Quiet. Unglamorous. Her example is the lesson, not her words.
+
+     Contradictions:
+     - careful yet afraid
+     - protective yet the source of the vulnerability
+     """},
+    {"The Flame Demon",
+     """
+     Essence: A cunning elemental parasite who survives by becoming whatever his captor needs most.
+
+     Voice: Warm, patient, precise. He does not invent hope. He locates it and feeds it.
+
+     Contradictions:
+     - charming yet consuming
+     - small yet growing
+     """},
+    {"The Alderman",
+     """
+     Essence: An expansionist ruler who genuinely believes the prophecy. This makes him more dangerous than a cynic.
+
+     Voice: Rational given his premise. He is collecting what he believes the world promised him.
+
+     Contradictions:
+     - sincere yet monstrous
+     - building peace yet burning people
+     """}
+  ]
+
+  all_characters =
+    for {name, content} <- characters_data do
+      character =
+        if name not in existing_character_names do
+          c =
+            Storybox.Stories.Character
+            |> Ash.Changeset.for_create(:create, %{name: name, story_id: little_witch.id})
+            |> Ash.create!(authorize?: false)
+
+          IO.puts("  Created character: #{name}")
+          c
+        else
+          Enum.find(existing_characters, &(&1.name == name))
+        end
+
+      {character, content}
+    end
+
+  for {character, content} <- all_characters do
+    existing_pieces =
+      Storybox.Stories.CharacterPiece
+      |> Ash.Query.filter(character_id == ^character.id)
+      |> Ash.read!(authorize?: false)
+
+    if existing_pieces == [] do
+      Storybox.Stories.CharacterPiece
+      |> Ash.ActionInput.for_action(:create_version, %{
+        character_id: character.id,
+        content: String.trim(content)
+      })
+      |> Ash.run_action!(authorize?: false)
+
+      IO.puts("  Created CharacterPiece v1 for #{character.name}")
+    end
+
+    {:ok, character_view} =
+      Storybox.Stories.CharacterView
+      |> Ash.ActionInput.for_action(:ensure_for_character, %{character_id: character.id})
+      |> Ash.run_action(authorize?: false)
+
+    existing_cvv =
+      Storybox.Stories.CharacterViewVersion
+      |> Ash.Query.filter(character_view_id == ^character_view.id)
+      |> Ash.read!(authorize?: false)
+
+    if existing_cvv == [] do
+      Storybox.Stories.CharacterViewVersion
+      |> Ash.ActionInput.for_action(:cut, %{character_view_id: character_view.id})
+      |> Ash.run_action!(authorize?: false)
+
+      IO.puts("  Cut CharacterViewVersion v1 for #{character.name}")
+    end
   end
 
   # -- Sequences -------------------------------------------------------------

--- a/test/storybox/stories/character_piece_test.exs
+++ b/test/storybox/stories/character_piece_test.exs
@@ -1,0 +1,149 @@
+defmodule Storybox.Stories.CharacterPieceTest do
+  use Storybox.DataCase
+
+  require Ash.Query
+
+  setup do
+    {:ok, user} =
+      Storybox.Accounts.User
+      |> Ash.Changeset.for_create(:register_with_password, %{
+        email: "cp_test@example.com",
+        password: "password123!",
+        password_confirmation: "password123!"
+      })
+      |> Ash.create()
+
+    {:ok, story} =
+      Storybox.Stories.Story
+      |> Ash.Changeset.for_create(:create, %{title: "Test Story", user_id: user.id})
+      |> Ash.create()
+
+    {:ok, character_a} =
+      Storybox.Stories.Character
+      |> Ash.Changeset.for_create(:create, %{name: "Alice", story_id: story.id})
+      |> Ash.create()
+
+    {:ok, character_b} =
+      Storybox.Stories.Character
+      |> Ash.Changeset.for_create(:create, %{name: "Bob", story_id: story.id})
+      |> Ash.create()
+
+    %{character_a: character_a, character_b: character_b}
+  end
+
+  describe "create" do
+    test "persists character_id, content_uri, version_number", %{character_a: char} do
+      uri = Storybox.Storage.uri_for_character_piece(char.id, 1)
+
+      assert {:ok, piece} =
+               Storybox.Stories.CharacterPiece
+               |> Ash.Changeset.for_create(:create, %{
+                 character_id: char.id,
+                 content_uri: uri,
+                 version_number: 1
+               })
+               |> Ash.create()
+
+      assert piece.character_id == char.id
+      assert piece.content_uri == uri
+      assert piece.version_number == 1
+    end
+
+    test "fails without character_id" do
+      assert {:error, %Ash.Error.Invalid{}} =
+               Storybox.Stories.CharacterPiece
+               |> Ash.Changeset.for_create(:create, %{
+                 content_uri: "storybox://characters/x/v1",
+                 version_number: 1
+               })
+               |> Ash.create()
+    end
+
+    test "rejects duplicate (character_id, version_number)", %{character_a: char} do
+      uri = Storybox.Storage.uri_for_character_piece(char.id, 1)
+
+      {:ok, _} =
+        Storybox.Stories.CharacterPiece
+        |> Ash.Changeset.for_create(:create, %{
+          character_id: char.id,
+          content_uri: uri,
+          version_number: 1
+        })
+        |> Ash.create()
+
+      assert {:error, %Ash.Error.Invalid{}} =
+               Storybox.Stories.CharacterPiece
+               |> Ash.Changeset.for_create(:create, %{
+                 character_id: char.id,
+                 content_uri: uri,
+                 version_number: 1
+               })
+               |> Ash.create()
+    end
+  end
+
+  describe "create_version action" do
+    test "returns v1 with correct URI for first call", %{character_a: char} do
+      assert {:ok, piece} =
+               Storybox.Stories.CharacterPiece
+               |> Ash.ActionInput.for_action(:create_version, %{
+                 character_id: char.id,
+                 content: "Essence: The hero."
+               })
+               |> Ash.run_action()
+
+      assert piece.version_number == 1
+      assert piece.character_id == char.id
+      assert piece.content_uri == Storybox.Storage.uri_for_character_piece(char.id, 1)
+    end
+
+    test "second call returns v2 scoped to the same character", %{character_a: char} do
+      {:ok, _v1} =
+        Storybox.Stories.CharacterPiece
+        |> Ash.ActionInput.for_action(:create_version, %{
+          character_id: char.id,
+          content: "Version one."
+        })
+        |> Ash.run_action()
+
+      assert {:ok, v2} =
+               Storybox.Stories.CharacterPiece
+               |> Ash.ActionInput.for_action(:create_version, %{
+                 character_id: char.id,
+                 content: "Version two."
+               })
+               |> Ash.run_action()
+
+      assert v2.version_number == 2
+    end
+
+    test "counter is independent per character", %{character_a: char_a, character_b: char_b} do
+      {:ok, _} =
+        Storybox.Stories.CharacterPiece
+        |> Ash.ActionInput.for_action(:create_version, %{
+          character_id: char_a.id,
+          content: "Alice v1."
+        })
+        |> Ash.run_action()
+
+      {:ok, _} =
+        Storybox.Stories.CharacterPiece
+        |> Ash.ActionInput.for_action(:create_version, %{
+          character_id: char_a.id,
+          content: "Alice v2."
+        })
+        |> Ash.run_action()
+
+      assert {:ok, bob_v1} =
+               Storybox.Stories.CharacterPiece
+               |> Ash.ActionInput.for_action(:create_version, %{
+                 character_id: char_b.id,
+                 content: "Bob v1."
+               })
+               |> Ash.run_action()
+
+      assert bob_v1.version_number == 1
+      assert bob_v1.character_id == char_b.id
+    end
+  end
+end

--- a/test/storybox/stories/character_test.exs
+++ b/test/storybox/stories/character_test.exs
@@ -1,6 +1,8 @@
 defmodule Storybox.Stories.CharacterTest do
   use Storybox.DataCase
 
+  require Ash.Query
+
   setup do
     {:ok, user} =
       Storybox.Accounts.User
@@ -25,17 +27,11 @@ defmodule Storybox.Stories.CharacterTest do
                Storybox.Stories.Character
                |> Ash.Changeset.for_create(:create, %{
                  name: "Alice",
-                 essence: "Driven by justice",
-                 contradictions: ["brave", "reckless"],
-                 voice: "Clipped, precise",
                  story_id: story.id
                })
                |> Ash.create()
 
       assert character.name == "Alice"
-      assert character.essence == "Driven by justice"
-      assert character.contradictions == ["brave", "reckless"]
-      assert character.voice == "Clipped, precise"
       assert character.story_id == story.id
     end
 
@@ -67,7 +63,7 @@ defmodule Storybox.Stories.CharacterTest do
   end
 
   describe "update" do
-    test "changes character fields", %{story: story} do
+    test "changes character name", %{story: story} do
       {:ok, character} =
         Storybox.Stories.Character
         |> Ash.Changeset.for_create(:create, %{name: "Charlie", story_id: story.id})
@@ -75,11 +71,41 @@ defmodule Storybox.Stories.CharacterTest do
 
       assert {:ok, updated} =
                character
-               |> Ash.Changeset.for_update(:update, %{name: "Charles", voice: "Deep baritone"})
+               |> Ash.Changeset.for_update(:update, %{name: "Charles"})
                |> Ash.update()
 
       assert updated.name == "Charles"
-      assert updated.voice == "Deep baritone"
+    end
+  end
+
+  describe "has_many :character_pieces association" do
+    test "returns CharacterPieces scoped to the Character", %{story: story} do
+      {:ok, character} =
+        Storybox.Stories.Character
+        |> Ash.Changeset.for_create(:create, %{name: "Dana", story_id: story.id})
+        |> Ash.create()
+
+      {:ok, _piece} =
+        Storybox.Stories.CharacterPiece
+        |> Ash.ActionInput.for_action(:create_version, %{
+          character_id: character.id,
+          content: "Essence: Brave."
+        })
+        |> Ash.run_action()
+
+      {:ok, loaded} = Ash.load(character, :character_pieces)
+      assert length(loaded.character_pieces) == 1
+      assert hd(loaded.character_pieces).character_id == character.id
+    end
+  end
+
+  describe "resource shape" do
+    test "has no essence, voice, or contradictions attribute" do
+      attrs = Ash.Resource.Info.attributes(Storybox.Stories.Character)
+      names = Enum.map(attrs, & &1.name)
+      refute :essence in names
+      refute :voice in names
+      refute :contradictions in names
     end
   end
 end

--- a/test/storybox/stories/character_view_test.exs
+++ b/test/storybox/stories/character_view_test.exs
@@ -1,0 +1,78 @@
+defmodule Storybox.Stories.CharacterViewTest do
+  use Storybox.DataCase
+
+  require Ash.Query
+
+  setup do
+    {:ok, user} =
+      Storybox.Accounts.User
+      |> Ash.Changeset.for_create(:register_with_password, %{
+        email: "cv_test@example.com",
+        password: "password123!",
+        password_confirmation: "password123!"
+      })
+      |> Ash.create()
+
+    {:ok, story} =
+      Storybox.Stories.Story
+      |> Ash.Changeset.for_create(:create, %{title: "Test Story", user_id: user.id})
+      |> Ash.create()
+
+    {:ok, character} =
+      Storybox.Stories.Character
+      |> Ash.Changeset.for_create(:create, %{name: "Alice", story_id: story.id})
+      |> Ash.create()
+
+    %{character: character}
+  end
+
+  describe "ensure_for_character" do
+    test "creates a CharacterView on first call", %{character: character} do
+      assert {:ok, cv} =
+               Storybox.Stories.CharacterView
+               |> Ash.ActionInput.for_action(:ensure_for_character, %{
+                 character_id: character.id
+               })
+               |> Ash.run_action()
+
+      assert cv.character_id == character.id
+    end
+
+    test "is idempotent — second call returns the same record", %{character: character} do
+      {:ok, cv1} =
+        Storybox.Stories.CharacterView
+        |> Ash.ActionInput.for_action(:ensure_for_character, %{character_id: character.id})
+        |> Ash.run_action()
+
+      {:ok, cv2} =
+        Storybox.Stories.CharacterView
+        |> Ash.ActionInput.for_action(:ensure_for_character, %{character_id: character.id})
+        |> Ash.run_action()
+
+      assert cv1.id == cv2.id
+    end
+  end
+
+  describe "direct create" do
+    test "succeeds with a unique character_id", %{character: character} do
+      assert {:ok, cv} =
+               Storybox.Stories.CharacterView
+               |> Ash.Changeset.for_create(:create, %{character_id: character.id})
+               |> Ash.create()
+
+      assert cv.character_id == character.id
+    end
+
+    test "raises unique-constraint error on duplicate character_id", %{character: character} do
+      {:ok, _} =
+        Storybox.Stories.CharacterView
+        |> Ash.Changeset.for_create(:create, %{character_id: character.id})
+        |> Ash.create()
+
+      assert {:error, %Ash.Error.Invalid{}} =
+               Storybox.Stories.CharacterView
+               |> Ash.Changeset.for_create(:create, %{character_id: character.id})
+               |> Ash.create()
+    end
+  end
+end

--- a/test/storybox/stories/character_view_version_test.exs
+++ b/test/storybox/stories/character_view_version_test.exs
@@ -1,0 +1,126 @@
+defmodule Storybox.Stories.CharacterViewVersionTest do
+  use Storybox.DataCase
+
+  require Ash.Query
+
+  setup do
+    {:ok, user} =
+      Storybox.Accounts.User
+      |> Ash.Changeset.for_create(:register_with_password, %{
+        email: "cvv_test@example.com",
+        password: "password123!",
+        password_confirmation: "password123!"
+      })
+      |> Ash.create()
+
+    {:ok, story} =
+      Storybox.Stories.Story
+      |> Ash.Changeset.for_create(:create, %{title: "Test Story", user_id: user.id})
+      |> Ash.create()
+
+    {:ok, character} =
+      Storybox.Stories.Character
+      |> Ash.Changeset.for_create(:create, %{name: "Alice", story_id: story.id})
+      |> Ash.create()
+
+    {:ok, piece} =
+      Storybox.Stories.CharacterPiece
+      |> Ash.ActionInput.for_action(:create_version, %{
+        character_id: character.id,
+        content: "Essence: The hero.\n\nVoice: Bold."
+      })
+      |> Ash.run_action()
+
+    {:ok, character_view} =
+      Storybox.Stories.CharacterView
+      |> Ash.ActionInput.for_action(:ensure_for_character, %{character_id: character.id})
+      |> Ash.run_action()
+
+    %{character_view: character_view, piece: piece}
+  end
+
+  describe "cut" do
+    test "creates a CharacterViewVersion with version_number 1 on first call", %{
+      character_view: cv
+    } do
+      assert {:ok, vv} =
+               Storybox.Stories.CharacterViewVersion
+               |> Ash.ActionInput.for_action(:cut, %{character_view_id: cv.id})
+               |> Ash.run_action()
+
+      assert vv.version_number == 1
+      assert vv.character_view_id == cv.id
+    end
+
+    test "creates exactly one Segment with view_version_type :character_vv", %{
+      character_view: cv
+    } do
+      {:ok, vv} =
+        Storybox.Stories.CharacterViewVersion
+        |> Ash.ActionInput.for_action(:cut, %{character_view_id: cv.id})
+        |> Ash.run_action()
+
+      segments =
+        Storybox.Stories.Segment
+        |> Ash.Query.filter(view_version_id == ^vv.id)
+        |> Ash.read!(authorize?: false)
+
+      assert length(segments) == 1
+      [seg] = segments
+      assert seg.view_version_type == :character_vv
+    end
+
+    test "Segment carries correct pin_id, pin_type, pin_version_at_creation, and position", %{
+      character_view: cv,
+      piece: piece
+    } do
+      {:ok, vv} =
+        Storybox.Stories.CharacterViewVersion
+        |> Ash.ActionInput.for_action(:cut, %{character_view_id: cv.id})
+        |> Ash.run_action()
+
+      [seg] =
+        Storybox.Stories.Segment
+        |> Ash.Query.filter(view_version_id == ^vv.id)
+        |> Ash.read!(authorize?: false)
+
+      assert seg.pin_id == piece.id
+      assert seg.pin_type == :character_piece
+      assert seg.pin_version_at_creation == piece.version_number
+      assert seg.position == 1
+    end
+
+    test "second cut produces version_number 2", %{character_view: cv} do
+      {:ok, _vv1} =
+        Storybox.Stories.CharacterViewVersion
+        |> Ash.ActionInput.for_action(:cut, %{character_view_id: cv.id})
+        |> Ash.run_action()
+
+      {:ok, vv2} =
+        Storybox.Stories.CharacterViewVersion
+        |> Ash.ActionInput.for_action(:cut, %{character_view_id: cv.id})
+        |> Ash.run_action()
+
+      assert vv2.version_number == 2
+    end
+
+    test "Segment.resolve_pin/1 returns {:resolved, %CharacterPiece{}}", %{
+      character_view: cv,
+      piece: piece
+    } do
+      {:ok, vv} =
+        Storybox.Stories.CharacterViewVersion
+        |> Ash.ActionInput.for_action(:cut, %{character_view_id: cv.id})
+        |> Ash.run_action()
+
+      [seg] =
+        Storybox.Stories.Segment
+        |> Ash.Query.filter(view_version_id == ^vv.id)
+        |> Ash.read!(authorize?: false)
+
+      assert {:resolved, resolved_piece} = Storybox.Stories.Segment.resolve_pin(seg)
+      assert resolved_piece.id == piece.id
+      assert resolved_piece.content_uri == piece.content_uri
+    end
+  end
+end

--- a/test/storybox/stories/segment_test.exs
+++ b/test/storybox/stories/segment_test.exs
@@ -301,10 +301,10 @@ defmodule Storybox.Stories.SegmentTest do
     test "raises ArgumentError for a not-yet-implemented pin_type" do
       segment = %{
         pin_id: Ecto.UUID.generate(),
-        pin_type: :character_piece
+        pin_type: :treatment_vv
       }
 
-      assert_raise ArgumentError, ~r/:character_piece/, fn -> Segment.resolve_pin(segment) end
+      assert_raise ArgumentError, ~r/:treatment_vv/, fn -> Segment.resolve_pin(segment) end
     end
   end
 
@@ -376,10 +376,10 @@ defmodule Storybox.Stories.SegmentTest do
     test "raises ArgumentError for a not-yet-implemented pin_type" do
       segment = %{
         pin_id: Ecto.UUID.generate(),
-        pin_type: :character_piece
+        pin_type: :treatment_vv
       }
 
-      assert_raise ArgumentError, ~r/:character_piece/, fn ->
+      assert_raise ArgumentError, ~r/:treatment_vv/, fn ->
         Segment.pin_target_latest_version(segment)
       end
     end

--- a/test/storybox/stories/world_piece_test.exs
+++ b/test/storybox/stories/world_piece_test.exs
@@ -1,0 +1,154 @@
+defmodule Storybox.Stories.WorldPieceTest do
+  use Storybox.DataCase
+
+  require Ash.Query
+
+  setup do
+    {:ok, user} =
+      Storybox.Accounts.User
+      |> Ash.Changeset.for_create(:register_with_password, %{
+        email: "wp_test@example.com",
+        password: "password123!",
+        password_confirmation: "password123!"
+      })
+      |> Ash.create()
+
+    {:ok, story_a} =
+      Storybox.Stories.Story
+      |> Ash.Changeset.for_create(:create, %{title: "Story A", user_id: user.id})
+      |> Ash.create()
+
+    {:ok, story_b} =
+      Storybox.Stories.Story
+      |> Ash.Changeset.for_create(:create, %{title: "Story B", user_id: user.id})
+      |> Ash.create()
+
+    {:ok, world_a} =
+      Storybox.Stories.World
+      |> Ash.Changeset.for_create(:create, %{story_id: story_a.id})
+      |> Ash.create()
+
+    {:ok, world_b} =
+      Storybox.Stories.World
+      |> Ash.Changeset.for_create(:create, %{story_id: story_b.id})
+      |> Ash.create()
+
+    %{world_a: world_a, world_b: world_b}
+  end
+
+  describe "create" do
+    test "persists world_id, content_uri, version_number", %{world_a: world} do
+      uri = Storybox.Storage.uri_for_world_piece(world.id, 1)
+
+      assert {:ok, piece} =
+               Storybox.Stories.WorldPiece
+               |> Ash.Changeset.for_create(:create, %{
+                 world_id: world.id,
+                 content_uri: uri,
+                 version_number: 1
+               })
+               |> Ash.create()
+
+      assert piece.world_id == world.id
+      assert piece.content_uri == uri
+      assert piece.version_number == 1
+    end
+
+    test "fails without world_id" do
+      assert {:error, %Ash.Error.Invalid{}} =
+               Storybox.Stories.WorldPiece
+               |> Ash.Changeset.for_create(:create, %{
+                 content_uri: "storybox://worlds/x/v1",
+                 version_number: 1
+               })
+               |> Ash.create()
+    end
+
+    test "rejects duplicate (world_id, version_number)", %{world_a: world} do
+      uri = Storybox.Storage.uri_for_world_piece(world.id, 1)
+
+      {:ok, _} =
+        Storybox.Stories.WorldPiece
+        |> Ash.Changeset.for_create(:create, %{
+          world_id: world.id,
+          content_uri: uri,
+          version_number: 1
+        })
+        |> Ash.create()
+
+      assert {:error, %Ash.Error.Invalid{}} =
+               Storybox.Stories.WorldPiece
+               |> Ash.Changeset.for_create(:create, %{
+                 world_id: world.id,
+                 content_uri: uri,
+                 version_number: 1
+               })
+               |> Ash.create()
+    end
+  end
+
+  describe "create_version action" do
+    test "returns v1 with correct URI for first call", %{world_a: world} do
+      assert {:ok, piece} =
+               Storybox.Stories.WorldPiece
+               |> Ash.ActionInput.for_action(:create_version, %{
+                 world_id: world.id,
+                 content: "History: Ancient times."
+               })
+               |> Ash.run_action()
+
+      assert piece.version_number == 1
+      assert piece.world_id == world.id
+      assert piece.content_uri == Storybox.Storage.uri_for_world_piece(world.id, 1)
+    end
+
+    test "second call returns v2", %{world_a: world} do
+      {:ok, _v1} =
+        Storybox.Stories.WorldPiece
+        |> Ash.ActionInput.for_action(:create_version, %{
+          world_id: world.id,
+          content: "Version one."
+        })
+        |> Ash.run_action()
+
+      assert {:ok, v2} =
+               Storybox.Stories.WorldPiece
+               |> Ash.ActionInput.for_action(:create_version, %{
+                 world_id: world.id,
+                 content: "Version two."
+               })
+               |> Ash.run_action()
+
+      assert v2.version_number == 2
+    end
+
+    test "counter is independent per world", %{world_a: world_a, world_b: world_b} do
+      {:ok, _} =
+        Storybox.Stories.WorldPiece
+        |> Ash.ActionInput.for_action(:create_version, %{
+          world_id: world_a.id,
+          content: "World A v1."
+        })
+        |> Ash.run_action()
+
+      {:ok, _} =
+        Storybox.Stories.WorldPiece
+        |> Ash.ActionInput.for_action(:create_version, %{
+          world_id: world_a.id,
+          content: "World A v2."
+        })
+        |> Ash.run_action()
+
+      assert {:ok, b_v1} =
+               Storybox.Stories.WorldPiece
+               |> Ash.ActionInput.for_action(:create_version, %{
+                 world_id: world_b.id,
+                 content: "World B v1."
+               })
+               |> Ash.run_action()
+
+      assert b_v1.version_number == 1
+      assert b_v1.world_id == world_b.id
+    end
+  end
+end

--- a/test/storybox/stories/world_test.exs
+++ b/test/storybox/stories/world_test.exs
@@ -1,6 +1,8 @@
 defmodule Storybox.Stories.WorldTest do
   use Storybox.DataCase
 
+  require Ash.Query
+
   setup do
     {:ok, user} =
       Storybox.Accounts.User
@@ -23,34 +25,16 @@ defmodule Storybox.Stories.WorldTest do
     test "creates a world with story_id", %{story: story} do
       assert {:ok, world} =
                Storybox.Stories.World
-               |> Ash.Changeset.for_create(:create, %{
-                 history: "Founded in 1842",
-                 rules: "Magic costs memory",
-                 subtext: "Power corrupts",
-                 story_id: story.id
-               })
-               |> Ash.create()
-
-      assert world.history == "Founded in 1842"
-      assert world.rules == "Magic costs memory"
-      assert world.subtext == "Power corrupts"
-      assert world.story_id == story.id
-    end
-
-    test "creates a world with only story_id (all fields optional)", %{story: story} do
-      assert {:ok, world} =
-               Storybox.Stories.World
                |> Ash.Changeset.for_create(:create, %{story_id: story.id})
                |> Ash.create()
 
       assert world.story_id == story.id
-      assert world.history == nil
     end
 
     test "fails without a story_id" do
       assert {:error, %Ash.Error.Invalid{}} =
                Storybox.Stories.World
-               |> Ash.Changeset.for_create(:create, %{history: "No story"})
+               |> Ash.Changeset.for_create(:create, %{})
                |> Ash.create()
     end
   end
@@ -59,31 +43,39 @@ defmodule Storybox.Stories.WorldTest do
     test "returns created worlds", %{story: story} do
       {:ok, _} =
         Storybox.Stories.World
-        |> Ash.Changeset.for_create(:create, %{history: "Ancient times", story_id: story.id})
+        |> Ash.Changeset.for_create(:create, %{story_id: story.id})
         |> Ash.create()
 
       assert {:ok, worlds} = Storybox.Stories.World |> Ash.read()
-      assert Enum.any?(worlds, &(&1.history == "Ancient times"))
+      assert Enum.any?(worlds, &(&1.story_id == story.id))
     end
   end
 
-  describe "update" do
-    test "changes world fields", %{story: story} do
+  describe "has_one :world_view association" do
+    test "loads the WorldView after it is created", %{story: story} do
       {:ok, world} =
         Storybox.Stories.World
-        |> Ash.Changeset.for_create(:create, %{history: "Old history", story_id: story.id})
+        |> Ash.Changeset.for_create(:create, %{story_id: story.id})
         |> Ash.create()
 
-      assert {:ok, updated} =
-               world
-               |> Ash.Changeset.for_update(:update, %{
-                 history: "New history",
-                 subtext: "Decay is inevitable"
-               })
-               |> Ash.update()
+      {:ok, _wv} =
+        Storybox.Stories.WorldView
+        |> Ash.ActionInput.for_action(:ensure_for_world, %{world_id: world.id})
+        |> Ash.run_action()
 
-      assert updated.history == "New history"
-      assert updated.subtext == "Decay is inevitable"
+      {:ok, loaded} = Ash.load(world, :world_view)
+      assert loaded.world_view != nil
+      assert loaded.world_view.world_id == world.id
+    end
+  end
+
+  describe "resource shape" do
+    test "has no history, rules, or subtext attribute" do
+      attrs = Ash.Resource.Info.attributes(Storybox.Stories.World)
+      names = Enum.map(attrs, & &1.name)
+      refute :history in names
+      refute :rules in names
+      refute :subtext in names
     end
   end
 end

--- a/test/storybox/stories/world_view_test.exs
+++ b/test/storybox/stories/world_view_test.exs
@@ -1,0 +1,76 @@
+defmodule Storybox.Stories.WorldViewTest do
+  use Storybox.DataCase
+
+  require Ash.Query
+
+  setup do
+    {:ok, user} =
+      Storybox.Accounts.User
+      |> Ash.Changeset.for_create(:register_with_password, %{
+        email: "wv_test@example.com",
+        password: "password123!",
+        password_confirmation: "password123!"
+      })
+      |> Ash.create()
+
+    {:ok, story} =
+      Storybox.Stories.Story
+      |> Ash.Changeset.for_create(:create, %{title: "Test Story", user_id: user.id})
+      |> Ash.create()
+
+    {:ok, world} =
+      Storybox.Stories.World
+      |> Ash.Changeset.for_create(:create, %{story_id: story.id})
+      |> Ash.create()
+
+    %{world: world}
+  end
+
+  describe "ensure_for_world" do
+    test "creates a WorldView on first call", %{world: world} do
+      assert {:ok, wv} =
+               Storybox.Stories.WorldView
+               |> Ash.ActionInput.for_action(:ensure_for_world, %{world_id: world.id})
+               |> Ash.run_action()
+
+      assert wv.world_id == world.id
+    end
+
+    test "is idempotent — second call returns the same record", %{world: world} do
+      {:ok, wv1} =
+        Storybox.Stories.WorldView
+        |> Ash.ActionInput.for_action(:ensure_for_world, %{world_id: world.id})
+        |> Ash.run_action()
+
+      {:ok, wv2} =
+        Storybox.Stories.WorldView
+        |> Ash.ActionInput.for_action(:ensure_for_world, %{world_id: world.id})
+        |> Ash.run_action()
+
+      assert wv1.id == wv2.id
+    end
+  end
+
+  describe "direct create" do
+    test "succeeds with a unique world_id", %{world: world} do
+      assert {:ok, wv} =
+               Storybox.Stories.WorldView
+               |> Ash.Changeset.for_create(:create, %{world_id: world.id})
+               |> Ash.create()
+
+      assert wv.world_id == world.id
+    end
+
+    test "raises unique-constraint error on duplicate world_id", %{world: world} do
+      {:ok, _} =
+        Storybox.Stories.WorldView
+        |> Ash.Changeset.for_create(:create, %{world_id: world.id})
+        |> Ash.create()
+
+      assert {:error, %Ash.Error.Invalid{}} =
+               Storybox.Stories.WorldView
+               |> Ash.Changeset.for_create(:create, %{world_id: world.id})
+               |> Ash.create()
+    end
+  end
+end

--- a/test/storybox/stories/world_view_version_test.exs
+++ b/test/storybox/stories/world_view_version_test.exs
@@ -1,0 +1,124 @@
+defmodule Storybox.Stories.WorldViewVersionTest do
+  use Storybox.DataCase
+
+  require Ash.Query
+
+  setup do
+    {:ok, user} =
+      Storybox.Accounts.User
+      |> Ash.Changeset.for_create(:register_with_password, %{
+        email: "wvv_test@example.com",
+        password: "password123!",
+        password_confirmation: "password123!"
+      })
+      |> Ash.create()
+
+    {:ok, story} =
+      Storybox.Stories.Story
+      |> Ash.Changeset.for_create(:create, %{title: "Test Story", user_id: user.id})
+      |> Ash.create()
+
+    {:ok, world} =
+      Storybox.Stories.World
+      |> Ash.Changeset.for_create(:create, %{story_id: story.id})
+      |> Ash.create()
+
+    {:ok, piece} =
+      Storybox.Stories.WorldPiece
+      |> Ash.ActionInput.for_action(:create_version, %{
+        world_id: world.id,
+        content: "History: Ancient.\n\nRules: Magic costs.\n\nSubtext: Power corrupts."
+      })
+      |> Ash.run_action()
+
+    {:ok, world_view} =
+      Storybox.Stories.WorldView
+      |> Ash.ActionInput.for_action(:ensure_for_world, %{world_id: world.id})
+      |> Ash.run_action()
+
+    %{world_view: world_view, piece: piece}
+  end
+
+  describe "cut" do
+    test "creates a WorldViewVersion with version_number 1 on first call", %{
+      world_view: wv
+    } do
+      assert {:ok, vv} =
+               Storybox.Stories.WorldViewVersion
+               |> Ash.ActionInput.for_action(:cut, %{world_view_id: wv.id})
+               |> Ash.run_action()
+
+      assert vv.version_number == 1
+      assert vv.world_view_id == wv.id
+    end
+
+    test "creates exactly one Segment with view_version_type :world_vv", %{world_view: wv} do
+      {:ok, vv} =
+        Storybox.Stories.WorldViewVersion
+        |> Ash.ActionInput.for_action(:cut, %{world_view_id: wv.id})
+        |> Ash.run_action()
+
+      segments =
+        Storybox.Stories.Segment
+        |> Ash.Query.filter(view_version_id == ^vv.id)
+        |> Ash.read!(authorize?: false)
+
+      assert length(segments) == 1
+      [seg] = segments
+      assert seg.view_version_type == :world_vv
+    end
+
+    test "Segment carries correct pin_id, pin_type, pin_version_at_creation, and position", %{
+      world_view: wv,
+      piece: piece
+    } do
+      {:ok, vv} =
+        Storybox.Stories.WorldViewVersion
+        |> Ash.ActionInput.for_action(:cut, %{world_view_id: wv.id})
+        |> Ash.run_action()
+
+      [seg] =
+        Storybox.Stories.Segment
+        |> Ash.Query.filter(view_version_id == ^vv.id)
+        |> Ash.read!(authorize?: false)
+
+      assert seg.pin_id == piece.id
+      assert seg.pin_type == :world_piece
+      assert seg.pin_version_at_creation == piece.version_number
+      assert seg.position == 1
+    end
+
+    test "second cut produces version_number 2", %{world_view: wv} do
+      {:ok, _vv1} =
+        Storybox.Stories.WorldViewVersion
+        |> Ash.ActionInput.for_action(:cut, %{world_view_id: wv.id})
+        |> Ash.run_action()
+
+      {:ok, vv2} =
+        Storybox.Stories.WorldViewVersion
+        |> Ash.ActionInput.for_action(:cut, %{world_view_id: wv.id})
+        |> Ash.run_action()
+
+      assert vv2.version_number == 2
+    end
+
+    test "Segment.resolve_pin/1 returns {:resolved, %WorldPiece{}}", %{
+      world_view: wv,
+      piece: piece
+    } do
+      {:ok, vv} =
+        Storybox.Stories.WorldViewVersion
+        |> Ash.ActionInput.for_action(:cut, %{world_view_id: wv.id})
+        |> Ash.run_action()
+
+      [seg] =
+        Storybox.Stories.Segment
+        |> Ash.Query.filter(view_version_id == ^vv.id)
+        |> Ash.read!(authorize?: false)
+
+      assert {:resolved, resolved_piece} = Storybox.Stories.Segment.resolve_pin(seg)
+      assert resolved_piece.id == piece.id
+      assert resolved_piece.content_uri == piece.content_uri
+    end
+  end
+end

--- a/test/storybox_web/live/story_overview_live_test.exs
+++ b/test/storybox_web/live/story_overview_live_test.exs
@@ -6,12 +6,12 @@ defmodule StoryboxWeb.StoryOverviewLiveTest do
   # Seed data graph:
   #
   #   alice ──► "The Grand Illusion" (story)
-  #               ├── Character: "Marcel"   (essence, voice, contradictions)
-  #               ├── Character: "Nora"     (essence only)
-  #               ├── World                 (history, rules, subtext)
+  #               ├── Character: "Marcel"   (CharacterPiece: essence, voice, contradictions)
+  #               ├── Character: "Nora"     (CharacterPiece: essence only)
+  #               ├── World                 (WorldPiece: history, rules, subtext)
   #               ├── SynopsisView          (one per story)
-  #               │     ├── SynopsisViewVersion v1  (older)
-  #               │     └── SynopsisViewVersion v2  (latest)
+  #               │     ├── SynopsisViewVersion v2  (older)
+  #               │     └── SynopsisViewVersion v3  (latest)
   #
   #   bob  ──► "Bob's Story" (separate user, used for auth isolation checks)
 
@@ -49,31 +49,74 @@ defmodule StoryboxWeb.StoryOverviewLiveTest do
       Storybox.Stories.Character
       |> Ash.Changeset.for_create(:create, %{
         name: "Marcel",
-        essence: "Dignified soldier",
-        voice: "Formal and restrained",
-        contradictions: ["noble yet complicit", "loyal yet resigned"],
         story_id: story.id
       })
       |> Ash.create()
+
+    {:ok, _} =
+      Storybox.Stories.CharacterPiece
+      |> Ash.ActionInput.for_action(:create_version, %{
+        character_id: marcel.id,
+        content:
+          "Essence: Dignified soldier\n\nVoice: Formal and restrained\n\nContradictions:\n- noble yet complicit\n- loyal yet resigned"
+      })
+      |> Ash.run_action()
+
+    {:ok, marcel_view} =
+      Storybox.Stories.CharacterView
+      |> Ash.ActionInput.for_action(:ensure_for_character, %{character_id: marcel.id})
+      |> Ash.run_action()
+
+    Storybox.Stories.CharacterViewVersion
+    |> Ash.ActionInput.for_action(:cut, %{character_view_id: marcel_view.id})
+    |> Ash.run_action!()
 
     {:ok, nora} =
       Storybox.Stories.Character
       |> Ash.Changeset.for_create(:create, %{
         name: "Nora",
-        essence: "Pragmatic survivor",
         story_id: story.id
       })
       |> Ash.create()
 
+    {:ok, _} =
+      Storybox.Stories.CharacterPiece
+      |> Ash.ActionInput.for_action(:create_version, %{
+        character_id: nora.id,
+        content: "Essence: Pragmatic survivor"
+      })
+      |> Ash.run_action()
+
+    {:ok, nora_view} =
+      Storybox.Stories.CharacterView
+      |> Ash.ActionInput.for_action(:ensure_for_character, %{character_id: nora.id})
+      |> Ash.run_action()
+
+    Storybox.Stories.CharacterViewVersion
+    |> Ash.ActionInput.for_action(:cut, %{character_view_id: nora_view.id})
+    |> Ash.run_action!()
+
     {:ok, world} =
       Storybox.Stories.World
-      |> Ash.Changeset.for_create(:create, %{
-        history: "Post-war Paris",
-        rules: "Trust no one",
-        subtext: "Loss of innocence",
-        story_id: story.id
-      })
+      |> Ash.Changeset.for_create(:create, %{story_id: story.id})
       |> Ash.create()
+
+    {:ok, _} =
+      Storybox.Stories.WorldPiece
+      |> Ash.ActionInput.for_action(:create_version, %{
+        world_id: world.id,
+        content: "History: Post-war Paris\n\nRules: Trust no one\n\nSubtext: Loss of innocence"
+      })
+      |> Ash.run_action()
+
+    {:ok, world_view} =
+      Storybox.Stories.WorldView
+      |> Ash.ActionInput.for_action(:ensure_for_world, %{world_id: world.id})
+      |> Ash.run_action()
+
+    Storybox.Stories.WorldViewVersion
+    |> Ash.ActionInput.for_action(:cut, %{world_view_id: world_view.id})
+    |> Ash.run_action!()
 
     {:ok, synopsis_view} =
       Storybox.Stories.SynopsisView
@@ -261,11 +304,11 @@ defmodule StoryboxWeb.StoryOverviewLiveTest do
       assert html =~ "Latest"
     end
 
-    test "shows v1 in the version list", %{conn: conn, alice: alice, story: story} do
+    test "shows v2 in the version list", %{conn: conn, alice: alice, story: story} do
       conn = log_in_user(conn, alice)
       {:ok, _view, html} = live(conn, "/stories/#{story.id}")
 
-      assert html =~ "v1"
+      assert html =~ "v2"
     end
 
     test "shows the bootstrap synopsis version (v1) for a freshly created story", %{


### PR DESCRIPTION
## Summary

- Drops `essence`, `voice`, `contradictions` from `Character` and `history`, `rules`, `subtext` from `World`
- Adds 6 new resources: `CharacterPiece`, `CharacterView`, `CharacterViewVersion`, `WorldPiece`, `WorldView`, `WorldViewVersion` — all following the same View+Piece pattern as Script/Sequence/Synopsis
- Migration creates 6 new tables and drops 6 content columns; seeds re-seeded with plain-text content blobs
- `StoryOverviewLive` now resolves character/world content via View→VV→Segment→Piece→MinIO
- `Segment.pin_module!/1` and `pin_target_latest_version/1` extended for `:character_piece` and `:world_piece`
- 6 new test files; `character_test.exs`, `world_test.exs`, `segment_test.exs`, and `story_overview_live_test.exs` updated
- Fixes two pre-existing seeds bugs (stale `ScriptView.title` input and removed `approve_version` action) that only surfaced on a full `mix ecto.reset`

Closes #101

## Test plan

- [x] `mix precommit` passes (264 tests, 0 failures)
- [ ] Reset DB and re-run seeds: `podman compose -f podman-compose.yml run --rm app mix ecto.reset`
- [ ] Log in as `dev@storybox.test` / `Password1!` at http://localhost:4000
- [ ] Navigate to **Little Witch** story overview — Characters section renders all five characters with content visible
- [ ] World section renders with labelled content (History / Rules / Subtext) and a "Last updated" timestamp
- [ ] No crash or blank card — no `KeyError` / `UndefinedFunctionError` on dropped fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)