### PR TITLE
Add Cut-ViewVersion API endpoints (#104)

### DIFF
--- a/lib/storybox_web/controllers/api_controller.ex
+++ b/lib/storybox_web/controllers/api_controller.ex
@@ -385,6 +385,129 @@ defmodule StoryboxWeb.ApiController do
     end
   end
 
+  def cut_synopsis_vv(conn, _params) do
+    story = conn.assigns.current_story
+
+    with {:ok, view} <-
+           Storybox.Stories.SynopsisView
+           |> Ash.ActionInput.for_action(:ensure_for_story, %{story_id: story.id})
+           |> Ash.run_action(authorize?: false),
+         {:ok, vv} <-
+           Storybox.Stories.SynopsisViewVersion
+           |> Ash.ActionInput.for_action(:cut, %{synopsis_view_id: view.id})
+           |> Ash.run_action(authorize?: false) do
+      conn |> put_status(201) |> json(format_cut_vv(vv, :synopsis_vv))
+    else
+      {:error, _} -> conn |> put_status(500) |> json(%{error: "internal error"})
+    end
+  end
+
+  def cut_treatment_vv(conn, _params) do
+    story = conn.assigns.current_story
+
+    with {:ok, view} <-
+           Storybox.Stories.TreatmentView
+           |> Ash.ActionInput.for_action(:ensure_for_story, %{story_id: story.id})
+           |> Ash.run_action(authorize?: false),
+         {:ok, vv} <-
+           Storybox.Stories.TreatmentViewVersion
+           |> Ash.ActionInput.for_action(:cut, %{treatment_view_id: view.id})
+           |> Ash.run_action(authorize?: false) do
+      conn |> put_status(201) |> json(format_cut_vv(vv, :treatment_vv))
+    else
+      {:error, _} -> conn |> put_status(500) |> json(%{error: "internal error"})
+    end
+  end
+
+  def cut_story_script_vv(conn, _params) do
+    story = conn.assigns.current_story
+
+    with {:ok, view} <-
+           Storybox.Stories.StoryScriptView
+           |> Ash.ActionInput.for_action(:ensure_for_story, %{story_id: story.id})
+           |> Ash.run_action(authorize?: false),
+         {:ok, vv} <-
+           Storybox.Stories.StoryScriptViewVersion
+           |> Ash.ActionInput.for_action(:cut, %{story_script_view_id: view.id})
+           |> Ash.run_action(authorize?: false) do
+      conn |> put_status(201) |> json(format_cut_vv(vv, :story_script_vv))
+    else
+      {:error, _} -> conn |> put_status(500) |> json(%{error: "internal error"})
+    end
+  end
+
+  def cut_sequence_vv(conn, %{"seq_id" => seq_id} = params) do
+    story = conn.assigns.current_story
+    script_view_version_ids = Map.get(params, "script_view_version_ids", [])
+
+    case load_sequence_for_story(seq_id, story.id) do
+      nil ->
+        conn |> put_status(404) |> json(%{error: "not found"})
+
+      sequence ->
+        with {:ok, view} <-
+               Storybox.Stories.SequenceView
+               |> Ash.ActionInput.for_action(:ensure_for_sequence, %{
+                 sequence_id: sequence.id,
+                 story_id: story.id
+               })
+               |> Ash.run_action(authorize?: false),
+             {:ok, vv} <-
+               Storybox.Stories.SequenceViewVersion
+               |> Ash.ActionInput.for_action(:cut, %{
+                 sequence_view_id: view.id,
+                 script_view_version_ids: script_view_version_ids
+               })
+               |> Ash.run_action(authorize?: false) do
+          conn |> put_status(201) |> json(format_cut_vv(vv, :sequence_vv))
+        else
+          {:error, _} -> conn |> put_status(500) |> json(%{error: "internal error"})
+        end
+    end
+  end
+
+  def cut_script_vv(conn, %{"scene_id" => scene_id} = params) do
+    case params["script_piece_id"] do
+      nil ->
+        conn |> put_status(400) |> json(%{error: "script_piece_id is required"})
+
+      script_piece_id ->
+        scene =
+          Storybox.Stories.Scene
+          |> Ash.Query.filter(id == ^scene_id)
+          |> Ash.read_one!(authorize?: false)
+
+        if is_nil(scene) do
+          conn |> put_status(404) |> json(%{error: "not found"})
+        else
+          piece =
+            Storybox.Stories.ScriptPiece
+            |> Ash.Query.filter(id == ^script_piece_id and scene_id == ^scene.id)
+            |> Ash.read_one!(authorize?: false)
+
+          if is_nil(piece) do
+            conn |> put_status(404) |> json(%{error: "not found"})
+          else
+            with {:ok, view} <-
+                   Storybox.Stories.ScriptView
+                   |> Ash.ActionInput.for_action(:ensure_for_scene, %{scene_id: scene.id})
+                   |> Ash.run_action(authorize?: false),
+                 {:ok, vv} <-
+                   Storybox.Stories.ScriptViewVersion
+                   |> Ash.ActionInput.for_action(:cut, %{
+                     script_view_id: view.id,
+                     script_piece_id: piece.id
+                   })
+                   |> Ash.run_action(authorize?: false) do
+              conn |> put_status(201) |> json(format_cut_vv(vv, :script_vv))
+            else
+              {:error, _} -> conn |> put_status(500) |> json(%{error: "internal error"})
+            end
+          end
+        end
+    end
+  end
+
   defp load_task_for_story(task_id, story_id) do
     Storybox.Stories.Task
     |> Ash.Query.filter(id == ^task_id and story_id == ^story_id)
@@ -422,6 +545,26 @@ defmodule StoryboxWeb.ApiController do
       inserted_at: task.inserted_at,
       updated_at: task.updated_at
     }
+  end
+
+  defp format_cut_vv(vv, vv_type) do
+    unresolvable =
+      Storybox.Stories.Segment
+      |> Ash.Query.filter(view_version_id == ^vv.id and view_version_type == ^vv_type)
+      |> Ash.read!(authorize?: false)
+      |> Enum.filter(fn seg -> is_nil(seg.pin_id) end)
+      |> Enum.map(fn seg ->
+        base = %{id: seg.id, position: seg.position}
+        if seg.sequence_id, do: Map.put(base, :sequence_id, seg.sequence_id), else: base
+      end)
+
+    %{id: vv.id, version_number: vv.version_number, unresolvable_segments: unresolvable}
+  end
+
+  defp load_sequence_for_story(seq_id, story_id) do
+    Storybox.Stories.Sequence
+    |> Ash.Query.filter(id == ^seq_id and story_id == ^story_id)
+    |> Ash.read_one!(authorize?: false)
   end
 
   defp format_version(nil), do: nil

--- a/lib/storybox_web/router.ex
+++ b/lib/storybox_web/router.ex
@@ -51,6 +51,15 @@ defmodule StoryboxWeb.Router do
     get "/stories/:story_id/tasks", ApiController, :list_tasks
     post "/stories/:story_id/tasks/:id/in_progress", ApiController, :mark_task_in_progress
     post "/stories/:story_id/tasks/:id/complete", ApiController, :mark_task_complete
+    post "/stories/:story_id/views/synopsis/cut", ApiController, :cut_synopsis_vv
+    post "/stories/:story_id/views/treatment/cut", ApiController, :cut_treatment_vv
+
+    post "/stories/:story_id/sequences/:seq_id/views/sequence/cut",
+         ApiController,
+         :cut_sequence_vv
+
+    post "/stories/:story_id/scenes/:scene_id/views/script/cut", ApiController, :cut_script_vv
+    post "/stories/:story_id/views/story_script/cut", ApiController, :cut_story_script_vv
   end
 
   # Enable LiveDashboard and Swoosh mailbox preview in development

--- a/test/storybox_web/controllers/cut_view_version_test.exs
+++ b/test/storybox_web/controllers/cut_view_version_test.exs
@@ -1,0 +1,387 @@
+defmodule StoryboxWeb.CutViewVersionTest do
+  use StoryboxWeb.ConnCase
+
+  alias Storybox.Accounts.ApiToken
+
+  require Ash.Query
+
+  # Bootstrap (BootstrapStory) runs on Story.create and creates:
+  #   Sequence 1, TreatmentView + TVV v1 (nil-pin seg), SynopsisView + SVV v1 (nil-pin seg).
+  #
+  # Setup adds on top of that:
+  #   StoryScriptView (not bootstrapped)
+  #   SequenceView for the bootstrap sequence (not bootstrapped)
+  #   Scene + ScriptView + ScriptPiece v1
+  #
+  # other_story exists only for 403/404 cross-story tests.
+  # raw_token scoped to story; raw_token_other scoped to other_story.
+
+  setup do
+    {:ok, user} =
+      Storybox.Accounts.User
+      |> Ash.Changeset.for_create(:register_with_password, %{
+        email: "cut_vv_test@example.com",
+        password: "password123!",
+        password_confirmation: "password123!"
+      })
+      |> Ash.create()
+
+    {:ok, story} =
+      Storybox.Stories.Story
+      |> Ash.Changeset.for_create(:create, %{title: "Cut VV Story", user_id: user.id})
+      |> Ash.create()
+
+    {:ok, other_story} =
+      Storybox.Stories.Story
+      |> Ash.Changeset.for_create(:create, %{title: "Other Story", user_id: user.id})
+      |> Ash.create()
+
+    {:ok, raw_token, _} = ApiToken.generate(%{story_id: story.id, user_id: user.id})
+    {:ok, raw_token_other, _} = ApiToken.generate(%{story_id: other_story.id, user_id: user.id})
+
+    # Bootstrap created "Sequence 1" — query it
+    sequence =
+      Storybox.Stories.Sequence
+      |> Ash.Query.filter(story_id == ^story.id)
+      |> Ash.read_one!(authorize?: false)
+
+    other_sequence =
+      Storybox.Stories.Sequence
+      |> Ash.Query.filter(story_id == ^other_story.id)
+      |> Ash.read_one!(authorize?: false)
+
+    # StoryScriptView is not bootstrapped — create it for the story_script cut test
+    {:ok, _story_script_view} =
+      Storybox.Stories.StoryScriptView
+      |> Ash.Changeset.for_create(:create, %{story_id: story.id})
+      |> Ash.create(authorize?: false)
+
+    # SequenceView is not bootstrapped — create it for the sequence cut test
+    {:ok, _sequence_view} =
+      Storybox.Stories.SequenceView
+      |> Ash.Changeset.for_create(:create, %{sequence_id: sequence.id, story_id: story.id})
+      |> Ash.create(authorize?: false)
+
+    {:ok, scene} =
+      Storybox.Stories.Scene
+      |> Ash.Changeset.for_create(:create, %{title: "Scene 1", story_id: story.id})
+      |> Ash.create(authorize?: false)
+
+    {:ok, _script_view} =
+      Storybox.Stories.ScriptView
+      |> Ash.Changeset.for_create(:create, %{scene_id: scene.id})
+      |> Ash.create(authorize?: false)
+
+    {:ok, script_piece} =
+      Storybox.Stories.ScriptPiece
+      |> Ash.Changeset.for_create(:create, %{
+        scene_id: scene.id,
+        content_uri: Storybox.Storage.uri_for_script_piece(scene.id, 1),
+        version_number: 1,
+        weights: %{}
+      })
+      |> Ash.create(authorize?: false)
+
+    %{
+      story: story,
+      other_story: other_story,
+      sequence: sequence,
+      other_sequence: other_sequence,
+      scene: scene,
+      script_piece: script_piece,
+      raw_token: raw_token,
+      raw_token_other: raw_token_other
+    }
+  end
+
+  describe "POST /api/stories/:story_id/views/synopsis/cut" do
+    test "201 with id, version_number 2, and unresolvable_segments for nil-pin sequences", %{
+      conn: conn,
+      story: story,
+      raw_token: token
+    } do
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{token}")
+        |> post("/api/stories/#{story.id}/views/synopsis/cut")
+
+      body = json_response(conn, 201)
+      assert body["id"]
+      # bootstrap created v1; this cut creates v2
+      assert body["version_number"] == 2
+      # bootstrap sequence has no SynopsisPiece → one unresolvable segment
+      assert length(body["unresolvable_segments"]) == 1
+      [seg] = body["unresolvable_segments"]
+      assert seg["position"] == 1
+    end
+
+    test "401 without token", %{conn: conn, story: story} do
+      conn = post(conn, "/api/stories/#{story.id}/views/synopsis/cut")
+      assert json_response(conn, 401)
+    end
+
+    test "403 when token story does not match path story_id", %{
+      conn: conn,
+      story: story,
+      raw_token_other: token_other
+    } do
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{token_other}")
+        |> post("/api/stories/#{story.id}/views/synopsis/cut")
+
+      assert json_response(conn, 403)
+    end
+  end
+
+  describe "POST /api/stories/:story_id/views/treatment/cut" do
+    test "201 with version_number 2 (bootstrap created v1)", %{
+      conn: conn,
+      story: story,
+      raw_token: token
+    } do
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{token}")
+        |> post("/api/stories/#{story.id}/views/treatment/cut")
+
+      body = json_response(conn, 201)
+      assert body["id"]
+      assert body["version_number"] == 2
+      assert is_list(body["unresolvable_segments"])
+    end
+
+    test "401 without token", %{conn: conn, story: story} do
+      conn = post(conn, "/api/stories/#{story.id}/views/treatment/cut")
+      assert json_response(conn, 401)
+    end
+
+    test "403 when token story does not match path story_id", %{
+      conn: conn,
+      story: story,
+      raw_token_other: token_other
+    } do
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{token_other}")
+        |> post("/api/stories/#{story.id}/views/treatment/cut")
+
+      assert json_response(conn, 403)
+    end
+  end
+
+  describe "POST /api/stories/:story_id/views/story_script/cut" do
+    test "201 with version_number 1 (first StoryScriptVV cut)", %{
+      conn: conn,
+      story: story,
+      raw_token: token
+    } do
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{token}")
+        |> post("/api/stories/#{story.id}/views/story_script/cut")
+
+      body = json_response(conn, 201)
+      assert body["id"]
+      assert body["version_number"] == 1
+      assert is_list(body["unresolvable_segments"])
+    end
+
+    test "401 without token", %{conn: conn, story: story} do
+      conn = post(conn, "/api/stories/#{story.id}/views/story_script/cut")
+      assert json_response(conn, 401)
+    end
+
+    test "403 when token story does not match path story_id", %{
+      conn: conn,
+      story: story,
+      raw_token_other: token_other
+    } do
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{token_other}")
+        |> post("/api/stories/#{story.id}/views/story_script/cut")
+
+      assert json_response(conn, 403)
+    end
+  end
+
+  describe "POST /api/stories/:story_id/sequences/:seq_id/views/sequence/cut" do
+    test "201 with empty script_view_version_ids list", %{
+      conn: conn,
+      story: story,
+      sequence: sequence,
+      raw_token: token
+    } do
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{token}")
+        |> post(
+          "/api/stories/#{story.id}/sequences/#{sequence.id}/views/sequence/cut",
+          %{"script_view_version_ids" => []}
+        )
+
+      body = json_response(conn, 201)
+      assert body["id"]
+      assert body["version_number"] == 1
+      assert body["unresolvable_segments"] == []
+    end
+
+    test "201 when body omits script_view_version_ids (defaults to [])", %{
+      conn: conn,
+      story: story,
+      sequence: sequence,
+      raw_token: token
+    } do
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{token}")
+        |> post("/api/stories/#{story.id}/sequences/#{sequence.id}/views/sequence/cut", %{})
+
+      body = json_response(conn, 201)
+      assert body["version_number"] == 1
+      assert body["unresolvable_segments"] == []
+    end
+
+    test "404 when seq_id belongs to a different story", %{
+      conn: conn,
+      story: story,
+      other_sequence: other_sequence,
+      raw_token: token
+    } do
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{token}")
+        |> post(
+          "/api/stories/#{story.id}/sequences/#{other_sequence.id}/views/sequence/cut",
+          %{}
+        )
+
+      assert json_response(conn, 404)
+    end
+
+    test "401 without token", %{conn: conn, story: story, sequence: sequence} do
+      conn =
+        post(conn, "/api/stories/#{story.id}/sequences/#{sequence.id}/views/sequence/cut", %{})
+
+      assert json_response(conn, 401)
+    end
+
+    test "403 when token story does not match path story_id", %{
+      conn: conn,
+      story: story,
+      sequence: sequence,
+      raw_token_other: token_other
+    } do
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{token_other}")
+        |> post(
+          "/api/stories/#{story.id}/sequences/#{sequence.id}/views/sequence/cut",
+          %{}
+        )
+
+      assert json_response(conn, 403)
+    end
+  end
+
+  describe "POST /api/stories/:story_id/scenes/:scene_id/views/script/cut" do
+    test "201 with unresolvable_segments empty (script piece pinned)", %{
+      conn: conn,
+      story: story,
+      scene: scene,
+      script_piece: piece,
+      raw_token: token
+    } do
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{token}")
+        |> post(
+          "/api/stories/#{story.id}/scenes/#{scene.id}/views/script/cut",
+          %{"script_piece_id" => piece.id}
+        )
+
+      body = json_response(conn, 201)
+      assert body["id"]
+      assert body["version_number"] == 1
+      assert body["unresolvable_segments"] == []
+    end
+
+    test "400 when script_piece_id is missing", %{
+      conn: conn,
+      story: story,
+      scene: scene,
+      raw_token: token
+    } do
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{token}")
+        |> post("/api/stories/#{story.id}/scenes/#{scene.id}/views/script/cut", %{})
+
+      assert json_response(conn, 400)["error"] =~ "script_piece_id"
+    end
+
+    test "404 when scene_id does not exist", %{
+      conn: conn,
+      story: story,
+      script_piece: piece,
+      raw_token: token
+    } do
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{token}")
+        |> post(
+          "/api/stories/#{story.id}/scenes/00000000-0000-0000-0000-000000000000/views/script/cut",
+          %{"script_piece_id" => piece.id}
+        )
+
+      assert json_response(conn, 404)
+    end
+
+    test "404 when script_piece_id does not belong to the scene", %{
+      conn: conn,
+      story: story,
+      scene: scene,
+      raw_token: token
+    } do
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{token}")
+        |> post(
+          "/api/stories/#{story.id}/scenes/#{scene.id}/views/script/cut",
+          %{"script_piece_id" => "00000000-0000-0000-0000-000000000000"}
+        )
+
+      assert json_response(conn, 404)
+    end
+
+    test "401 without token", %{conn: conn, story: story, scene: scene, script_piece: piece} do
+      conn =
+        post(
+          conn,
+          "/api/stories/#{story.id}/scenes/#{scene.id}/views/script/cut",
+          %{"script_piece_id" => piece.id}
+        )
+
+      assert json_response(conn, 401)
+    end
+
+    test "403 when token story does not match path story_id", %{
+      conn: conn,
+      story: story,
+      scene: scene,
+      script_piece: piece,
+      raw_token_other: token_other
+    } do
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{token_other}")
+        |> post(
+          "/api/stories/#{story.id}/scenes/#{scene.id}/views/script/cut",
+          %{"script_piece_id" => piece.id}
+        )
+
+      assert json_response(conn, 403)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds five `POST .../cut` endpoints for cutting new ViewVersions: synopsis, treatment, story-script, sequence (per-sequence), and script (per-scene)
- Each returns `201 { id, version_number, unresolvable_segments }` where `unresolvable_segments` lists nil-pin Segments (Tasks auto-generated by `TaskGeneration.after_cut`)
- Routes restructured per orchestrator review: `story_id` in path on all five routes (ApiAuth enforces 403 centrally); sequence route uses `views/sequence/cut` not `views/script/cut`
- `script_view_version_ids` defaults to `[]` when absent for sequence cut; `script_piece_id` returns 400 when absent for script cut

## Test plan

- [x] `mix precommit` passes (313 tests, 0 failures)
- [x] ConnCase for all five endpoints: 201 happy-path, 401 without token, 403 wrong story token, 404 cross-story resource, 400 missing required body param, 404 non-existent resource

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)