### PR TITLE
Make plan-issue + do-issue replan-aware

### DIFF
--- a/.claude/commands/do-issue.md
+++ b/.claude/commands/do-issue.md
@@ -8,15 +8,15 @@ gh issue view $ARGUMENTS --repo StoryBox-io/storybox-mvp
 
 Note the title, milestone, labels, and Domain block.
 
-## Step 2 — Check for an existing planning proposal
+## Step 2 — Identify the current planning proposal
 
 ```
 gh issue view $ARGUMENTS --repo StoryBox-io/storybox-mvp --comments
 ```
 
-Look for:
-- A comment containing `## Planning proposal` (the plan)
-- A comment containing `## Orchestrator review` (the approval)
+Find every comment whose body contains the heading `## Planning proposal`. There may be more than one — issues can be replanned when the orchestrator updates scope or design. **The current plan is the comment with the most recent `createdAt` timestamp.** Older `## Planning proposal` comments are superseded historical context — ignore them when implementing. (A current plan should also have a `_Supersedes [previous plan](...)_` line at the top if it superseded an earlier one; absence of that line on a sole plan comment is normal for first-time plans.)
+
+Then look for an **orchestrator review** that applies to the current plan: a comment containing `## Orchestrator review` whose `createdAt` timestamp is **after** the current plan's timestamp. Reviews older than the current plan reviewed a superseded plan and do not apply.
 
 ---
 
@@ -32,17 +32,17 @@ Report the Actions run URL and tell the user: the planning agent is running and 
 
 ---
 
-## If a planning proposal EXISTS but NO orchestrator review exists
+## If a current planning proposal EXISTS but NO orchestrator review (newer than the plan) exists
 
-Check the **Questions / ambiguities** section of the proposal:
+Check the **Questions / ambiguities** section of the current plan:
 - If it says `None` — the plan is self-contained. Proceed with implementation.
-- If it lists open questions — tell the user the plan has unresolved questions that need orchestrator review. Do not implement. Stop here.
+- If it lists open questions — tell the user the current plan has unresolved questions that need orchestrator review. Do not implement. Stop here.
 
 ---
 
-## If BOTH a planning proposal AND an orchestrator review exist
+## If BOTH a current planning proposal AND a newer orchestrator review exist
 
-Read both comments in full. The orchestrator review may override or constrain the plan — its instructions take precedence over the planning proposal where they conflict.
+Read both comments in full. The orchestrator review may override or constrain the plan — its instructions take precedence over the current planning proposal where they conflict. Do **not** read superseded older `## Planning proposal` or `## Orchestrator review` comments — they have no bearing on what to implement now.
 
 Implement now.
 

--- a/.github/prompts/plan-issue.md
+++ b/.github/prompts/plan-issue.md
@@ -16,7 +16,28 @@ Parse the **Domain** block to understand:
 - What is NOT ALLOWED (out of scope — do not propose it)
 - Reference content listed (read those files first)
 
-## Step 2 — Investigate the codebase
+## Step 2 — Check for prior planning proposals
+
+```
+gh issue view $ISSUE_NUMBER --repo StoryBox-io/storybox-mvp --comments
+```
+
+Look for any existing comments containing `## Planning proposal`. **If one or more exist, you are doing a replan, not a fresh plan.** Handle as follows:
+
+1. Read each prior plan in full to understand what was previously proposed.
+2. Read all comments posted **after** the most recent prior plan — these are orchestrator feedback indicating why the prior plan is being revisited (scope changes, design updates, missing concerns, mistaken assumptions).
+3. The **issue body** is the source of truth for what is currently wanted. If it has been updated since a prior plan was posted, the body wins over the plan. Detect this by checking if the body contains content not reflected in the prior plan, or if it explicitly says the prior plan is superseded.
+4. Capture the URL of the most recent prior plan comment — you will reference it at the top of your new plan.
+5. Your new plan must be **self-contained**. Do not write "see prior plan" or "as previously discussed" — a reader of just your new plan should understand the work without reading the old one.
+6. At the very top of your new comment body (before `## Planning proposal`), include a single italicised line linking the most recent prior plan as superseded:
+
+   ```
+   _Supersedes [previous plan](<comment URL>)._
+   ```
+
+If **no** prior plan comments exist, this is a fresh plan — proceed without the supersedes line.
+
+## Step 3 — Investigate the codebase
 
 Read the files named in the Domain block. Then follow the data model outward as needed:
 - Ash resources under `lib/storybox/stories/`
@@ -25,7 +46,7 @@ Read the files named in the Domain block. Then follow the data model outward as 
 
 Use only: `Read`, `Glob`, `Grep`, `Bash` (read-only shell commands — `mix`, `grep`, `find`, `cat`). Do NOT edit or create files.
 
-## Step 3 — Produce your proposal
+## Step 4 — Produce your proposal
 
 Structure the proposal as follows. Be concrete — name exact files, function names, and migration names.
 
@@ -126,7 +147,7 @@ mix ecto.reset
 - [ ] step 2
 ```
 
-## Step 4 — Post the proposal
+## Step 5 — Post the proposal
 
 Post your proposal as a comment on the issue:
 


### PR DESCRIPTION
## Summary

When an issue is replanned (orchestrator updates scope or design after the original plan was posted), the workflow needs to handle multiple `## Planning proposal` comments coherently. This PR makes the planning prompt and the do-issue skill replan-aware.

## Why

Surfaced from #103, where the issue body was substantively rewritten after the original plan was posted. The original setup had two gaps:

- `plan-issue.yml` prompt told the agent to post a fresh plan with no awareness of prior plans. Triggering it on a replanned issue would produce two `## Planning proposal` comments with no signal which was current.
- `do-issue.md` searched for a single `## Planning proposal` comment via substring match. With multiple plans present, behaviour was undefined — the work agent could pick the wrong one.

Without these fixes, every replan would require manual workarounds (deleting old plans, editing comment headings, etc).

## Changes

- **`.github/prompts/plan-issue.md`** — new Step 2 detects prior plan comments and treats the work as a replan. Reads prior plans as historical context, reads all comments after the most recent prior plan as orchestrator feedback, and treats the issue body as the source of truth. Prepends a `_Supersedes [previous plan](url)._` line at the top of the new plan so humans browsing can see the chain. New plan is self-contained — readers do not need the prior plan.
- **`.claude/commands/do-issue.md`** — identifies the current plan as the `## Planning proposal` comment with the most recent `createdAt` timestamp; older such comments are explicitly ignored as superseded. The orchestrator review must also be newer than the current plan to apply (older reviews reviewed superseded plans).

## Test plan

- [ ] Trigger plan-issue on a fresh issue (no prior plans) — confirm a normal `## Planning proposal` comment with no supersedes line
- [ ] Trigger plan-issue on an issue with one prior plan (i.e., #103) — confirm new plan has the supersedes link to the old plan, reads orchestrator feedback comments after the old plan, and is self-contained
- [ ] Run /do-issue on an issue with multiple `## Planning proposal` comments — confirm only the most recent one is read, older ones are ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)