### PR TITLE
docs: Ash-true conventions + instance-focused README

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,14 @@ This is a web application written using the Phoenix web framework.
   Without the override the run fails during setup with `cannot invoke sandbox operation with pool DBConnection.ConnectionPool`. A suite that errors during environment/connection-pool setup is **not** green — treat the checks as passing only when the full suite runs to completion with zero failures.
 - Use the already included and available `:req` (`Req`) library for HTTP requests, **avoid** `:httpoison`, `:tesla`, and `:httpc`. Req is included by default and is the preferred HTTP client for Phoenix apps
 
+### Ash & data layer
+
+This app's schema and data layer are **Ash 3 / AshPostgres 2** (`{:ash, "~> 3.0"}`, `{:ash_postgres, "~> 2.0"}`) — domain schema is defined as **Ash resources**, not raw Ecto schemas. Define attributes, relationships, actions, validations, and policies on the resource.
+
+- **Migrations and resource snapshots are generated, never hand-authored.** Change the Ash resource, then run `mix ash_postgres.generate_migrations <name>` — it derives the migration in `priv/repo/migrations/` **and** the matching `priv/resource_snapshots/repo/<table>/` snapshot together. **Never** write a migration by hand or edit a snapshot file.
+- `mix precommit` runs `ash_postgres.generate_migrations --check`; any divergence between a resource and its snapshot **fails the gate**. A schema change is green only when `--check` reports no pending migration.
+- The generic **Ecto Guidelines** below apply only where Ash exposes Ecto directly (e.g. a changeset inside an action); they do **not** describe how schema, validations, or migrations are authored here — that is all Ash.
+
 ### Phoenix v1.8 guidelines
 
 - **Always** begin your LiveView templates with `<Layouts.app flash={@flash} ...>` which wraps all inner content

--- a/README.md
+++ b/README.md
@@ -1,128 +1,79 @@
 # StoryBox MVP
 
-A story project manager with versioned components, dependency tracking, and an agentic API.
+A story project manager with a versioned story graph and an agentic HTTP API. This is a
+Phoenix/Ash application and **one instance** of the StoryBox story model — the model itself
+is maintained as a separate living spec and is out of scope for this README, which covers
+working *in this codebase*.
 
-This MVP validates the StoryBox story model before building the full hub/spoke platform. It is deliberately scoped: no spoke architecture, no distributed storage, no multi-tenant propagation. Those emerge from what is learned here.
+## Tech stack
 
----
-
-## What It Does
-
-StoryBox organises a story as a graph of versioned, interdependent components. Changes at the top propagate down. Every piece of content is versioned and reviewed. An API exposes the story graph to agentic workflows so agents work on bounded, scoped pieces rather than whole documents.
-
----
-
-## The Story Model
-
-Four core **Components** — modular, independently versioned, reusable across stories:
-
-| Component | Contains | Through-line |
-|---|---|---|
-| **Story** | Controlling idea · Logline · Title | Beat schema — biases all sequences |
-| **Character** | Essence · Contradictions · Voice | Arc — biases sequences they appear in |
-| **World** | History · Rules · Subtext | State progression — biases world context |
-| **Scene** | Dramatic function · Role slots | Dramatic function — biases instantiation |
-
-Three **Views** — assemblies of components at increasing resolution:
-
-```
-Synopsis    →  story at sequence resolution (one paragraph per sequence)
-Treatment   →  one versioned piece per sequence
-Script      →  sequences broken into scenes (each scene versioned)
-```
-
-Changes flow **top-down only**. A synopsis change diffs against the previous version — only affected sequences become candidates for update. Unaffected sequences keep their current version untouched.
-
----
-
-## Versioning Model
-
-Every piece of content (sequence, scene) is versioned using append-only versions. No version is ever deleted.
-
-**Scene has an approved marker** pointing to one of its versions. Versions can be added freely; moving approval is just updating the pointer.
-
-**Script views:**
-- `:latest` — dynamically resolves to the highest version of each scene
-- `:approved` — assembles from each scene's approved version
-- `:snapshot` — a saved, named map of scene → pinned version (a discrete mixture)
-
----
-
-## Review and Weights
-
-Every piece version has a `weights` map. A new version starts unreviewed (`weights: {}`). Once a weight is applied it is reviewed.
-
-```
-weights: %{"preference" => 0.9}
-```
-
-For MVP, one through-line weight: `preference` (0.0–1.0). A weight of 1.0 signals maximum protection — do not overwrite this. Additional through-lines (super objective alignment, character arc) will be added as the model matures.
-
-**Upstream status** is tracked separately from review status. When an upstream component changes (e.g. controlling idea updated), all downstream piece versions are flagged `:stale` with a record of what changed. This is independent of whether the piece has been reviewed.
-
----
-
-## Storage
-
-| Store | Contains |
-|---|---|
-| **PostgreSQL** | All metadata — story structure, versions, weights, upstream changes, approved markers |
-| **MinIO (S3)** | Piece content — raw `.fountain` files referenced by URI |
-
-Piece content is referenced by URI: `storybox://stories/:id/sequences/:seq_id/v3`. This abstraction is designed for the eventual hub/spoke model where content moves to local Spoke storage.
-
----
-
-## API
-
-Exposes the story graph for agentic workflows. Agents query scoped slices rather than whole documents.
-
-```
-GET  /api/stories/:id/views/synopsis
-GET  /api/stories/:id/views/treatment
-GET  /api/stories/:id/views/treatment/sequences/:seq_id
-GET  /api/stories/:id/views/treatment/diff?from=synopsis_v1&to=synopsis_v2
-GET  /api/stories/:id/views/script
-GET  /api/stories/:id/views/script/scenes/:scene_id
-POST /api/stories/:id/views/treatment/sequences/:seq_id/versions
-POST /api/stories/:id/views/script/scenes/:scene_id/versions
-```
-
----
-
-## Tech Stack
-
-- **Elixir / Phoenix + LiveView** — application and UI
-- **Ash Framework** — declarative resources, dependency graph, custom actions
-- **PostgreSQL** — metadata store
-- **MinIO** — S3-compatible local object storage for piece files
+- **Elixir / Phoenix + LiveView** — application and web UI
+- **Ash 3 / AshPostgres 2** — domain modelling, resources, and the PostgreSQL data layer
+- **AshAuthentication** — user accounts and story-scoped API tokens
+- **PostgreSQL** — structural metadata
+- **MinIO** — S3-compatible object storage for piece content, referenced by URI
 - **Podman** — containerised dev environment
 
----
+## Architecture (as-built)
 
-## Dev Setup
+Two Ash domains (`config :storybox, ash_domains: [...]`):
+
+- **`Storybox.Accounts`** — users and authentication.
+- **`Storybox.Stories`** — the story graph; resources in `lib/storybox/stories/` (`Story`,
+  `Character`/`World`/`Scene` with their `*View` / `*ViewVersion` / `*Piece` resources,
+  `Sequence`, `Segment`, the synopsis/treatment/script views, and `Task`), with cross-cutting
+  logic alongside (`staleness.ex`, `task_generation.ex`, `changes/`).
+
+Layers:
+
+- **Data layer** — Ash resources over PostgreSQL via AshPostgres; schema is defined on the
+  resources (see [AGENTS.md](AGENTS.md) for the resource/migration workflow).
+- **Content storage** — piece bodies live in MinIO, referenced from Postgres by URI
+  (`lib/storybox/storage.ex`); the database holds structure and metadata only.
+- **Web layer** — `StoryboxWeb`: a JSON API (`controllers/api_controller.ex`) for agentic
+  workflows, plus LiveView screens (`StoryListLive`, `StoryOverviewLive`) as a viewer.
+
+## Dev setup & running
+
+Containerised with Podman — see **[docs/dev_setup.md](docs/dev_setup.md)** for full
+instructions (services, ports, env vars, seeding, local API testing). In short:
 
 ```bash
-podman compose -f podman-compose.yml up -d
+podman compose -f podman-compose.yml up -d                                    # app :4000, db, minio
+podman compose -f podman-compose.yml run --rm app mix run priv/repo/seeds.exs
 ```
 
-Services: `app` (Phoenix on :4000), `db` (PostgreSQL on :5432), `minio` (S3 on :9000, console on :9001).
+## Build & test
 
-See [docs/dev_setup.md](docs/dev_setup.md) for full setup instructions.
+```bash
+podman compose -f podman-compose.yml run --rm -e MIX_ENV=test app mix precommit
+```
 
----
+`mix precommit` runs compile (warnings-as-errors), `ash_postgres.generate_migrations --check`,
+unused-deps check, format, and the test suite. The `MIX_ENV=test` override is required in the
+Podman dev env (the `app` service pins `MIX_ENV=dev`).
 
-## What This MVP Is Not
+## API surface
 
-- No hub/spoke distributed architecture
-- No multi-user collaboration or piece propagation
-- No DCC integrations
-- No CG asset pipeline
+A story-scoped JSON API for agentic authoring, under `/api` (authoritative routes:
+`lib/storybox_web/router.ex`):
 
-These are deferred. The MVP validates the story model and agentic workflow before the platform is built around it.
+- **Auth** — `POST /api/auth/token` issues a story-scoped bearer token (`email`, `password`, `story_id`).
+- **Reads** — resolved `GET .../views/synopsis` and `.../views/script`; characters; world; task list.
+- **View cuts** — `POST .../views/{synopsis,treatment,story_script}/cut`,
+  `.../sequences/:seq_id/views/sequence/cut`, `.../scenes/:scene_id/views/script/cut`.
+- **Piece writes** — new versions of scene, character, and world pieces.
+- **Tasks & weights** — advance tasks (`in_progress` / `complete`); set sequence / script-piece weights.
 
----
+Every `/api/stories/:story_id/*` route requires the bearer token and is scoped to that story
+(a token for one story returns 403 on another).
 
-## Docs
+## Scope
 
-- [Dev Setup](docs/dev_setup.md)
+This codebase deliberately excludes the hub/spoke distributed architecture, multi-user
+collaboration/propagation, DCC integrations, and a CG asset pipeline.
+
+## Conventions
+
+Contributor and agent conventions — branch naming, the precommit gate, the Ash
+resource/migration workflow, and the Phoenix/LiveView rules — live in **[AGENTS.md](AGENTS.md)**.


### PR DESCRIPTION
## Steer — repo docs: Ash-true + instance-focused

Orchestrator ambient-layer steer (no issue).

**Problem.** `AGENTS.md` was the stock Phoenix v1.8 template — generic *Ecto Guidelines* and **no Ash content** — despite this being an Ash 3 / AshPostgres 2 app. With only an "Ecto" lens, a planning agent produced a hand-written migration, which fails `mix precommit` (it runs `ash_postgres.generate_migrations --check`). Separately, `README.md` restated a **stale v1 of the story model** (approved-markers, `:latest`/`:approved`/`:snapshot`, a `preference` weight, stored staleness).

**Change.**
- **`AGENTS.md`** — add an *Ash & data layer* section: schema is defined as Ash resources; migrations and resource snapshots are generated via `mix ash_postgres.generate_migrations`, never hand-authored; the generic Ecto section is subordinated to Ash.
- **`README.md`** — drop the model description entirely. The model is a separate living spec; this repo is one instance of it. The README now covers technical interaction only — stack, as-built architecture, dev/build/test, and the real API surface (verified against `router.ex`) — and points to `AGENTS.md` for conventions.

No code or schema changes; docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01GhhCj2fqQxP3P5Wak2uaCt
