### PR TITLE
Add ?format=fountain to GET /views/script (Closes #59)

### DIFF
--- a/lib/storybox_web/controllers/api_controller.ex
+++ b/lib/storybox_web/controllers/api_controller.ex
@@ -471,7 +471,9 @@ defmodule StoryboxWeb.ApiController do
     if unresolved == [] do
       conn
     else
-      lines = Enum.map_join(unresolved, "\n", &"/* unresolved: #{&1} */")
+      # Fountain block comments do not nest — labels inside the summary must be
+      # plain text, never the `/* */`-wrapped form used for the inline markers.
+      lines = Enum.map_join(unresolved, "\n", &"  - #{&1}")
       {:ok, conn} = Plug.Conn.chunk(conn, "/* UNRESOLVED SCENES:\n#{lines}\n*/\n")
       conn
     end

--- a/lib/storybox_web/controllers/api_controller.ex
+++ b/lib/storybox_web/controllers/api_controller.ex
@@ -98,21 +98,54 @@ defmodule StoryboxWeb.ApiController do
   def script_view(conn, params) do
     story = conn.assigns.current_story
 
-    case parse_script_view_mode(params) do
-      {:error, reason} ->
-        conn |> put_status(400) |> json(%{error: reason})
+    with {:ok, format} <- parse_script_view_format(params),
+         {:ok, mode, snapshot_id} <- parse_script_view_mode(params) do
+      case format do
+        "json" -> respond_json_script_view(conn, story, mode, snapshot_id)
+        "fountain" -> respond_fountain_script_view(conn, story, mode, snapshot_id)
+      end
+    else
+      {:error, reason} -> conn |> put_status(400) |> json(%{error: reason})
+    end
+  end
 
-      {:ok, mode, snapshot_id} ->
-        case assemble_script_view(story, mode, snapshot_id) do
-          {:error, :snapshot_not_found} ->
-            conn |> put_status(404) |> json(%{error: "snapshot not found"})
+  defp respond_json_script_view(conn, story, mode, snapshot_id) do
+    case assemble_script_view(story, mode, snapshot_id) do
+      {:error, :snapshot_not_found} ->
+        conn |> put_status(404) |> json(%{error: "snapshot not found"})
 
-          {:error, :content_unavailable} ->
-            conn |> put_status(503) |> json(%{error: "content unavailable"})
+      {:error, :content_unavailable} ->
+        conn |> put_status(503) |> json(%{error: "content unavailable"})
 
-          {:ok, response} ->
-            json(conn, response)
-        end
+      {:ok, response} ->
+        json(conn, response)
+    end
+  end
+
+  # Resolve-then-stream: the full slot list (pieces + null-pin holes) is
+  # traversed and all ScriptPiece content is fetched into memory *before*
+  # `send_chunked` commits the 200. A storage failure therefore still
+  # surfaces as a clean 503 JSON, identical to the JSON path; chunking is
+  # only a delivery detail over already-resolved content (orchestrator Q2).
+  defp respond_fountain_script_view(conn, story, mode, snapshot_id) do
+    case assemble_fountain_script_view(story, mode, snapshot_id) do
+      {:error, :snapshot_not_found} ->
+        conn |> put_status(404) |> json(%{error: "snapshot not found"})
+
+      {:error, :content_unavailable} ->
+        conn |> put_status(503) |> json(%{error: "content unavailable"})
+
+      {:ok, slots} ->
+        stream_fountain(conn, slots)
+    end
+  end
+
+  # `?format=` is optional and defaults to "json". Only "json" and
+  # "fountain" are accepted — anything else is a 400 (orchestrator Q4).
+  defp parse_script_view_format(params) do
+    case Map.get(params, "format", "json") do
+      format when format in ["json", "fountain"] -> {:ok, format}
+      _ -> {:error, "format must be json or fountain"}
     end
   end
 
@@ -329,6 +362,119 @@ defmodule StoryboxWeb.ApiController do
         {:error, _} -> {:halt, {:error, :content_unavailable}}
       end
     end)
+  end
+
+  # ── format=fountain ───────────────────────────────────────────────────────
+
+  # Assembles the ordered slot list for a Fountain stream. Returns
+  # `{:ok, slots}` where each slot is `{:content, fountain_text}` or
+  # `{:unresolved, label}`, in document order — or an `{:error, _}` tuple
+  # that the caller renders as JSON before any chunking begins.
+  defp assemble_fountain_script_view(_story, "approved", _snapshot_id), do: {:ok, []}
+
+  defp assemble_fountain_script_view(story, mode, snapshot_id) do
+    story_script_view =
+      Storybox.Stories.StoryScriptView
+      |> Ash.Query.filter(story_id == ^story.id)
+      |> Ash.read_one!(authorize?: false)
+
+    case resolve_story_script_vv(mode, snapshot_id, story_script_view) do
+      {:error, reason} -> {:error, reason}
+      {:ok, nil} -> {:ok, []}
+      {:ok, ssvv} -> resolve_slot_content(traverse_fountain_slots(mode, ssvv))
+    end
+  end
+
+  # Flat-maps the V/VV stack into a position-ordered slot list. Unlike the
+  # JSON path's two-list accumulation, this interleaves pieces and null-pin
+  # holes so the document order is preserved. Null pins are labelled by the
+  # layer that failed: `sequence-N` at the story_script layer, `scene-position-N`
+  # at the sequence layer, and the real Scene slug at the script layer
+  # (orchestrator Q1).
+  defp traverse_fountain_slots(mode, ssvv) do
+    ssvv.id
+    |> load_segments(:story_script_vv)
+    |> Enum.flat_map(fn seq_seg ->
+      case resolve_segment(mode, seq_seg) do
+        nil ->
+          [{:unresolved, "sequence-#{seq_seg.position}"}]
+
+        seq_vv ->
+          seq_vv.id
+          |> load_segments(:sequence_vv)
+          |> Enum.flat_map(fn script_seg ->
+            case resolve_segment(mode, script_seg) do
+              nil ->
+                [{:unresolved, "scene-position-#{script_seg.position}"}]
+
+              script_vv ->
+                script_vv.id
+                |> load_segments(:script_vv)
+                |> Enum.map(fn piece_seg ->
+                  case resolve_segment(mode, piece_seg) do
+                    nil -> {:unresolved, scene_label_for_script_vv(script_vv)}
+                    piece -> {:piece, piece}
+                  end
+                end)
+            end
+          end)
+      end
+    end)
+  end
+
+  # Looks up the owning Scene for a ScriptViewVersion to label a null script
+  # piece pin. Two extra reads, run only for unresolvable slots.
+  defp scene_label_for_script_vv(script_vv) do
+    with sv when not is_nil(sv) <-
+           read_by_id(Storybox.Stories.ScriptView, script_vv.script_view_id),
+         scene when not is_nil(scene) <- read_by_id(Storybox.Stories.Scene, sv.scene_id) do
+      scene.slug || scene.title || "unknown"
+    else
+      _ -> "unknown"
+    end
+  end
+
+  # Fetches all ScriptPiece content into memory. A storage failure halts with
+  # `{:error, :content_unavailable}` so the caller can still send a 503 JSON.
+  defp resolve_slot_content(slots) do
+    Enum.reduce_while(slots, {:ok, []}, fn
+      {:piece, piece}, {:ok, acc} ->
+        case Storybox.Storage.get_content(piece.content_uri) do
+          {:ok, content} -> {:cont, {:ok, acc ++ [{:content, content}]}}
+          {:error, _} -> {:halt, {:error, :content_unavailable}}
+        end
+
+      {:unresolved, label}, {:ok, acc} ->
+        {:cont, {:ok, acc ++ [{:unresolved, label}]}}
+    end)
+  end
+
+  # Streams the pre-resolved slots as a chunked `text/plain` document. Null-pin
+  # holes emit an inline `/* unresolved: ... */` marker and a trailing summary.
+  defp stream_fountain(conn, slots) do
+    conn =
+      conn
+      |> put_resp_content_type("text/plain")
+      |> send_chunked(200)
+
+    {conn, unresolved} =
+      Enum.reduce(slots, {conn, []}, fn
+        {:content, content}, {conn, unres} ->
+          {:ok, conn} = Plug.Conn.chunk(conn, content <> "\n\n")
+          {conn, unres}
+
+        {:unresolved, label}, {conn, unres} ->
+          {:ok, conn} = Plug.Conn.chunk(conn, "/* unresolved: #{label} */\n\n")
+          {conn, unres ++ [label]}
+      end)
+
+    if unresolved == [] do
+      conn
+    else
+      lines = Enum.map_join(unresolved, "\n", &"/* unresolved: #{&1} */")
+      {:ok, conn} = Plug.Conn.chunk(conn, "/* UNRESOLVED SCENES:\n#{lines}\n*/\n")
+      conn
+    end
   end
 
   def create_scene_version(conn, %{"id" => id} = params) do

--- a/test/storybox_web/controllers/script_view_fountain_test.exs
+++ b/test/storybox_web/controllers/script_view_fountain_test.exs
@@ -1,0 +1,234 @@
+defmodule StoryboxWeb.ScriptViewFountainTest do
+  use StoryboxWeb.ConnCase
+
+  import StoryboxWeb.ScriptViewHelpers
+
+  alias Storybox.Accounts.ApiToken
+
+  # The shared setup mirrors `ScriptViewTest` — see that module for the full
+  # V/VV stack diagram. Fixture builders live in `StoryboxWeb.ScriptViewHelpers`.
+  #
+  #   story        — full resolvable chain (Scene A DRAFT/REVISED, Scene B ONLY)
+  #   unres_story  — StoryScriptVV → SequenceVV with one null-pin Segment
+  #   empty_story  — no StoryScriptView at all
+
+  setup do
+    {:ok, user} =
+      Storybox.Accounts.User
+      |> Ash.Changeset.for_create(:register_with_password, %{
+        email: "script_view_fountain_test@example.com",
+        password: "password123!",
+        password_confirmation: "password123!"
+      })
+      |> Ash.create()
+
+    story = create_story(user, "Fountain Test Story")
+    unres_story = create_story(user, "Unresolvable Fountain Story")
+
+    {:ok, raw_token, _} = ApiToken.generate(%{story_id: story.id, user_id: user.id})
+    {:ok, unres_token, _} = ApiToken.generate(%{story_id: unres_story.id, user_id: user.id})
+
+    # ── main story: full resolvable chain ────────────────────────────────────
+    scene_a = create_scene(story, "Scene A")
+    scv_a = create_script_view(scene_a)
+    a_p1 = create_script_piece(scene_a, "SCENE A — DRAFT")
+    a_p2 = create_script_piece(scene_a, "SCENE A — REVISED")
+    scvv_a1 = create_script_vv(scv_a, 1, a_p1)
+    scvv_a2 = create_script_vv(scv_a, 2, a_p2)
+
+    scene_b = create_scene(story, "Scene B")
+    scv_b = create_script_view(scene_b)
+    b_p1 = create_script_piece(scene_b, "SCENE B — ONLY")
+    scvv_b1 = create_script_vv(scv_b, 1, b_p1)
+
+    seq = create_sequence(story, "Main Sequence", "sequence-main")
+    seq_view = create_sequence_view(story, seq)
+
+    seq_vv_1 =
+      create_sequence_vv(seq_view, 1, [pin(:script_vv, scvv_a1), pin(:script_vv, scvv_b1)])
+
+    seq_vv_2 =
+      create_sequence_vv(seq_view, 2, [pin(:script_vv, scvv_a2), pin(:script_vv, scvv_b1)])
+
+    ssv = create_story_script_view(story)
+    ssvv_v1 = create_story_script_vv(ssv, 1, [pin(:sequence_vv, seq_vv_1)])
+    ssvv_v2 = create_story_script_vv(ssv, 2, [pin(:sequence_vv, seq_vv_2)])
+
+    # ── unresolvable story: SequenceVV carries a null-pin Segment ────────────
+    u_seq = create_sequence(unres_story, "U Sequence", "u-sequence")
+    u_seq_view = create_sequence_view(unres_story, u_seq)
+    u_seq_vv = create_sequence_vv(u_seq_view, 1, [nil])
+    u_ssv = create_story_script_view(unres_story)
+    create_story_script_vv(u_ssv, 1, [pin(:sequence_vv, u_seq_vv)])
+
+    %{
+      user: user,
+      story: story,
+      unres_story: unres_story,
+      raw_token: raw_token,
+      unres_token: unres_token,
+      ssvv_v1: ssvv_v1,
+      ssvv_v2: ssvv_v2
+    }
+  end
+
+  defp authed(conn, raw_token), do: put_req_header(conn, "authorization", "Bearer #{raw_token}")
+
+  defp get_script(conn, story, raw_token, params) do
+    query = URI.encode_query(params)
+    conn |> authed(raw_token) |> get("/api/stories/#{story.id}/views/script?#{query}")
+  end
+
+  # ── mode=latest ──────────────────────────────────────────────────────────
+
+  describe "GET /views/script?format=fountain — mode=latest" do
+    test "streams the latest content as a chunked text/plain document", %{
+      conn: conn,
+      story: story,
+      raw_token: raw_token
+    } do
+      conn = get_script(conn, story, raw_token, %{format: "fountain", mode: "latest"})
+      body = response(conn, 200)
+
+      assert get_resp_header(conn, "content-type") == ["text/plain; charset=utf-8"]
+      assert body == "SCENE A — REVISED\n\nSCENE B — ONLY\n\n"
+    end
+
+    test "a fully resolved story has no trailing summary block", %{
+      conn: conn,
+      story: story,
+      raw_token: raw_token
+    } do
+      body =
+        conn
+        |> get_script(story, raw_token, %{format: "fountain", mode: "latest"})
+        |> response(200)
+
+      refute body =~ "UNRESOLVED SCENES"
+      refute body =~ "/* unresolved:"
+    end
+  end
+
+  # ── mode=snapshot ────────────────────────────────────────────────────────
+
+  describe "GET /views/script?format=fountain — mode=snapshot" do
+    test "follows the discrete pins of the addressed StoryScriptViewVersion", %{
+      conn: conn,
+      story: story,
+      raw_token: raw_token,
+      ssvv_v1: ssvv_v1
+    } do
+      conn =
+        get_script(conn, story, raw_token, %{
+          format: "fountain",
+          mode: "snapshot",
+          snapshot_id: ssvv_v1.id
+        })
+
+      # v1 pins the older chain, so snapshot mode yields DRAFT, not REVISED.
+      assert response(conn, 200) == "SCENE A — DRAFT\n\nSCENE B — ONLY\n\n"
+    end
+
+    test "unknown snapshot_id returns 404 JSON before chunking starts", %{
+      conn: conn,
+      story: story,
+      raw_token: raw_token
+    } do
+      conn =
+        get_script(conn, story, raw_token, %{
+          format: "fountain",
+          mode: "snapshot",
+          snapshot_id: Ash.UUID.generate()
+        })
+
+      assert json_response(conn, 404)["error"] == "snapshot not found"
+    end
+  end
+
+  # ── mode=approved ────────────────────────────────────────────────────────
+
+  describe "GET /views/script?format=fountain — mode=approved" do
+    test "returns a 200 chunked response with an empty body", %{
+      conn: conn,
+      story: story,
+      raw_token: raw_token
+    } do
+      conn = get_script(conn, story, raw_token, %{format: "fountain", mode: "approved"})
+
+      assert response(conn, 200) == ""
+      assert get_resp_header(conn, "content-type") == ["text/plain; charset=utf-8"]
+    end
+  end
+
+  # ── unresolvable scenes ──────────────────────────────────────────────────
+
+  describe "unresolvable scenes" do
+    test "a null-pin Segment emits an inline comment and a trailing summary", %{
+      conn: conn,
+      unres_story: unres_story,
+      unres_token: unres_token
+    } do
+      conn = get_script(conn, unres_story, unres_token, %{format: "fountain", mode: "latest"})
+      body = response(conn, 200)
+
+      # The null pin sits at the sequence layer, so it is labelled positionally.
+      assert body =~ "/* unresolved: scene-position-1 */"
+      assert body =~ "/* UNRESOLVED SCENES:"
+    end
+  end
+
+  # ── parameter validation ─────────────────────────────────────────────────
+
+  describe "parameter validation" do
+    test "an unrecognised format value returns 400 JSON", %{
+      conn: conn,
+      story: story,
+      raw_token: raw_token
+    } do
+      conn = get_script(conn, story, raw_token, %{format: "xml"})
+      assert json_response(conn, 400)["error"] == "format must be json or fountain"
+    end
+
+    test "an unrecognised mode value returns 400 JSON", %{
+      conn: conn,
+      story: story,
+      raw_token: raw_token
+    } do
+      conn = get_script(conn, story, raw_token, %{format: "fountain", mode: "draft"})
+      assert json_response(conn, 400)["error"] == "mode must be latest, approved, or snapshot"
+    end
+
+    test "mode=snapshot without snapshot_id returns 400 JSON", %{
+      conn: conn,
+      story: story,
+      raw_token: raw_token
+    } do
+      conn = get_script(conn, story, raw_token, %{format: "fountain", mode: "snapshot"})
+      assert json_response(conn, 400)["error"] == "snapshot_id is required when mode is snapshot"
+    end
+  end
+
+  # ── seeded Little Witch story ────────────────────────────────────────────
+
+  describe "seeded Little Witch story" do
+    test "streams the full screenplay with the reckoning gap as a comment", %{
+      conn: conn,
+      user: user
+    } do
+      lw_story = create_story(user, "Little Witch")
+      :ok = Storybox.Seeds.LittleWitchLoader.seed!(lw_story)
+      {:ok, lw_token, _} = ApiToken.generate(%{story_id: lw_story.id, user_id: user.id})
+
+      conn = get_script(conn, lw_story, lw_token, %{format: "fountain", mode: "latest"})
+      body = response(conn, 200)
+
+      assert get_resp_header(conn, "content-type") == ["text/plain; charset=utf-8"]
+      assert body != ""
+
+      # The "reckoning" sequence has one null-pin Segment in the seed data, so
+      # the gap appears inline and in the trailing summary.
+      assert body =~ "/* unresolved:"
+      assert body =~ "/* UNRESOLVED SCENES:"
+    end
+  end
+end

--- a/test/storybox_web/controllers/script_view_fountain_test.exs
+++ b/test/storybox_web/controllers/script_view_fountain_test.exs
@@ -173,7 +173,24 @@ defmodule StoryboxWeb.ScriptViewFountainTest do
 
       # The null pin sits at the sequence layer, so it is labelled positionally.
       assert body =~ "/* unresolved: scene-position-1 */"
-      assert body =~ "/* UNRESOLVED SCENES:"
+      assert body =~ "/* UNRESOLVED SCENES:\n  - scene-position-1\n*/"
+    end
+
+    test "the trailing summary block is a single non-nested block comment", %{
+      conn: conn,
+      unres_story: unres_story,
+      unres_token: unres_token
+    } do
+      body =
+        conn
+        |> get_script(unres_story, unres_token, %{format: "fountain", mode: "latest"})
+        |> response(200)
+
+      # Fountain block comments do not nest — a parser closes at the first
+      # `*/`. The summary must wrap plain-text labels, never re-wrap the
+      # `/* */`-formatted inline markers.
+      [_, summary] = String.split(body, "/* UNRESOLVED SCENES:", parts: 2)
+      refute summary =~ "/*"
     end
   end
 

--- a/test/storybox_web/controllers/script_view_test.exs
+++ b/test/storybox_web/controllers/script_view_test.exs
@@ -1,21 +1,10 @@
 defmodule StoryboxWeb.ScriptViewTest do
   use StoryboxWeb.ConnCase
 
-  alias Storybox.Accounts.ApiToken
+  import StoryboxWeb.ScriptViewHelpers
 
-  alias Storybox.Stories.{
-    Scene,
-    ScriptPiece,
-    ScriptView,
-    ScriptViewVersion,
-    Segment,
-    Sequence,
-    SequenceView,
-    SequenceViewVersion,
-    Story,
-    StoryScriptView,
-    StoryScriptViewVersion
-  }
+  alias Storybox.Accounts.ApiToken
+  alias Storybox.Stories.ScriptPiece
 
   # The shared setup builds the full V/VV stack the script-view endpoint
   # traverses:
@@ -101,150 +90,6 @@ defmodule StoryboxWeb.ScriptViewTest do
       ssvv_v2: ssvv_v2,
       u_seq_vv: u_seq_vv
     }
-  end
-
-  # ── resource builders ────────────────────────────────────────────────────
-
-  defp create_story(user, title) do
-    {:ok, story} =
-      Story
-      |> Ash.Changeset.for_create(:create, %{title: title, user_id: user.id})
-      |> Ash.create()
-
-    story
-  end
-
-  defp create_scene(story, title) do
-    {:ok, scene} =
-      Scene
-      |> Ash.Changeset.for_create(:create, %{title: title, story_id: story.id})
-      |> Ash.create(authorize?: false)
-
-    scene
-  end
-
-  defp create_script_view(scene) do
-    {:ok, sv} =
-      ScriptView
-      |> Ash.Changeset.for_create(:create, %{scene_id: scene.id})
-      |> Ash.create(authorize?: false)
-
-    sv
-  end
-
-  defp create_script_piece(scene, content) do
-    {:ok, piece} =
-      ScriptPiece
-      |> Ash.ActionInput.for_action(:create_version, %{scene_id: scene.id, content: content})
-      |> Ash.run_action(authorize?: false)
-
-    piece
-  end
-
-  defp create_script_vv(script_view, version_number, piece) do
-    {:ok, vv} =
-      ScriptViewVersion
-      |> Ash.Changeset.for_create(:create, %{
-        script_view_id: script_view.id,
-        version_number: version_number
-      })
-      |> Ash.create(authorize?: false)
-
-    create_segment(vv.id, :script_vv, 1, pin(:script_piece, piece))
-    vv
-  end
-
-  defp create_sequence(story, name, slug) do
-    {:ok, seq} =
-      Sequence
-      |> Ash.Changeset.for_create(:create, %{story_id: story.id, name: name, slug: slug})
-      |> Ash.create(authorize?: false)
-
-    seq
-  end
-
-  defp create_sequence_view(story, sequence) do
-    {:ok, sv} =
-      SequenceView
-      |> Ash.Changeset.for_create(:create, %{story_id: story.id, sequence_id: sequence.id})
-      |> Ash.create(authorize?: false)
-
-    sv
-  end
-
-  defp create_sequence_vv(sequence_view, version_number, pins) do
-    {:ok, vv} =
-      SequenceViewVersion
-      |> Ash.Changeset.for_create(:create, %{
-        sequence_view_id: sequence_view.id,
-        version_number: version_number
-      })
-      |> Ash.create(authorize?: false)
-
-    create_pinned_segments(vv.id, :sequence_vv, pins)
-    vv
-  end
-
-  defp create_story_script_view(story) do
-    {:ok, ssv} =
-      StoryScriptView
-      |> Ash.Changeset.for_create(:create, %{story_id: story.id})
-      |> Ash.create(authorize?: false)
-
-    ssv
-  end
-
-  defp create_story_script_vv(story_script_view, version_number, pins) do
-    {:ok, vv} =
-      StoryScriptViewVersion
-      |> Ash.Changeset.for_create(:create, %{
-        story_script_view_id: story_script_view.id,
-        version_number: version_number,
-        source_treatment_view_version_id: Ash.UUID.generate()
-      })
-      |> Ash.create(authorize?: false)
-
-    create_pinned_segments(vv.id, :story_script_vv, pins)
-    vv
-  end
-
-  # `pin/2` produces the {pin_type, pin_id, pin_version} tuple a Segment needs.
-  defp pin(pin_type, target), do: {pin_type, target.id, target.version_number}
-
-  defp create_pinned_segments(view_version_id, view_version_type, pins) do
-    pins
-    |> Enum.with_index(1)
-    |> Enum.each(fn {pin, position} ->
-      create_segment(view_version_id, view_version_type, position, pin)
-    end)
-  end
-
-  defp create_segment(view_version_id, view_version_type, position, pin) do
-    attrs = %{
-      view_version_id: view_version_id,
-      view_version_type: view_version_type,
-      position: position
-    }
-
-    attrs =
-      case pin do
-        nil ->
-          attrs
-
-        {pin_type, pin_id, pin_version} ->
-          Map.merge(attrs, %{
-            pin_id: pin_id,
-            pin_type: pin_type,
-            pin_version_at_creation: pin_version
-          })
-      end
-
-    {:ok, seg} =
-      Segment
-      |> Ash.Changeset.for_create(:create, attrs)
-      |> Ash.create(authorize?: false)
-
-    seg
   end
 
   # ── request helpers ──────────────────────────────────────────────────────

--- a/test/support/script_view_helpers.ex
+++ b/test/support/script_view_helpers.ex
@@ -1,0 +1,166 @@
+defmodule StoryboxWeb.ScriptViewHelpers do
+  @moduledoc """
+  Shared fixture builders for the script-view endpoint tests.
+
+  Builds the V/VV stack the endpoint traverses —
+  `StoryScriptView → SequenceView → ScriptView → ScriptPiece` — and is used
+  by both the JSON (`ScriptViewTest`) and Fountain (`ScriptViewFountainTest`)
+  test modules. `import StoryboxWeb.ScriptViewHelpers` to use it.
+  """
+
+  alias Storybox.Stories.{
+    Scene,
+    ScriptPiece,
+    ScriptView,
+    ScriptViewVersion,
+    Segment,
+    Sequence,
+    SequenceView,
+    SequenceViewVersion,
+    Story,
+    StoryScriptView,
+    StoryScriptViewVersion
+  }
+
+  def create_story(user, title) do
+    {:ok, story} =
+      Story
+      |> Ash.Changeset.for_create(:create, %{title: title, user_id: user.id})
+      |> Ash.create()
+
+    story
+  end
+
+  def create_scene(story, title) do
+    {:ok, scene} =
+      Scene
+      |> Ash.Changeset.for_create(:create, %{title: title, story_id: story.id})
+      |> Ash.create(authorize?: false)
+
+    scene
+  end
+
+  def create_script_view(scene) do
+    {:ok, sv} =
+      ScriptView
+      |> Ash.Changeset.for_create(:create, %{scene_id: scene.id})
+      |> Ash.create(authorize?: false)
+
+    sv
+  end
+
+  def create_script_piece(scene, content) do
+    {:ok, piece} =
+      ScriptPiece
+      |> Ash.ActionInput.for_action(:create_version, %{scene_id: scene.id, content: content})
+      |> Ash.run_action(authorize?: false)
+
+    piece
+  end
+
+  def create_script_vv(script_view, version_number, piece) do
+    {:ok, vv} =
+      ScriptViewVersion
+      |> Ash.Changeset.for_create(:create, %{
+        script_view_id: script_view.id,
+        version_number: version_number
+      })
+      |> Ash.create(authorize?: false)
+
+    create_segment(vv.id, :script_vv, 1, pin(:script_piece, piece))
+    vv
+  end
+
+  def create_sequence(story, name, slug) do
+    {:ok, seq} =
+      Sequence
+      |> Ash.Changeset.for_create(:create, %{story_id: story.id, name: name, slug: slug})
+      |> Ash.create(authorize?: false)
+
+    seq
+  end
+
+  def create_sequence_view(story, sequence) do
+    {:ok, sv} =
+      SequenceView
+      |> Ash.Changeset.for_create(:create, %{story_id: story.id, sequence_id: sequence.id})
+      |> Ash.create(authorize?: false)
+
+    sv
+  end
+
+  def create_sequence_vv(sequence_view, version_number, pins) do
+    {:ok, vv} =
+      SequenceViewVersion
+      |> Ash.Changeset.for_create(:create, %{
+        sequence_view_id: sequence_view.id,
+        version_number: version_number
+      })
+      |> Ash.create(authorize?: false)
+
+    create_pinned_segments(vv.id, :sequence_vv, pins)
+    vv
+  end
+
+  def create_story_script_view(story) do
+    {:ok, ssv} =
+      StoryScriptView
+      |> Ash.Changeset.for_create(:create, %{story_id: story.id})
+      |> Ash.create(authorize?: false)
+
+    ssv
+  end
+
+  def create_story_script_vv(story_script_view, version_number, pins) do
+    {:ok, vv} =
+      StoryScriptViewVersion
+      |> Ash.Changeset.for_create(:create, %{
+        story_script_view_id: story_script_view.id,
+        version_number: version_number,
+        source_treatment_view_version_id: Ash.UUID.generate()
+      })
+      |> Ash.create(authorize?: false)
+
+    create_pinned_segments(vv.id, :story_script_vv, pins)
+    vv
+  end
+
+  # `pin/2` produces the {pin_type, pin_id, pin_version} tuple a Segment needs.
+  def pin(pin_type, target), do: {pin_type, target.id, target.version_number}
+
+  def create_pinned_segments(view_version_id, view_version_type, pins) do
+    pins
+    |> Enum.with_index(1)
+    |> Enum.each(fn {pin, position} ->
+      create_segment(view_version_id, view_version_type, position, pin)
+    end)
+  end
+
+  def create_segment(view_version_id, view_version_type, position, pin) do
+    attrs = %{
+      view_version_id: view_version_id,
+      view_version_type: view_version_type,
+      position: position
+    }
+
+    attrs =
+      case pin do
+        nil ->
+          attrs
+
+        {pin_type, pin_id, pin_version} ->
+          Map.merge(attrs, %{
+            pin_id: pin_id,
+            pin_type: pin_type,
+            pin_version_at_creation: pin_version
+          })
+      end
+
+    {:ok, seg} =
+      Segment
+      |> Ash.Changeset.for_create(:create, attrs)
+      |> Ash.create(authorize?: false)
+
+    seg
+  end
+end


### PR DESCRIPTION
## Summary

Adds `?format=fountain` to the assembled-script endpoint introduced by #76. A request with `format=fountain` streams a Fountain-format document over a chunked `text/plain; charset=utf-8` response; the JSON path is unchanged.

- **Traversal** — flat-maps the V/VV stack (`StoryScriptVV → SequenceVV → ScriptVV → ScriptPiece`) into a position-ordered slot list, interleaving resolved pieces with null-pin holes so document order is preserved.
- **Unresolvable labels** — null pins are labelled by the failing layer: `sequence-N` (story_script layer), `scene-position-N` (sequence layer), real Scene slug (script layer). They emit an inline `/* unresolved: ... */` marker and contribute to a trailing summary block.
- **Resolve-then-stream** — the full slot list is traversed and all `ScriptPiece` content fetched into memory *before* `send_chunked` commits the 200, so a storage failure still surfaces as a clean **503 JSON** (orchestrator Q2).
- **Validation** — unknown `format` values return **400**, validated alongside `mode` (orchestrator Q4).
- All three `mode` values (`latest`/`approved`/`snapshot`) are supported.

## Tests

- New `ScriptViewFountainTest` ConnCase covering each `mode`, the unresolvable path, parameter validation, and the seeded Little Witch story.
- Shared fixture builders extracted to `test/support/script_view_helpers.ex`; `ScriptViewTest` updated to import them (orchestrator directive — no test logic changes).
- `mix precommit` passes (362 tests, 0 failures — run against `main` after rebase).

## User testing

**Boot the service:**
```
podman compose -f podman-compose.yml up -d
mix ecto.reset
```

**Validate:**
- [ ] Obtain an API token via `POST /api/auth/token`
- [ ] `GET /api/stories/:id/views/script?format=fountain&mode=latest` — confirm response headers include `content-type: text/plain` and `transfer-encoding: chunked`; body is valid Fountain text
- [ ] Re-request with `format=json` (or no format) — confirm the JSON envelope is unchanged (existing behaviour preserved)
- [ ] Seed the Little Witch story and request `format=fountain` — confirm the unresolved reckoning scene appears as `/* unresolved: ... */` inline and in the trailing summary block

> Note: `transfer-encoding: chunked` is added by the real HTTP server (Bandit/Cowboy), not by Plug's test adapter — verifiable in a live browser/curl request but not in ConnCase tests.

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)