### PR TITLE
Add POST /api/stories/:id/scenes/:scene_id/weights endpoint (Closes #63)

### DIFF
--- a/lib/storybox_web/controllers/api_controller.ex
+++ b/lib/storybox_web/controllers/api_controller.ex
@@ -539,6 +539,51 @@ defmodule StoryboxWeb.ApiController do
     end
   end
 
+  def set_script_piece_weights(conn, %{"scene_id" => scene_id} = params) do
+    story = conn.assigns.current_story
+    weights = params["weights"]
+
+    if is_nil(weights) or not is_map(weights) do
+      conn |> put_status(400) |> json(%{error: "weights is required"})
+    else
+      scene =
+        Storybox.Stories.Scene
+        |> Ash.Query.filter(id == ^scene_id and story_id == ^story.id)
+        |> Ash.read_one(authorize?: false)
+
+      case scene do
+        {:ok, nil} ->
+          conn |> put_status(404) |> json(%{error: "not found"})
+
+        {:ok, s} ->
+          piece =
+            Storybox.Stories.ScriptPiece
+            |> Ash.Query.filter(scene_id == ^s.id)
+            |> Ash.Query.sort(version_number: :desc)
+            |> Ash.Query.limit(1)
+            |> Ash.read_one(authorize?: false)
+
+          case piece do
+            {:ok, nil} ->
+              conn |> put_status(404) |> json(%{error: "not found"})
+
+            {:ok, p} ->
+              case Ash.Changeset.for_update(p, :set_weights, %{weights: weights})
+                   |> Ash.update(authorize?: false) do
+                {:ok, updated} -> json(conn, format_version(updated))
+                {:error, _} -> conn |> put_status(500) |> json(%{error: "internal error"})
+              end
+
+            {:error, _} ->
+              conn |> put_status(500) |> json(%{error: "internal error"})
+          end
+
+        {:error, _} ->
+          conn |> put_status(500) |> json(%{error: "internal error"})
+      end
+    end
+  end
+
   defp load_task_for_story(task_id, story_id) do
     Storybox.Stories.Task
     |> Ash.Query.filter(id == ^task_id and story_id == ^story_id)

--- a/lib/storybox_web/router.ex
+++ b/lib/storybox_web/router.ex
@@ -61,6 +61,7 @@ defmodule StoryboxWeb.Router do
     post "/stories/:story_id/scenes/:scene_id/views/script/cut", ApiController, :cut_script_vv
     post "/stories/:story_id/views/story_script/cut", ApiController, :cut_story_script_vv
     post "/stories/:story_id/sequences/:seq_id/weights", ApiController, :set_sequence_weights
+    post "/stories/:story_id/scenes/:scene_id/weights", ApiController, :set_script_piece_weights
   end
 
   # Enable LiveDashboard and Swoosh mailbox preview in development

--- a/test/storybox_web/controllers/script_piece_weights_test.exs
+++ b/test/storybox_web/controllers/script_piece_weights_test.exs
@@ -1,0 +1,237 @@
+defmodule StoryboxWeb.ScriptPieceWeightsTest do
+  use StoryboxWeb.ConnCase
+
+  alias Storybox.Accounts.ApiToken
+
+  # Setup creates:
+  #
+  #   user ──── story ──── scene ──── script_piece (v1, weights %{})
+  #          └── other_story
+  #
+  # raw_token is scoped to story.
+
+  setup do
+    {:ok, user} =
+      Storybox.Accounts.User
+      |> Ash.Changeset.for_create(:register_with_password, %{
+        email: "script_piece_weights_test@example.com",
+        password: "password123!",
+        password_confirmation: "password123!"
+      })
+      |> Ash.create()
+
+    {:ok, story} =
+      Storybox.Stories.Story
+      |> Ash.Changeset.for_create(:create, %{title: "Weights Story", user_id: user.id})
+      |> Ash.create()
+
+    {:ok, other_story} =
+      Storybox.Stories.Story
+      |> Ash.Changeset.for_create(:create, %{title: "Other Story", user_id: user.id})
+      |> Ash.create()
+
+    {:ok, raw_token, _} = ApiToken.generate(%{story_id: story.id, user_id: user.id})
+    {:ok, other_token, _} = ApiToken.generate(%{story_id: other_story.id, user_id: user.id})
+
+    {:ok, scene} =
+      Storybox.Stories.Scene
+      |> Ash.Changeset.for_create(:create, %{story_id: story.id, title: "Scene 1"})
+      |> Ash.create(authorize?: false)
+
+    {:ok, piece} =
+      Storybox.Stories.ScriptPiece
+      |> Ash.ActionInput.for_action(:create_version, %{
+        scene_id: scene.id,
+        content: "INT. OFFICE - DAY"
+      })
+      |> Ash.run_action(authorize?: false)
+
+    %{
+      story: story,
+      other_story: other_story,
+      scene: scene,
+      piece: piece,
+      raw_token: raw_token,
+      other_token: other_token
+    }
+  end
+
+  describe "POST /api/stories/:story_id/scenes/:scene_id/weights" do
+    test "returns 200 with updated weights", %{
+      conn: conn,
+      story: story,
+      scene: scene,
+      raw_token: raw_token
+    } do
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{raw_token}")
+        |> post("/api/stories/#{story.id}/scenes/#{scene.id}/weights", %{
+          "weights" => %{"importance" => 0.8}
+        })
+
+      body = json_response(conn, 200)
+      assert body["weights"] == %{"importance" => 0.8}
+      assert body["id"]
+      assert body["version_number"] == 1
+    end
+
+    test "read-back: DB record has updated weights", %{
+      conn: conn,
+      story: story,
+      scene: scene,
+      piece: piece,
+      raw_token: raw_token
+    } do
+      conn
+      |> put_req_header("authorization", "Bearer #{raw_token}")
+      |> post("/api/stories/#{story.id}/scenes/#{scene.id}/weights", %{
+        "weights" => %{"score" => 99}
+      })
+
+      updated = Ash.get!(Storybox.Stories.ScriptPiece, piece.id, authorize?: false)
+      assert updated.weights == %{"score" => 99}
+    end
+
+    test "full-map replace: prior keys are dropped", %{
+      conn: conn,
+      story: story,
+      scene: scene,
+      piece: piece,
+      raw_token: raw_token
+    } do
+      conn
+      |> put_req_header("authorization", "Bearer #{raw_token}")
+      |> post("/api/stories/#{story.id}/scenes/#{scene.id}/weights", %{
+        "weights" => %{"a" => 1}
+      })
+
+      conn
+      |> put_req_header("authorization", "Bearer #{raw_token}")
+      |> post("/api/stories/#{story.id}/scenes/#{scene.id}/weights", %{
+        "weights" => %{"b" => 2}
+      })
+
+      updated = Ash.get!(Storybox.Stories.ScriptPiece, piece.id, authorize?: false)
+      assert updated.weights == %{"b" => 2}
+      refute Map.has_key?(updated.weights, "a")
+    end
+
+    test "returns 400 when weights key is absent", %{
+      conn: conn,
+      story: story,
+      scene: scene,
+      raw_token: raw_token
+    } do
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{raw_token}")
+        |> post("/api/stories/#{story.id}/scenes/#{scene.id}/weights", %{})
+
+      assert json_response(conn, 400)["error"] == "weights is required"
+    end
+
+    test "returns 400 when weights value is not a map", %{
+      conn: conn,
+      story: story,
+      scene: scene,
+      raw_token: raw_token
+    } do
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{raw_token}")
+        |> post("/api/stories/#{story.id}/scenes/#{scene.id}/weights", %{
+          "weights" => "not_a_map"
+        })
+
+      assert json_response(conn, 400)["error"] == "weights is required"
+    end
+
+    test "returns 404 for unknown scene_id", %{
+      conn: conn,
+      story: story,
+      raw_token: raw_token
+    } do
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{raw_token}")
+        |> post(
+          "/api/stories/#{story.id}/scenes/00000000-0000-0000-0000-000000000000/weights",
+          %{"weights" => %{}}
+        )
+
+      assert json_response(conn, 404)["error"] == "not found"
+    end
+
+    test "returns 404 when scene belongs to a different story", %{
+      conn: conn,
+      story: story,
+      raw_token: raw_token,
+      other_story: other_story
+    } do
+      {:ok, other_scene} =
+        Storybox.Stories.Scene
+        |> Ash.Changeset.for_create(:create, %{story_id: other_story.id, title: "Other Scene"})
+        |> Ash.create(authorize?: false)
+
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{raw_token}")
+        |> post("/api/stories/#{story.id}/scenes/#{other_scene.id}/weights", %{
+          "weights" => %{}
+        })
+
+      assert json_response(conn, 404)["error"] == "not found"
+    end
+
+    test "returns 404 when scene has no ScriptPiece", %{
+      conn: conn,
+      story: story,
+      raw_token: raw_token
+    } do
+      {:ok, empty_scene} =
+        Storybox.Stories.Scene
+        |> Ash.Changeset.for_create(:create, %{story_id: story.id, title: "Empty Scene"})
+        |> Ash.create(authorize?: false)
+
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{raw_token}")
+        |> post("/api/stories/#{story.id}/scenes/#{empty_scene.id}/weights", %{
+          "weights" => %{}
+        })
+
+      assert json_response(conn, 404)["error"] == "not found"
+    end
+
+    test "returns 401 without Authorization header", %{
+      conn: conn,
+      story: story,
+      scene: scene
+    } do
+      conn =
+        conn
+        |> post("/api/stories/#{story.id}/scenes/#{scene.id}/weights", %{
+          "weights" => %{}
+        })
+
+      assert json_response(conn, 401)
+    end
+
+    test "returns 403 when token is scoped to a different story", %{
+      conn: conn,
+      story: story,
+      scene: scene,
+      other_token: other_token
+    } do
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{other_token}")
+        |> post("/api/stories/#{story.id}/scenes/#{scene.id}/weights", %{
+          "weights" => %{}
+        })
+
+      assert json_response(conn, 403)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `POST /api/stories/:story_id/scenes/:scene_id/weights` route to the authenticated API scope
- Implements `set_script_piece_weights/2` in `ApiController` — resolves the latest `ScriptPiece` by `scene_id` (with story ownership check), calls the existing `:set_weights` Ash update action
- Adds 9-case `ConnCase` suite covering set + read-back, full-map replace, 400/404/401/403 error paths

Closes #63

## Test plan

- [x] `mix precommit` passes — 329 tests, 0 failures
- [ ] Boot service, obtain token, `POST /api/stories/:story_id/scenes/:scene_id/weights` with `{"weights": {"importance": 0.8}}` — expect `200` with matching `weights` field
- [ ] Repeat with `{"weights": {}}` — expect `200` and prior keys cleared
- [ ] Try with a `scene_id` from a different story — expect `404`

🤖 Generated with [Claude Code](https://claude.com/claude-code)