### PR TITLE
Synopsis read returns resolved content (#188)

### DIFF
--- a/lib/storybox_web/controllers/api_controller.ex
+++ b/lib/storybox_web/controllers/api_controller.ex
@@ -75,12 +75,13 @@ defmodule StoryboxWeb.ApiController do
             |> json(%{error: "no synopsis found"})
 
           {:ok, vv} ->
-            json(conn, %{
-              story_id: story.id,
-              synopsis_view_id: view.id,
-              version_number: vv.version_number,
-              inserted_at: vv.inserted_at
-            })
+            case assemble_synopsis_view(story, view, vv) do
+              {:error, :content_unavailable} ->
+                conn |> put_status(503) |> json(%{error: "content unavailable"})
+
+              {:ok, response} ->
+                json(conn, response)
+            end
 
           {:error, _} ->
             conn
@@ -92,6 +93,76 @@ defmodule StoryboxWeb.ApiController do
         conn
         |> put_status(500)
         |> json(%{error: "internal error"})
+    end
+  end
+
+  # Resolves the latest SynopsisViewVersion to per-sequence paragraphs. Segments
+  # pin directly to SynopsisPiece (one layer, no intermediate VVs), keyed by
+  # sequence_id. Iteration follows the live StorySpine order — segments whose
+  # sequence is no longer on the spine are skipped (orchestrator R2); an empty
+  # spine yields no paragraphs (orchestrator R3). Null-pin segments are recorded
+  # in `unresolvable`; a storage failure surfaces as `{:error, :content_unavailable}`.
+  defp assemble_synopsis_view(story, view, vv) do
+    synopsis_vv_type = :synopsis_vv
+
+    segments =
+      Storybox.Stories.Segment
+      |> Ash.Query.filter(view_version_id == ^vv.id and view_version_type == ^synopsis_vv_type)
+      |> Ash.read!(authorize?: false)
+
+    seg_by_seq = Map.new(segments, fn seg -> {seg.sequence_id, seg} end)
+
+    spine_order = Storybox.Stories.StorySpine.sequence_ids_in_order(story.id)
+
+    result =
+      Enum.reduce_while(spine_order, {:ok, [], []}, fn seq_id, {:ok, paras, unres} ->
+        case Map.get(seg_by_seq, seq_id) do
+          nil ->
+            # Sequence on the spine but not in this VV (cut before it existed) — skip.
+            {:cont, {:ok, paras, unres}}
+
+          %{pin_id: nil} = seg ->
+            {:cont,
+             {:ok, paras, unres ++ [%{sequence_id: seg.sequence_id, position: seg.position}]}}
+
+          seg ->
+            case fetch_synopsis_piece_content(seg.pin_id) do
+              {:ok, content} ->
+                {:cont, {:ok, paras ++ [%{sequence_id: seq_id, content: content}], unres}}
+
+              {:error, :content_unavailable} ->
+                {:halt, {:error, :content_unavailable}}
+            end
+        end
+      end)
+
+    case result do
+      {:error, reason} ->
+        {:error, reason}
+
+      {:ok, paragraphs, unresolvable} ->
+        {:ok,
+         %{
+           story_id: story.id,
+           synopsis_view_id: view.id,
+           version_number: vv.version_number,
+           inserted_at: vv.inserted_at,
+           resolved: unresolvable == [],
+           unresolvable: unresolvable,
+           paragraphs: paragraphs
+         }}
+    end
+  end
+
+  defp fetch_synopsis_piece_content(pin_id) do
+    piece =
+      Storybox.Stories.SynopsisPiece
+      |> Ash.Query.filter(id == ^pin_id)
+      |> Ash.read_one!(authorize?: false)
+
+    case Storybox.Storage.get_content(piece.content_uri) do
+      {:ok, content} -> {:ok, content}
+      {:error, _} -> {:error, :content_unavailable}
     end
   end
 

--- a/test/storybox_web/controllers/synopsis_view_test.exs
+++ b/test/storybox_web/controllers/synopsis_view_test.exs
@@ -34,6 +34,49 @@ defmodule StoryboxWeb.SynopsisViewTest do
     put_req_header(conn, "authorization", "Bearer #{raw_token}")
   end
 
+  defp create_sequence(story, name, slug) do
+    {:ok, seq} =
+      Storybox.Stories.Sequence
+      |> Ash.Changeset.for_create(:create, %{story_id: story.id, name: name, slug: slug})
+      |> Ash.create(authorize?: false)
+
+    seq
+  end
+
+  defp create_synopsis_piece(story, sequence, content) do
+    {:ok, piece} =
+      Storybox.Stories.SynopsisPiece
+      |> Ash.ActionInput.for_action(:create_version, %{
+        story_id: story.id,
+        sequence_id: sequence.id,
+        content: content
+      })
+      |> Ash.run_action(authorize?: false)
+
+    piece
+  end
+
+  # Ensures the SynopsisView and cuts a fresh ViewVersion from the live spine.
+  defp cut_synopsis(story) do
+    {:ok, sv} =
+      Storybox.Stories.SynopsisView
+      |> Ash.ActionInput.for_action(:ensure_for_story, %{story_id: story.id})
+      |> Ash.run_action(authorize?: false)
+
+    {:ok, vv} =
+      Storybox.Stories.SynopsisViewVersion
+      |> Ash.ActionInput.for_action(:cut, %{synopsis_view_id: sv.id})
+      |> Ash.run_action(authorize?: false)
+
+    {sv, vv}
+  end
+
+  defp story_spine(story) do
+    Storybox.Stories.StorySpine
+    |> Ash.Query.filter(story_id == ^story.id)
+    |> Ash.read_one!(authorize?: false)
+  end
+
   describe "GET /api/stories/:story_id/views/synopsis" do
     test "returns 404 when no SynopsisView exists for the story", %{
       conn: conn,
@@ -116,6 +159,189 @@ defmodule StoryboxWeb.SynopsisViewTest do
       assert story_id == story.id
       assert synopsis_view_id == sv.id
       assert version_number == 2
+    end
+
+    test "returns 403 when token is scoped to a different story", %{
+      conn: conn,
+      other_story: other_story,
+      raw_token: raw_token
+    } do
+      conn =
+        conn
+        |> authed(raw_token)
+        |> get("/api/stories/#{other_story.id}/views/synopsis")
+
+      assert json_response(conn, 403)["error"] == "forbidden"
+    end
+  end
+
+  describe "GET /api/stories/:story_id/views/synopsis — resolved content" do
+    setup %{story: story} do
+      seq_a = create_sequence(story, "Act One", "act-one")
+      seq_b = create_sequence(story, "Act Two", "act-two")
+      %{seq_a: seq_a, seq_b: seq_b}
+    end
+
+    test "resolves each segment's SynopsisPiece content in live spine order", %{
+      conn: conn,
+      story: story,
+      raw_token: raw_token,
+      seq_a: seq_a,
+      seq_b: seq_b
+    } do
+      create_synopsis_piece(story, seq_a, "Act one synopsis.")
+      create_synopsis_piece(story, seq_b, "Act two synopsis.")
+      {sv, vv} = cut_synopsis(story)
+
+      conn =
+        conn
+        |> authed(raw_token)
+        |> get("/api/stories/#{story.id}/views/synopsis")
+
+      body = json_response(conn, 200)
+
+      assert body["story_id"] == story.id
+      assert body["synopsis_view_id"] == sv.id
+      assert body["version_number"] == vv.version_number
+      assert body["resolved"] == true
+      assert body["unresolvable"] == []
+
+      assert body["paragraphs"] == [
+               %{"sequence_id" => seq_a.id, "content" => "Act one synopsis."},
+               %{"sequence_id" => seq_b.id, "content" => "Act two synopsis."}
+             ]
+    end
+
+    test "records nil-pin segments in unresolvable and omits them from paragraphs", %{
+      conn: conn,
+      story: story,
+      raw_token: raw_token,
+      seq_a: seq_a,
+      seq_b: seq_b
+    } do
+      # seq_a has a piece; seq_b has none → a nil-pin segment in the cut VV.
+      create_synopsis_piece(story, seq_a, "Act one synopsis.")
+      cut_synopsis(story)
+
+      conn =
+        conn
+        |> authed(raw_token)
+        |> get("/api/stories/#{story.id}/views/synopsis")
+
+      body = json_response(conn, 200)
+
+      assert body["resolved"] == false
+
+      assert body["paragraphs"] == [
+               %{"sequence_id" => seq_a.id, "content" => "Act one synopsis."}
+             ]
+
+      assert [%{"sequence_id" => unresolved_seq_id, "position" => position}] =
+               body["unresolvable"]
+
+      assert unresolved_seq_id == seq_b.id
+      assert is_integer(position)
+    end
+
+    test "returns 503 when a pinned SynopsisPiece's content is unavailable", %{
+      conn: conn,
+      story: story,
+      raw_token: raw_token,
+      seq_a: seq_a
+    } do
+      # A SynopsisPiece pointing at a non-existent storage object becomes the
+      # latest version the cut pins for seq_a.
+      {:ok, _bad_piece} =
+        Storybox.Stories.SynopsisPiece
+        |> Ash.Changeset.for_create(:create, %{
+          story_id: story.id,
+          sequence_id: seq_a.id,
+          content_uri: "storybox://synopsis/#{seq_a.id}/v999_missing.md",
+          version_number: 999
+        })
+        |> Ash.create(authorize?: false)
+
+      cut_synopsis(story)
+
+      conn =
+        conn
+        |> authed(raw_token)
+        |> get("/api/stories/#{story.id}/views/synopsis")
+
+      assert json_response(conn, 503)["error"] == "content unavailable"
+    end
+
+    test "returns paragraphs in live spine order after the spine is reordered post-cut", %{
+      conn: conn,
+      story: story,
+      raw_token: raw_token,
+      seq_a: seq_a,
+      seq_b: seq_b
+    } do
+      create_synopsis_piece(story, seq_a, "Act one synopsis.")
+      create_synopsis_piece(story, seq_b, "Act two synopsis.")
+      cut_synopsis(story)
+
+      # Move seq_b ahead of seq_a on the live spine, after the VV was cut.
+      spine = story_spine(story)
+
+      {:ok, _} =
+        Storybox.Stories.StorySpine
+        |> Ash.ActionInput.for_action(:reorder_entry, %{
+          story_spine_id: spine.id,
+          sequence_id: seq_b.id,
+          new_position: 1
+        })
+        |> Ash.run_action(authorize?: false)
+
+      conn =
+        conn
+        |> authed(raw_token)
+        |> get("/api/stories/#{story.id}/views/synopsis")
+
+      body = json_response(conn, 200)
+
+      assert body["paragraphs"] == [
+               %{"sequence_id" => seq_b.id, "content" => "Act two synopsis."},
+               %{"sequence_id" => seq_a.id, "content" => "Act one synopsis."}
+             ]
+    end
+
+    test "skips segments whose sequence is no longer on the live spine", %{
+      conn: conn,
+      story: story,
+      raw_token: raw_token,
+      seq_a: seq_a,
+      seq_b: seq_b
+    } do
+      create_synopsis_piece(story, seq_a, "Act one synopsis.")
+      create_synopsis_piece(story, seq_b, "Act two synopsis.")
+      cut_synopsis(story)
+
+      # Remove seq_b from the spine after the cut — its segment is now orphaned.
+      spine = story_spine(story)
+
+      {:ok, _} =
+        Storybox.Stories.StorySpine
+        |> Ash.ActionInput.for_action(:remove_entry, %{
+          story_spine_id: spine.id,
+          sequence_id: seq_b.id
+        })
+        |> Ash.run_action(authorize?: false)
+
+      conn =
+        conn
+        |> authed(raw_token)
+        |> get("/api/stories/#{story.id}/views/synopsis")
+
+      body = json_response(conn, 200)
+
+      assert body["resolved"] == true
+      assert body["unresolvable"] == []
+
+      assert body["paragraphs"] == [
+               %{"sequence_id" => seq_a.id, "content" => "Act one synopsis."}
+             ]
     end
 
     test "returns 403 when token is scoped to a different story", %{


### PR DESCRIPTION
## Summary

`GET /views/synopsis` previously returned metadata only. It now resolves the latest `SynopsisViewVersion`'s segments to their pinned `SynopsisPiece` content, returning per-sequence paragraphs alongside a consistent `unresolvable` list.

## Behaviour

- Resolution is one layer: `SynopsisViewVersion → Segment` (keyed by `sequence_id`) `→ SynopsisPiece.content_uri → Storage.get_content`.
- Iteration follows the **live** `StorySpine` order (`StorySpine.sequence_ids_in_order/1`), per the epic #205 order-free re-scope — not the stored segment `position`.
- Segments whose sequence is no longer on the spine are **skipped** (orchestrator R2); an empty spine yields `paragraphs: []` (orchestrator R3).
- Null-pin segments are recorded in `unresolvable: [{sequence_id, position}]`; `resolved` is `true` only when `unresolvable == []`.
- A storage failure on any pinned piece returns `503 {"error": "content unavailable"}`.
- Existing metadata fields (`story_id`, `synopsis_view_id`, `version_number`, `inserted_at`) are retained.

Mirrors the existing script-read resolution pattern. No schema changes.

## Tests

Added cases for: resolved content in spine order, nil-pin → `unresolvable`, 503 on content unavailable, live-spine ordering after a post-cut reorder, and skipping orphaned segments. `mix precommit` green (391 tests, 0 failures).

Closes #188