### PR TITLE
Add POST /api/stories/:id/sequences/:seq_id/weights

### DIFF
--- a/lib/storybox_web/controllers/api_controller.ex
+++ b/lib/storybox_web/controllers/api_controller.ex
@@ -508,6 +508,37 @@ defmodule StoryboxWeb.ApiController do
     end
   end
 
+  def set_sequence_weights(conn, %{"seq_id" => seq_id} = params) do
+    story = conn.assigns.current_story
+    weights = params["weights"]
+
+    if is_nil(weights) or not is_map(weights) do
+      conn |> put_status(400) |> json(%{error: "weights is required"})
+    else
+      piece =
+        Storybox.Stories.SequencePiece
+        |> Ash.Query.filter(story_id == ^story.id and sequence_id == ^seq_id)
+        |> Ash.Query.sort(version_number: :desc)
+        |> Ash.Query.limit(1)
+        |> Ash.read_one(authorize?: false)
+
+      case piece do
+        {:ok, nil} ->
+          conn |> put_status(404) |> json(%{error: "not found"})
+
+        {:ok, p} ->
+          case Ash.Changeset.for_update(p, :set_weights, %{weights: weights})
+               |> Ash.update(authorize?: false) do
+            {:ok, updated} -> json(conn, format_version(updated))
+            {:error, _} -> conn |> put_status(500) |> json(%{error: "internal error"})
+          end
+
+        {:error, _} ->
+          conn |> put_status(500) |> json(%{error: "internal error"})
+      end
+    end
+  end
+
   defp load_task_for_story(task_id, story_id) do
     Storybox.Stories.Task
     |> Ash.Query.filter(id == ^task_id and story_id == ^story_id)

--- a/lib/storybox_web/router.ex
+++ b/lib/storybox_web/router.ex
@@ -60,6 +60,7 @@ defmodule StoryboxWeb.Router do
 
     post "/stories/:story_id/scenes/:scene_id/views/script/cut", ApiController, :cut_script_vv
     post "/stories/:story_id/views/story_script/cut", ApiController, :cut_story_script_vv
+    post "/stories/:story_id/sequences/:seq_id/weights", ApiController, :set_sequence_weights
   end
 
   # Enable LiveDashboard and Swoosh mailbox preview in development

--- a/test/storybox_web/controllers/sequence_weights_test.exs
+++ b/test/storybox_web/controllers/sequence_weights_test.exs
@@ -1,0 +1,159 @@
+defmodule StoryboxWeb.SequenceWeightsTest do
+  use StoryboxWeb.ConnCase
+
+  alias Storybox.Accounts.ApiToken
+
+  # Setup creates:
+  #
+  #   user ──── story ──── sequence ──── sequence_piece (v1, weights %{})
+  #          └── other_story
+  #
+  # raw_token is scoped to story.
+
+  setup do
+    {:ok, user} =
+      Storybox.Accounts.User
+      |> Ash.Changeset.for_create(:register_with_password, %{
+        email: "sequence_weights_test@example.com",
+        password: "password123!",
+        password_confirmation: "password123!"
+      })
+      |> Ash.create()
+
+    {:ok, story} =
+      Storybox.Stories.Story
+      |> Ash.Changeset.for_create(:create, %{title: "Weights Story", user_id: user.id})
+      |> Ash.create()
+
+    {:ok, other_story} =
+      Storybox.Stories.Story
+      |> Ash.Changeset.for_create(:create, %{title: "Other Story", user_id: user.id})
+      |> Ash.create()
+
+    {:ok, raw_token, _} = ApiToken.generate(%{story_id: story.id, user_id: user.id})
+    {:ok, other_token, _} = ApiToken.generate(%{story_id: other_story.id, user_id: user.id})
+
+    {:ok, sequence} =
+      Storybox.Stories.Sequence
+      |> Ash.Changeset.for_create(:create, %{story_id: story.id, name: "Seq 1", slug: "seq-1"})
+      |> Ash.create(authorize?: false)
+
+    {:ok, piece} =
+      Storybox.Stories.SequencePiece
+      |> Ash.Changeset.for_create(:create, %{
+        story_id: story.id,
+        sequence_id: sequence.id,
+        content_uri: "seq/#{sequence.id}/1.fountain",
+        version_number: 1,
+        weights: %{}
+      })
+      |> Ash.create(authorize?: false)
+
+    %{
+      story: story,
+      other_story: other_story,
+      sequence: sequence,
+      piece: piece,
+      raw_token: raw_token,
+      other_token: other_token
+    }
+  end
+
+  describe "POST /api/stories/:story_id/sequences/:seq_id/weights" do
+    test "returns 200 with updated weights", %{
+      conn: conn,
+      story: story,
+      sequence: sequence,
+      raw_token: raw_token
+    } do
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{raw_token}")
+        |> post("/api/stories/#{story.id}/sequences/#{sequence.id}/weights", %{
+          "weights" => %{"importance" => 0.9}
+        })
+
+      body = json_response(conn, 200)
+      assert body["weights"] == %{"importance" => 0.9}
+      assert body["id"]
+      assert body["version_number"] == 1
+    end
+
+    test "read-back: DB record has updated weights", %{
+      conn: conn,
+      story: story,
+      sequence: sequence,
+      piece: piece,
+      raw_token: raw_token
+    } do
+      conn
+      |> put_req_header("authorization", "Bearer #{raw_token}")
+      |> post("/api/stories/#{story.id}/sequences/#{sequence.id}/weights", %{
+        "weights" => %{"score" => 42}
+      })
+
+      updated = Ash.get!(Storybox.Stories.SequencePiece, piece.id, authorize?: false)
+      assert updated.weights == %{"score" => 42}
+    end
+
+    test "returns 404 for unknown seq_id", %{
+      conn: conn,
+      story: story,
+      raw_token: raw_token
+    } do
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{raw_token}")
+        |> post(
+          "/api/stories/#{story.id}/sequences/00000000-0000-0000-0000-000000000000/weights",
+          %{"weights" => %{}}
+        )
+
+      assert json_response(conn, 404)["error"] == "not found"
+    end
+
+    test "returns 400 when weights key is absent", %{
+      conn: conn,
+      story: story,
+      sequence: sequence,
+      raw_token: raw_token
+    } do
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{raw_token}")
+        |> post("/api/stories/#{story.id}/sequences/#{sequence.id}/weights", %{})
+
+      assert json_response(conn, 400)["error"] == "weights is required"
+    end
+
+    test "returns 401 without Authorization header", %{
+      conn: conn,
+      story: story,
+      sequence: sequence
+    } do
+      conn =
+        conn
+        |> post("/api/stories/#{story.id}/sequences/#{sequence.id}/weights", %{
+          "weights" => %{}
+        })
+
+      assert json_response(conn, 401)
+    end
+
+    test "returns 403 when token is scoped to a different story", %{
+      conn: conn,
+      story: story,
+      sequence: sequence,
+      other_token: other_token
+    } do
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{other_token}")
+        |> post("/api/stories/#{story.id}/sequences/#{sequence.id}/weights", %{
+          "weights" => %{}
+        })
+
+      assert json_response(conn, 403)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `POST /api/stories/:story_id/sequences/:seq_id/weights` inside the `require_api_auth` pipeline
- Resolves the latest `SequencePiece` for `(story_id, sequence_id)` and replaces its weights map via the `:set_weights` action
- Returns `format_version/1` on success (consistent with `create_scene_version`); `400` for missing `weights` key, `404` for unknown sequence, `403`/`401` handled by existing `ApiAuth` plug

## Test plan

- [x] `mix precommit` passes (319 tests, 0 failures)
- [x] `POST` with valid weights returns `200` with updated weights in body
- [x] Read-back asserts DB record reflects posted weights
- [x] Unknown `seq_id` → `404`
- [x] Missing `weights` key → `400`
- [x] No auth header → `401`
- [x] Token scoped to different story → `403`

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)