### PR TITLE
Add DISPATCH_PROOF.md marker (Closes #163)

### DIFF
--- a/DISPATCH_PROOF.md
+++ b/DISPATCH_PROOF.md
@@ -1,0 +1,1 @@
+Dispatch pattern proof — 2026-05-31. Throwaway marker; safe to delete.


### PR DESCRIPTION
Adds a single throwaway marker file `DISPATCH_PROOF.md` at the repository root to prove the agent-dispatch loop end-to-end. Deliberately trivial and fully reversible — no application code, schema, tests, or config touched.

Closes #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)