### PR TITLE
Add SequencePiece create endpoint (provenance-free) + lazy sequence/spine

### DIFF
--- a/lib/storybox_web/controllers/api_controller.ex
+++ b/lib/storybox_web/controllers/api_controller.ex
@@ -518,6 +518,41 @@ defmodule StoryboxWeb.ApiController do
     end
   end
 
+  # Writes a treatment-prose SequencePiece version, provenance-free. The target
+  # sequence is addressed by slug: if it does not yet exist for this story it is
+  # lazily materialized (Sequence.create's after_action registers its spine
+  # entry, materializing the StorySpine too). `name` defaults to the slug.
+  def create_sequence_piece(conn, %{"seq_slug" => seq_slug} = params) do
+    story = conn.assigns.current_story
+    content = params["content"]
+
+    if is_nil(content) or content == "" do
+      conn |> put_status(400) |> json(%{error: "content is required"})
+    else
+      name = Map.get(params, "name", seq_slug)
+
+      case find_or_create_sequence(story.id, seq_slug, name) do
+        {:error, _} ->
+          conn |> put_status(500) |> json(%{error: "internal error"})
+
+        {:ok, sequence} ->
+          case Storybox.Stories.SequencePiece
+               |> Ash.ActionInput.for_action(:create_version, %{
+                 story_id: story.id,
+                 sequence_id: sequence.id,
+                 content: content
+               })
+               |> Ash.run_action(authorize?: false) do
+            {:ok, piece} ->
+              conn |> put_status(201) |> json(format_version(piece))
+
+            {:error, _} ->
+              conn |> put_status(503) |> json(%{error: "storage error"})
+          end
+      end
+    end
+  end
+
   def list_tasks(conn, params) do
     story = conn.assigns.current_story
     status_str = Map.get(params, "status", "pending")
@@ -1096,6 +1131,25 @@ defmodule StoryboxWeb.ApiController do
     Storybox.Stories.Sequence
     |> Ash.Query.filter(id == ^seq_id and story_id == ^story_id)
     |> Ash.read_one!(authorize?: false)
+  end
+
+  # Resolves a Sequence by slug within a story, creating it if absent. The
+  # create's after_action materializes the StorySpine + entry.
+  defp find_or_create_sequence(story_id, slug, name) do
+    case Storybox.Stories.Sequence
+         |> Ash.Query.filter(slug == ^slug and story_id == ^story_id)
+         |> Ash.read_one(authorize?: false) do
+      {:ok, nil} ->
+        Storybox.Stories.Sequence
+        |> Ash.Changeset.for_create(:create, %{story_id: story_id, name: name, slug: slug})
+        |> Ash.create(authorize?: false)
+
+      {:ok, seq} ->
+        {:ok, seq}
+
+      {:error, error} ->
+        {:error, error}
+    end
   end
 
   defp format_version(nil), do: nil

--- a/lib/storybox_web/router.ex
+++ b/lib/storybox_web/router.ex
@@ -61,6 +61,11 @@ defmodule StoryboxWeb.Router do
     post "/stories/:story_id/scenes/:scene_id/views/script/cut", ApiController, :cut_script_vv
     post "/stories/:story_id/views/story_script/cut", ApiController, :cut_story_script_vv
     post "/stories/:story_id/sequences/:seq_id/weights", ApiController, :set_sequence_weights
+
+    post "/stories/:story_id/sequences/:seq_slug/pieces",
+         ApiController,
+         :create_sequence_piece
+
     post "/stories/:story_id/scenes/:scene_id/weights", ApiController, :set_script_piece_weights
 
     get "/stories/:story_id/characters", ApiController, :list_characters

--- a/test/storybox_web/controllers/sequence_piece_test.exs
+++ b/test/storybox_web/controllers/sequence_piece_test.exs
@@ -1,0 +1,147 @@
+defmodule StoryboxWeb.SequencePieceTest do
+  use StoryboxWeb.ConnCase
+
+  require Ash.Query
+
+  alias Storybox.Accounts.ApiToken
+
+  # Shared setup creates:
+  #
+  #   user ──── story ──── existing_seq (slug "act-1", with sp_v1)
+  #
+  # raw_token is scoped to story.
+
+  setup do
+    {:ok, user} =
+      Storybox.Accounts.User
+      |> Ash.Changeset.for_create(:register_with_password, %{
+        email: "sequence_piece_test@example.com",
+        password: "password123!",
+        password_confirmation: "password123!"
+      })
+      |> Ash.create()
+
+    {:ok, story} =
+      Storybox.Stories.Story
+      |> Ash.Changeset.for_create(:create, %{title: "Sequence Piece Story", user_id: user.id})
+      |> Ash.create()
+
+    {:ok, raw_token, _} = ApiToken.generate(%{story_id: story.id, user_id: user.id})
+
+    {:ok, existing_seq} =
+      Storybox.Stories.Sequence
+      |> Ash.Changeset.for_create(:create, %{
+        story_id: story.id,
+        name: "Act One",
+        slug: "act-1"
+      })
+      |> Ash.create(authorize?: false)
+
+    {:ok, _sp_v1} =
+      Storybox.Stories.SequencePiece
+      |> Ash.ActionInput.for_action(:create_version, %{
+        story_id: story.id,
+        sequence_id: existing_seq.id,
+        content: "Opening treatment prose."
+      })
+      |> Ash.run_action(authorize?: false)
+
+    %{story: story, existing_seq: existing_seq, raw_token: raw_token}
+  end
+
+  describe "POST /api/stories/:story_id/sequences/:seq_slug/pieces" do
+    test "creates a new version on an existing sequence and returns 201", %{
+      conn: conn,
+      story: story,
+      raw_token: raw_token
+    } do
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{raw_token}")
+        |> post("/api/stories/#{story.id}/sequences/act-1/pieces", %{
+          "content" => "Revised treatment prose."
+        })
+
+      body = json_response(conn, 201)
+      assert body["version_number"] == 2
+      assert body["weights"] == %{}
+      assert body["id"]
+      refute Map.has_key?(body, "sequence_id")
+    end
+
+    test "lazily materializes the sequence and spine entry for an unknown slug", %{
+      conn: conn,
+      story: story,
+      raw_token: raw_token
+    } do
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{raw_token}")
+        |> post("/api/stories/#{story.id}/sequences/act-2/pieces", %{
+          "content" => "Brand new sequence prose."
+        })
+
+      body = json_response(conn, 201)
+      assert body["version_number"] == 1
+      assert body["id"]
+
+      sequence =
+        Storybox.Stories.Sequence
+        |> Ash.Query.filter(story_id == ^story.id and slug == "act-2")
+        |> Ash.read_one!(authorize?: false)
+
+      assert sequence
+      assert sequence.name == "act-2"
+
+      spine =
+        Storybox.Stories.StorySpine
+        |> Ash.Query.filter(story_id == ^story.id)
+        |> Ash.read_one!(authorize?: false)
+
+      assert spine
+
+      entry =
+        Storybox.Stories.StorySpineEntry
+        |> Ash.Query.filter(story_spine_id == ^spine.id and sequence_id == ^sequence.id)
+        |> Ash.read_one!(authorize?: false)
+
+      assert entry
+    end
+
+    test "uses an explicit name when supplied for a lazily-created sequence", %{
+      conn: conn,
+      story: story,
+      raw_token: raw_token
+    } do
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{raw_token}")
+        |> post("/api/stories/#{story.id}/sequences/act-3/pieces", %{
+          "content" => "Named sequence prose.",
+          "name" => "Act Three"
+        })
+
+      assert json_response(conn, 201)
+
+      sequence =
+        Storybox.Stories.Sequence
+        |> Ash.Query.filter(story_id == ^story.id and slug == "act-3")
+        |> Ash.read_one!(authorize?: false)
+
+      assert sequence.name == "Act Three"
+    end
+
+    test "returns 400 when content is missing", %{
+      conn: conn,
+      story: story,
+      raw_token: raw_token
+    } do
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{raw_token}")
+        |> post("/api/stories/#{story.id}/sequences/act-1/pieces", %{})
+
+      assert json_response(conn, 400)["error"] == "content is required"
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds `POST /api/stories/:story_id/sequences/:seq_slug/pieces` — the treatment-prose write path. It creates a new `SequencePiece` version (provenance-free) and lazily materializes the `Sequence` + its `StorySpine` entry when the addressed slug does not yet exist.

- **Route** — new slug-keyed endpoint (`:seq_slug`, distinct from the UUID-keyed `:seq_id` routes).
- **Controller** — `create_sequence_piece/2` + `find_or_create_sequence/3` helper. Lazy create relies on `Sequence.create`'s existing `after_action` to register the spine entry (materializing the spine too). Task generation fires via `SequencePiece.create_version`. No new resource changes.
- **Response** — bare `format_version(piece)`, consistent with `create_scene_version` and the other piece-creation endpoints (per orchestrator review Q2).
- **Name** — lazily-created sequences default `name` to the slug, with an optional `name` override (per orchestrator review Q1).

## Tests

New `test/storybox_web/controllers/sequence_piece_test.exs`:
- 201 + new `version_number` on an existing sequence
- 201 + lazy `Sequence`, `StorySpine`, and spine entry creation for an unknown slug
- explicit `name` override honored
- 400 when `content` is missing

`mix precommit` green (385 tests, 0 failures).

Closes #209

🤖 Generated with [Claude Code](https://claude.com/claude-code)