### PR TITLE
Add Character and World API endpoints (Closes #78)

### DIFF
--- a/lib/storybox_web/controllers/api_controller.ex
+++ b/lib/storybox_web/controllers/api_controller.ex
@@ -584,6 +584,196 @@ defmodule StoryboxWeb.ApiController do
     end
   end
 
+  def list_characters(conn, _params) do
+    story = conn.assigns.current_story
+
+    characters =
+      Storybox.Stories.Character
+      |> Ash.Query.filter(story_id == ^story.id)
+      |> Ash.read!(authorize?: false)
+
+    json(conn, Enum.map(characters, fn c -> %{id: c.id, name: c.name} end))
+  end
+
+  def character_detail(conn, %{"char_id" => char_id}) do
+    story = conn.assigns.current_story
+
+    case load_character_for_story(char_id, story.id) do
+      nil ->
+        conn |> put_status(404) |> json(%{error: "not found"})
+
+      character ->
+        char_view =
+          Storybox.Stories.CharacterView
+          |> Ash.Query.filter(character_id == ^character.id)
+          |> Ash.read_one!(authorize?: false)
+
+        {latest_vv, segment} =
+          if char_view do
+            vv =
+              Storybox.Stories.CharacterViewVersion
+              |> Ash.Query.filter(character_view_id == ^char_view.id)
+              |> Ash.Query.sort(version_number: :desc)
+              |> Ash.Query.limit(1)
+              |> Ash.read_one!(authorize?: false)
+
+            seg =
+              if vv do
+                char_vv_type = :character_vv
+
+                Storybox.Stories.Segment
+                |> Ash.Query.filter(
+                  view_version_id == ^vv.id and view_version_type == ^char_vv_type
+                )
+                |> Ash.read_one!(authorize?: false)
+              end
+
+            {vv, seg}
+          else
+            {nil, nil}
+          end
+
+        case resolve_piece_content(segment) do
+          {:ok, content} ->
+            json(conn, %{
+              id: character.id,
+              name: character.name,
+              character_view_id: char_view && char_view.id,
+              version_number: latest_vv && latest_vv.version_number,
+              content: content
+            })
+
+          {:error, :content_unavailable} ->
+            conn |> put_status(503) |> json(%{error: "content unavailable"})
+        end
+    end
+  end
+
+  def create_character_piece(conn, %{"char_id" => char_id} = params) do
+    story = conn.assigns.current_story
+    content = params["content"]
+
+    if is_nil(content) or content == "" do
+      conn |> put_status(400) |> json(%{error: "content is required"})
+    else
+      case load_character_for_story(char_id, story.id) do
+        nil ->
+          conn |> put_status(404) |> json(%{error: "not found"})
+
+        character ->
+          with {:ok, _piece} <-
+                 Storybox.Stories.CharacterPiece
+                 |> Ash.ActionInput.for_action(:create_version, %{
+                   character_id: character.id,
+                   content: content
+                 })
+                 |> Ash.run_action(authorize?: false),
+               {:ok, view} <-
+                 Storybox.Stories.CharacterView
+                 |> Ash.ActionInput.for_action(:ensure_for_character, %{
+                   character_id: character.id
+                 })
+                 |> Ash.run_action(authorize?: false),
+               {:ok, vv} <-
+                 Storybox.Stories.CharacterViewVersion
+                 |> Ash.ActionInput.for_action(:cut, %{character_view_id: view.id})
+                 |> Ash.run_action(authorize?: false) do
+            conn |> put_status(201) |> json(format_cut_vv(vv, :character_vv))
+          else
+            {:error, _} -> conn |> put_status(500) |> json(%{error: "internal error"})
+          end
+      end
+    end
+  end
+
+  def world_detail(conn, _params) do
+    story = conn.assigns.current_story
+
+    case load_world_for_story(story.id) do
+      nil ->
+        conn |> put_status(404) |> json(%{error: "not found"})
+
+      world ->
+        world_view =
+          Storybox.Stories.WorldView
+          |> Ash.Query.filter(world_id == ^world.id)
+          |> Ash.read_one!(authorize?: false)
+
+        {latest_vv, segment} =
+          if world_view do
+            vv =
+              Storybox.Stories.WorldViewVersion
+              |> Ash.Query.filter(world_view_id == ^world_view.id)
+              |> Ash.Query.sort(version_number: :desc)
+              |> Ash.Query.limit(1)
+              |> Ash.read_one!(authorize?: false)
+
+            seg =
+              if vv do
+                world_vv_type = :world_vv
+
+                Storybox.Stories.Segment
+                |> Ash.Query.filter(
+                  view_version_id == ^vv.id and view_version_type == ^world_vv_type
+                )
+                |> Ash.read_one!(authorize?: false)
+              end
+
+            {vv, seg}
+          else
+            {nil, nil}
+          end
+
+        case resolve_piece_content(segment) do
+          {:ok, content} ->
+            json(conn, %{
+              world_id: world.id,
+              world_view_id: world_view && world_view.id,
+              version_number: latest_vv && latest_vv.version_number,
+              content: content
+            })
+
+          {:error, :content_unavailable} ->
+            conn |> put_status(503) |> json(%{error: "content unavailable"})
+        end
+    end
+  end
+
+  def create_world_piece(conn, params) do
+    story = conn.assigns.current_story
+    content = params["content"]
+
+    if is_nil(content) or content == "" do
+      conn |> put_status(400) |> json(%{error: "content is required"})
+    else
+      case load_world_for_story(story.id) do
+        nil ->
+          conn |> put_status(404) |> json(%{error: "not found"})
+
+        world ->
+          with {:ok, _piece} <-
+                 Storybox.Stories.WorldPiece
+                 |> Ash.ActionInput.for_action(:create_version, %{
+                   world_id: world.id,
+                   content: content
+                 })
+                 |> Ash.run_action(authorize?: false),
+               {:ok, view} <-
+                 Storybox.Stories.WorldView
+                 |> Ash.ActionInput.for_action(:ensure_for_world, %{world_id: world.id})
+                 |> Ash.run_action(authorize?: false),
+               {:ok, vv} <-
+                 Storybox.Stories.WorldViewVersion
+                 |> Ash.ActionInput.for_action(:cut, %{world_view_id: view.id})
+                 |> Ash.run_action(authorize?: false) do
+            conn |> put_status(201) |> json(format_cut_vv(vv, :world_vv))
+          else
+            {:error, _} -> conn |> put_status(500) |> json(%{error: "internal error"})
+          end
+      end
+    end
+  end
+
   defp load_task_for_story(task_id, story_id) do
     Storybox.Stories.Task
     |> Ash.Query.filter(id == ^task_id and story_id == ^story_id)
@@ -635,6 +825,46 @@ defmodule StoryboxWeb.ApiController do
       end)
 
     %{id: vv.id, version_number: vv.version_number, unresolvable_segments: unresolvable}
+  end
+
+  defp load_character_for_story(char_id, story_id) do
+    Storybox.Stories.Character
+    |> Ash.Query.filter(id == ^char_id and story_id == ^story_id)
+    |> Ash.read_one!(authorize?: false)
+  end
+
+  defp load_world_for_story(story_id) do
+    Storybox.Stories.World
+    |> Ash.Query.filter(story_id == ^story_id)
+    |> Ash.read_one!(authorize?: false)
+  end
+
+  defp resolve_piece_content(nil), do: {:ok, nil}
+
+  defp resolve_piece_content(%{pin_id: nil}), do: {:ok, nil}
+
+  defp resolve_piece_content(%{pin_id: pin_id, pin_type: :character_piece}) do
+    piece =
+      Storybox.Stories.CharacterPiece
+      |> Ash.Query.filter(id == ^pin_id)
+      |> Ash.read_one!(authorize?: false)
+
+    case Storybox.Storage.get_content(piece.content_uri) do
+      {:ok, content} -> {:ok, content}
+      {:error, _} -> {:error, :content_unavailable}
+    end
+  end
+
+  defp resolve_piece_content(%{pin_id: pin_id, pin_type: :world_piece}) do
+    piece =
+      Storybox.Stories.WorldPiece
+      |> Ash.Query.filter(id == ^pin_id)
+      |> Ash.read_one!(authorize?: false)
+
+    case Storybox.Storage.get_content(piece.content_uri) do
+      {:ok, content} -> {:ok, content}
+      {:error, _} -> {:error, :content_unavailable}
+    end
   end
 
   defp load_sequence_for_story(seq_id, story_id) do

--- a/lib/storybox_web/router.ex
+++ b/lib/storybox_web/router.ex
@@ -62,6 +62,12 @@ defmodule StoryboxWeb.Router do
     post "/stories/:story_id/views/story_script/cut", ApiController, :cut_story_script_vv
     post "/stories/:story_id/sequences/:seq_id/weights", ApiController, :set_sequence_weights
     post "/stories/:story_id/scenes/:scene_id/weights", ApiController, :set_script_piece_weights
+
+    get "/stories/:story_id/characters", ApiController, :list_characters
+    get "/stories/:story_id/characters/:char_id", ApiController, :character_detail
+    post "/stories/:story_id/characters/:char_id/pieces", ApiController, :create_character_piece
+    get "/stories/:story_id/world", ApiController, :world_detail
+    post "/stories/:story_id/world/pieces", ApiController, :create_world_piece
   end
 
   # Enable LiveDashboard and Swoosh mailbox preview in development

--- a/test/storybox_web/controllers/character_world_api_test.exs
+++ b/test/storybox_web/controllers/character_world_api_test.exs
@@ -1,0 +1,446 @@
+defmodule StoryboxWeb.CharacterWorldApiTest do
+  use StoryboxWeb.ConnCase
+
+  alias Storybox.Accounts.ApiToken
+
+  require Ash.Query
+
+  # Setup creates three stories:
+  #
+  # story —— char_1 (CharacterPiece v1 + CharacterView + CVV v1, content pinned)
+  #        ├─ char_2 (CharacterView only, no CVV — exercises nil-content path)
+  #        └─ world  (WorldPiece v1 + WorldView + WVV v1, content pinned)
+  #
+  # story_2 —— world_2 (WorldView only, no WVV — exercises nil-content path)
+  #
+  # other_story —— other_char (for character 404 test)
+  #             (no World — for world 404 test)
+  #
+  # raw_token scoped to story; raw_token_2 to story_2; raw_token_other to other_story.
+
+  setup do
+    {:ok, user} =
+      Storybox.Accounts.User
+      |> Ash.Changeset.for_create(:register_with_password, %{
+        email: "char_world_api_test@example.com",
+        password: "password123!",
+        password_confirmation: "password123!"
+      })
+      |> Ash.create()
+
+    {:ok, story} =
+      Storybox.Stories.Story
+      |> Ash.Changeset.for_create(:create, %{title: "Main Story", user_id: user.id})
+      |> Ash.create()
+
+    {:ok, story_2} =
+      Storybox.Stories.Story
+      |> Ash.Changeset.for_create(:create, %{title: "Bare World Story", user_id: user.id})
+      |> Ash.create()
+
+    {:ok, other_story} =
+      Storybox.Stories.Story
+      |> Ash.Changeset.for_create(:create, %{title: "Other Story", user_id: user.id})
+      |> Ash.create()
+
+    {:ok, raw_token, _} = ApiToken.generate(%{story_id: story.id, user_id: user.id})
+    {:ok, raw_token_2, _} = ApiToken.generate(%{story_id: story_2.id, user_id: user.id})
+    {:ok, raw_token_other, _} = ApiToken.generate(%{story_id: other_story.id, user_id: user.id})
+
+    # char_1: full setup (piece + view + VV)
+    {:ok, char_1} =
+      Storybox.Stories.Character
+      |> Ash.Changeset.for_create(:create, %{name: "Akko", story_id: story.id})
+      |> Ash.create(authorize?: false)
+
+    {:ok, _cp_v1} =
+      Storybox.Stories.CharacterPiece
+      |> Ash.ActionInput.for_action(:create_version, %{
+        character_id: char_1.id,
+        content: "Akko is a witch in training."
+      })
+      |> Ash.run_action(authorize?: false)
+
+    {:ok, char_view_1} =
+      Storybox.Stories.CharacterView
+      |> Ash.ActionInput.for_action(:ensure_for_character, %{character_id: char_1.id})
+      |> Ash.run_action(authorize?: false)
+
+    {:ok, _char_vv_1} =
+      Storybox.Stories.CharacterViewVersion
+      |> Ash.ActionInput.for_action(:cut, %{character_view_id: char_view_1.id})
+      |> Ash.run_action(authorize?: false)
+
+    # char_2: view exists but no piece/cut (nil-content path)
+    {:ok, char_2} =
+      Storybox.Stories.Character
+      |> Ash.Changeset.for_create(:create, %{name: "Lotte", story_id: story.id})
+      |> Ash.create(authorize?: false)
+
+    {:ok, _char_view_2} =
+      Storybox.Stories.CharacterView
+      |> Ash.ActionInput.for_action(:ensure_for_character, %{character_id: char_2.id})
+      |> Ash.run_action(authorize?: false)
+
+    # other_char: for 404 test (belongs to other_story)
+    {:ok, other_char} =
+      Storybox.Stories.Character
+      |> Ash.Changeset.for_create(:create, %{name: "Other Char", story_id: other_story.id})
+      |> Ash.create(authorize?: false)
+
+    # world: full setup (piece + view + WVV)
+    {:ok, world} =
+      Storybox.Stories.World
+      |> Ash.Changeset.for_create(:create, %{story_id: story.id})
+      |> Ash.create(authorize?: false)
+
+    {:ok, _wp_v1} =
+      Storybox.Stories.WorldPiece
+      |> Ash.ActionInput.for_action(:create_version, %{
+        world_id: world.id,
+        content: "The witch academy world."
+      })
+      |> Ash.run_action(authorize?: false)
+
+    {:ok, world_view} =
+      Storybox.Stories.WorldView
+      |> Ash.ActionInput.for_action(:ensure_for_world, %{world_id: world.id})
+      |> Ash.run_action(authorize?: false)
+
+    {:ok, _world_vv_1} =
+      Storybox.Stories.WorldViewVersion
+      |> Ash.ActionInput.for_action(:cut, %{world_view_id: world_view.id})
+      |> Ash.run_action(authorize?: false)
+
+    # world_2: WorldView only, no WVV (nil-content path)
+    {:ok, world_2} =
+      Storybox.Stories.World
+      |> Ash.Changeset.for_create(:create, %{story_id: story_2.id})
+      |> Ash.create(authorize?: false)
+
+    {:ok, _world_view_2} =
+      Storybox.Stories.WorldView
+      |> Ash.ActionInput.for_action(:ensure_for_world, %{world_id: world_2.id})
+      |> Ash.run_action(authorize?: false)
+
+    %{
+      story: story,
+      story_2: story_2,
+      other_story: other_story,
+      char_1: char_1,
+      char_2: char_2,
+      other_char: other_char,
+      world: world,
+      raw_token: raw_token,
+      raw_token_2: raw_token_2,
+      raw_token_other: raw_token_other
+    }
+  end
+
+  describe "GET /api/stories/:story_id/characters" do
+    test "200 — returns id and name for each character in the story", %{
+      conn: conn,
+      story: story,
+      char_1: char_1,
+      char_2: char_2,
+      raw_token: token
+    } do
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{token}")
+        |> get("/api/stories/#{story.id}/characters")
+
+      body = json_response(conn, 200)
+      assert is_list(body)
+      ids = Enum.map(body, & &1["id"])
+      assert char_1.id in ids
+      assert char_2.id in ids
+      Enum.each(body, fn c -> assert Map.has_key?(c, "name") end)
+    end
+
+    test "401 without token", %{conn: conn, story: story} do
+      conn = get(conn, "/api/stories/#{story.id}/characters")
+      assert json_response(conn, 401)
+    end
+
+    test "403 when token story does not match path story_id", %{
+      conn: conn,
+      story: story,
+      raw_token_other: token_other
+    } do
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{token_other}")
+        |> get("/api/stories/#{story.id}/characters")
+
+      assert json_response(conn, 403)
+    end
+  end
+
+  describe "GET /api/stories/:story_id/characters/:char_id" do
+    test "200 — returns name, view id, version number, and resolved content", %{
+      conn: conn,
+      story: story,
+      char_1: char_1,
+      raw_token: token
+    } do
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{token}")
+        |> get("/api/stories/#{story.id}/characters/#{char_1.id}")
+
+      body = json_response(conn, 200)
+      assert body["id"] == char_1.id
+      assert body["name"] == "Akko"
+      assert body["character_view_id"]
+      assert body["version_number"] == 1
+      assert body["content"] == "Akko is a witch in training."
+    end
+
+    test "200 content null — character exists with view but no CVV", %{
+      conn: conn,
+      story: story,
+      char_2: char_2,
+      raw_token: token
+    } do
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{token}")
+        |> get("/api/stories/#{story.id}/characters/#{char_2.id}")
+
+      body = json_response(conn, 200)
+      assert body["id"] == char_2.id
+      assert body["name"] == "Lotte"
+      assert body["character_view_id"]
+      assert is_nil(body["version_number"])
+      assert is_nil(body["content"])
+    end
+
+    test "404 when char_id belongs to a different story", %{
+      conn: conn,
+      story: story,
+      other_char: other_char,
+      raw_token: token
+    } do
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{token}")
+        |> get("/api/stories/#{story.id}/characters/#{other_char.id}")
+
+      assert json_response(conn, 404)
+    end
+
+    test "401 without token", %{conn: conn, story: story, char_1: char_1} do
+      conn = get(conn, "/api/stories/#{story.id}/characters/#{char_1.id}")
+      assert json_response(conn, 401)
+    end
+  end
+
+  describe "POST /api/stories/:story_id/characters/:char_id/pieces" do
+    test "201 — cuts new CVV; subsequent GET reflects new content", %{
+      conn: conn,
+      story: story,
+      char_1: char_1,
+      raw_token: token
+    } do
+      new_content = "Akko is now a full-fledged witch."
+
+      post_conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{token}")
+        |> post("/api/stories/#{story.id}/characters/#{char_1.id}/pieces", %{
+          "content" => new_content
+        })
+
+      body = json_response(post_conn, 201)
+      assert body["id"]
+      assert body["version_number"] == 2
+      assert body["unresolvable_segments"] == []
+
+      get_conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{token}")
+        |> get("/api/stories/#{story.id}/characters/#{char_1.id}")
+
+      get_body = json_response(get_conn, 200)
+      assert get_body["content"] == new_content
+      assert get_body["version_number"] == 2
+    end
+
+    test "400 — missing content", %{conn: conn, story: story, char_1: char_1, raw_token: token} do
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{token}")
+        |> post("/api/stories/#{story.id}/characters/#{char_1.id}/pieces", %{})
+
+      assert json_response(conn, 400)["error"] =~ "content"
+    end
+
+    test "400 — empty content", %{conn: conn, story: story, char_1: char_1, raw_token: token} do
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{token}")
+        |> post("/api/stories/#{story.id}/characters/#{char_1.id}/pieces", %{"content" => ""})
+
+      assert json_response(conn, 400)["error"] =~ "content"
+    end
+
+    test "404 when char_id belongs to a different story", %{
+      conn: conn,
+      story: story,
+      other_char: other_char,
+      raw_token: token
+    } do
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{token}")
+        |> post("/api/stories/#{story.id}/characters/#{other_char.id}/pieces", %{
+          "content" => "Some content."
+        })
+
+      assert json_response(conn, 404)
+    end
+
+    test "401 without token", %{conn: conn, story: story, char_1: char_1} do
+      conn =
+        post(conn, "/api/stories/#{story.id}/characters/#{char_1.id}/pieces", %{
+          "content" => "Some content."
+        })
+
+      assert json_response(conn, 401)
+    end
+  end
+
+  describe "GET /api/stories/:story_id/world" do
+    test "200 — returns world_id, view id, version number, and resolved content", %{
+      conn: conn,
+      story: story,
+      world: world,
+      raw_token: token
+    } do
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{token}")
+        |> get("/api/stories/#{story.id}/world")
+
+      body = json_response(conn, 200)
+      assert body["world_id"] == world.id
+      assert body["world_view_id"]
+      assert body["version_number"] == 1
+      assert body["content"] == "The witch academy world."
+    end
+
+    test "200 content null — world exists with view but no WVV", %{
+      conn: conn,
+      story_2: story_2,
+      raw_token_2: token_2
+    } do
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{token_2}")
+        |> get("/api/stories/#{story_2.id}/world")
+
+      body = json_response(conn, 200)
+      assert body["world_id"]
+      assert body["world_view_id"]
+      assert is_nil(body["version_number"])
+      assert is_nil(body["content"])
+    end
+
+    test "404 when no world record for story", %{
+      conn: conn,
+      other_story: other_story,
+      raw_token_other: token_other
+    } do
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{token_other}")
+        |> get("/api/stories/#{other_story.id}/world")
+
+      assert json_response(conn, 404)
+    end
+
+    test "401 without token", %{conn: conn, story: story} do
+      conn = get(conn, "/api/stories/#{story.id}/world")
+      assert json_response(conn, 401)
+    end
+
+    test "403 when token story does not match path story_id", %{
+      conn: conn,
+      story: story,
+      raw_token_other: token_other
+    } do
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{token_other}")
+        |> get("/api/stories/#{story.id}/world")
+
+      assert json_response(conn, 403)
+    end
+  end
+
+  describe "POST /api/stories/:story_id/world/pieces" do
+    test "201 — cuts new WVV; subsequent GET reflects new content", %{
+      conn: conn,
+      story: story,
+      raw_token: token
+    } do
+      new_content = "The witch academy world, expanded."
+
+      post_conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{token}")
+        |> post("/api/stories/#{story.id}/world/pieces", %{"content" => new_content})
+
+      body = json_response(post_conn, 201)
+      assert body["id"]
+      assert body["version_number"] == 2
+      assert body["unresolvable_segments"] == []
+
+      get_conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{token}")
+        |> get("/api/stories/#{story.id}/world")
+
+      get_body = json_response(get_conn, 200)
+      assert get_body["content"] == new_content
+      assert get_body["version_number"] == 2
+    end
+
+    test "400 — missing content", %{conn: conn, story: story, raw_token: token} do
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{token}")
+        |> post("/api/stories/#{story.id}/world/pieces", %{})
+
+      assert json_response(conn, 400)["error"] =~ "content"
+    end
+
+    test "400 — empty content", %{conn: conn, story: story, raw_token: token} do
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{token}")
+        |> post("/api/stories/#{story.id}/world/pieces", %{"content" => ""})
+
+      assert json_response(conn, 400)["error"] =~ "content"
+    end
+
+    test "404 when no world record for story", %{
+      conn: conn,
+      other_story: other_story,
+      raw_token_other: token_other
+    } do
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{token_other}")
+        |> post("/api/stories/#{other_story.id}/world/pieces", %{"content" => "Some content."})
+
+      assert json_response(conn, 404)
+    end
+
+    test "401 without token", %{conn: conn, story: story} do
+      conn = post(conn, "/api/stories/#{story.id}/world/pieces", %{"content" => "Some content."})
+      assert json_response(conn, 401)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds 5 new authenticated API endpoints for Characters and World
- Read endpoints resolve View → ViewVersion → Segment → Piece → Storage content; return `content: null` when no VV/Segment exists
- Write endpoints run `create_version` → `ensure_for_*` → `cut` and return `format_cut_vv` shape
- ConnCase test file covering all endpoints (200, 200-null, 201, 400, 401, 403/404)

## Endpoints added

| Method | Path | Action |
|--------|------|--------|
| GET | `/api/stories/:story_id/characters` | list characters `[{id, name}]` |
| GET | `/api/stories/:story_id/characters/:char_id` | character detail with resolved content |
| POST | `/api/stories/:story_id/characters/:char_id/pieces` | write new CharacterPiece; cut new CVV |
| GET | `/api/stories/:story_id/world` | world detail with resolved content |
| POST | `/api/stories/:story_id/world/pieces` | write new WorldPiece; cut new WVV |

## Test plan

- [x] `POST /api/auth/token` with Little Witch credentials → bearer token
- [x] `GET /api/stories/:story_id/characters` → list with `id` and `name` fields
- [x] `GET /api/stories/:story_id/characters/:char_id` for a seeded character → `content` non-null
- [x] `POST /api/stories/:story_id/characters/:char_id/pieces` with `{"content": "..."}` → 201 with incremented `version_number`; re-GET reflects new content
- [x] `GET /api/stories/:story_id/world` → `content` non-null for seeded Little Witch world
- [x] `POST /api/stories/:story_id/world/pieces` with `{"content": "..."}` → 201; re-GET reflects new content
- [x] All endpoints return 403 when bearer token is scoped to a different story

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)