### PR TITLE
Add Through-line View read endpoint (Closes #184)

### DIFF
--- a/lib/storybox_web/controllers/api_controller.ex
+++ b/lib/storybox_web/controllers/api_controller.ex
@@ -286,6 +286,127 @@ defmodule StoryboxWeb.ApiController do
     end
   end
 
+  def throughline_view(conn, _params) do
+    story = conn.assigns.current_story
+
+    throughline_view =
+      Storybox.Stories.ThroughlineView
+      |> Ash.Query.filter(story_id == ^story.id)
+      |> Ash.read_one(authorize?: false)
+
+    case throughline_view do
+      {:ok, nil} ->
+        conn
+        |> put_status(404)
+        |> json(%{error: "no through-line found"})
+
+      {:ok, view} ->
+        latest_vv =
+          Storybox.Stories.ThroughlineViewVersion
+          |> Ash.Query.filter(throughline_view_id == ^view.id)
+          |> Ash.Query.sort(version_number: :desc)
+          |> Ash.Query.limit(1)
+          |> Ash.read_one(authorize?: false)
+
+        case latest_vv do
+          {:ok, nil} ->
+            conn
+            |> put_status(404)
+            |> json(%{error: "no through-line found"})
+
+          {:ok, vv} ->
+            case assemble_throughline_view(story, view, vv) do
+              {:error, :content_unavailable} ->
+                conn |> put_status(503) |> json(%{error: "content unavailable"})
+
+              {:ok, response} ->
+                json(conn, response)
+            end
+
+          {:error, _} ->
+            conn
+            |> put_status(500)
+            |> json(%{error: "internal error"})
+        end
+
+      {:error, _} ->
+        conn
+        |> put_status(500)
+        |> json(%{error: "internal error"})
+    end
+  end
+
+  # Resolves the latest ThroughlineViewVersion to the controlling idea + one
+  # through-line per character. The harness has no spine — Segments pin directly
+  # to ThroughlinePiece and are traversed in `:position` order. Each resolved
+  # piece is split on its `character_id`: a nil character is the Story's
+  # controlling idea, a set character is that character's through-line. Null-pin
+  # segments are recorded in `unresolvable`; a storage failure surfaces as
+  # `{:error, :content_unavailable}`.
+  defp assemble_throughline_view(story, view, vv) do
+    throughline_vv_type = :throughline_vv
+
+    segments =
+      Storybox.Stories.Segment
+      |> Ash.Query.filter(view_version_id == ^vv.id and view_version_type == ^throughline_vv_type)
+      |> Ash.Query.sort(:position)
+      |> Ash.read!(authorize?: false)
+
+    result =
+      Enum.reduce_while(segments, {:ok, nil, [], []}, fn seg, {:ok, idea, lines, unres} ->
+        case seg do
+          %{pin_id: nil} ->
+            {:cont, {:ok, idea, lines, unres ++ [%{position: seg.position}]}}
+
+          seg ->
+            case fetch_throughline_piece_content(seg.pin_id) do
+              {:ok, %{character_id: nil}, content} ->
+                {:cont, {:ok, content, lines, unres}}
+
+              {:ok, piece, content} ->
+                {:cont,
+                 {:ok, idea, lines ++ [%{character_id: piece.character_id, content: content}],
+                  unres}}
+
+              {:error, :content_unavailable} ->
+                {:halt, {:error, :content_unavailable}}
+            end
+        end
+      end)
+
+    case result do
+      {:error, reason} ->
+        {:error, reason}
+
+      {:ok, controlling_idea, through_lines, unresolvable} ->
+        {:ok,
+         %{
+           story_id: story.id,
+           throughline_view_id: view.id,
+           version_number: vv.version_number,
+           inserted_at: vv.inserted_at,
+           resolved: unresolvable == [],
+           unresolvable: unresolvable,
+           controlling_idea: controlling_idea,
+           through_lines: through_lines
+         }}
+    end
+  end
+
+  # Loads the pinned ThroughlinePiece and its content. Returns the piece itself
+  # (not just the content) so the caller can split on `character_id`.
+  defp fetch_throughline_piece_content(pin_id) do
+    piece =
+      Storybox.Stories.ThroughlinePiece
+      |> Ash.Query.filter(id == ^pin_id)
+      |> Ash.read_one!(authorize?: false)
+
+    case Storybox.Storage.get_content(piece.content_uri) do
+      {:ok, content} -> {:ok, piece, content}
+      {:error, _} -> {:error, :content_unavailable}
+    end
+  end
+
   def script_view(conn, params) do
     story = conn.assigns.current_story
 

--- a/lib/storybox_web/router.ex
+++ b/lib/storybox_web/router.ex
@@ -47,6 +47,7 @@ defmodule StoryboxWeb.Router do
     get "/stories/:story_id/ping", ApiController, :ping
     get "/stories/:story_id/views/synopsis", ApiController, :synopsis_view
     get "/stories/:story_id/views/treatment", ApiController, :treatment_view
+    get "/stories/:story_id/views/throughline", ApiController, :throughline_view
     get "/stories/:story_id/views/script", ApiController, :script_view
     post "/stories/:story_id/scenes/:id/versions", ApiController, :create_scene_version
     get "/stories/:story_id/tasks", ApiController, :list_tasks

--- a/test/storybox_web/controllers/throughline_view_test.exs
+++ b/test/storybox_web/controllers/throughline_view_test.exs
@@ -1,0 +1,276 @@
+defmodule StoryboxWeb.ThroughlineViewTest do
+  use StoryboxWeb.ConnCase
+
+  alias Storybox.Accounts.ApiToken
+
+  require Ash.Query
+
+  setup do
+    {:ok, user} =
+      Storybox.Accounts.User
+      |> Ash.Changeset.for_create(:register_with_password, %{
+        email: "throughline_view_test@example.com",
+        password: "password123!",
+        password_confirmation: "password123!"
+      })
+      |> Ash.create()
+
+    {:ok, story} =
+      Storybox.Stories.Story
+      |> Ash.Changeset.for_create(:create, %{title: "Through-line Test Story", user_id: user.id})
+      |> Ash.create()
+
+    {:ok, other_story} =
+      Storybox.Stories.Story
+      |> Ash.Changeset.for_create(:create, %{title: "Other Story", user_id: user.id})
+      |> Ash.create()
+
+    {:ok, raw_token, _} = ApiToken.generate(%{story_id: story.id, user_id: user.id})
+
+    %{user: user, story: story, other_story: other_story, raw_token: raw_token}
+  end
+
+  defp authed(conn, raw_token) do
+    put_req_header(conn, "authorization", "Bearer #{raw_token}")
+  end
+
+  defp create_character(story, name) do
+    {:ok, character} =
+      Storybox.Stories.Character
+      |> Ash.Changeset.for_create(:create, %{story_id: story.id, name: name})
+      |> Ash.create(authorize?: false)
+
+    character
+  end
+
+  # Writes a ThroughlinePiece version. A nil character_id is the Story's
+  # controlling idea; a set character_id is that character's through-line.
+  defp create_throughline_piece(story, character_id, content) do
+    {:ok, piece} =
+      Storybox.Stories.ThroughlinePiece
+      |> Ash.ActionInput.for_action(:create_version, %{
+        story_id: story.id,
+        character_id: character_id,
+        content: content
+      })
+      |> Ash.run_action(authorize?: false)
+
+    piece
+  end
+
+  defp ensure_throughline_view(story) do
+    {:ok, tv} =
+      Storybox.Stories.ThroughlineView
+      |> Ash.ActionInput.for_action(:ensure_for_story, %{story_id: story.id})
+      |> Ash.run_action(authorize?: false)
+
+    tv
+  end
+
+  defp segment_for(piece) do
+    %{
+      "pin_id" => piece.id,
+      "pin_type" => "throughline_piece",
+      "pin_version_at_creation" => piece.version_number
+    }
+  end
+
+  # Ensures the ThroughlineView and cuts a fresh ViewVersion with the given
+  # explicit segment list (the harness has no spine to derive segments from).
+  defp cut_throughline(story, segments) do
+    tv = ensure_throughline_view(story)
+
+    {:ok, vv} =
+      Storybox.Stories.ThroughlineViewVersion
+      |> Ash.ActionInput.for_action(:cut, %{throughline_view_id: tv.id, segments: segments})
+      |> Ash.run_action(authorize?: false)
+
+    {tv, vv}
+  end
+
+  describe "GET /api/stories/:story_id/views/throughline" do
+    test "returns 404 when no ThroughlineView exists for the story", %{
+      conn: conn,
+      story: story,
+      raw_token: raw_token
+    } do
+      # A fresh story has no ThroughlineView (bootstrap does not create one).
+      conn =
+        conn
+        |> authed(raw_token)
+        |> get("/api/stories/#{story.id}/views/throughline")
+
+      assert json_response(conn, 404)["error"] == "no through-line found"
+    end
+
+    test "returns 404 when ThroughlineView exists but has no versions", %{
+      conn: conn,
+      story: story,
+      raw_token: raw_token
+    } do
+      ensure_throughline_view(story)
+
+      conn =
+        conn
+        |> authed(raw_token)
+        |> get("/api/stories/#{story.id}/views/throughline")
+
+      assert json_response(conn, 404)["error"] == "no through-line found"
+    end
+
+    test "returns 403 when token is scoped to a different story", %{
+      conn: conn,
+      other_story: other_story,
+      raw_token: raw_token
+    } do
+      conn =
+        conn
+        |> authed(raw_token)
+        |> get("/api/stories/#{other_story.id}/views/throughline")
+
+      assert json_response(conn, 403)["error"] == "forbidden"
+    end
+  end
+
+  describe "GET /api/stories/:story_id/views/throughline — resolved content" do
+    test "resolves the controlling idea and one through-line per character", %{
+      conn: conn,
+      story: story,
+      raw_token: raw_token
+    } do
+      char_a = create_character(story, "Alice")
+      char_b = create_character(story, "Bob")
+
+      idea = create_throughline_piece(story, nil, "The cost of revenge.")
+      line_a = create_throughline_piece(story, char_a.id, "Alice learns to forgive.")
+      line_b = create_throughline_piece(story, char_b.id, "Bob loses everything.")
+
+      {tv, vv} =
+        cut_throughline(story, [segment_for(idea), segment_for(line_a), segment_for(line_b)])
+
+      conn =
+        conn
+        |> authed(raw_token)
+        |> get("/api/stories/#{story.id}/views/throughline")
+
+      body = json_response(conn, 200)
+
+      assert body["story_id"] == story.id
+      assert body["throughline_view_id"] == tv.id
+      assert body["version_number"] == vv.version_number
+      assert body["resolved"] == true
+      assert body["unresolvable"] == []
+      assert body["controlling_idea"] == "The cost of revenge."
+
+      assert body["through_lines"] == [
+               %{"character_id" => char_a.id, "content" => "Alice learns to forgive."},
+               %{"character_id" => char_b.id, "content" => "Bob loses everything."}
+             ]
+    end
+
+    test "records nil-pin segments in unresolvable and omits them from content", %{
+      conn: conn,
+      story: story,
+      raw_token: raw_token
+    } do
+      char_a = create_character(story, "Alice")
+      idea = create_throughline_piece(story, nil, "The cost of revenge.")
+      line_a = create_throughline_piece(story, char_a.id, "Alice learns to forgive.")
+
+      # A nil-pin segment sits between the two resolved pieces.
+      {_tv, _vv} =
+        cut_throughline(story, [
+          segment_for(idea),
+          %{"pin_id" => nil, "pin_type" => nil, "pin_version_at_creation" => nil},
+          segment_for(line_a)
+        ])
+
+      conn =
+        conn
+        |> authed(raw_token)
+        |> get("/api/stories/#{story.id}/views/throughline")
+
+      body = json_response(conn, 200)
+
+      assert body["resolved"] == false
+      assert body["controlling_idea"] == "The cost of revenge."
+
+      assert body["through_lines"] == [
+               %{"character_id" => char_a.id, "content" => "Alice learns to forgive."}
+             ]
+
+      assert [%{"position" => position}] = body["unresolvable"]
+      assert is_integer(position)
+    end
+
+    test "returns 503 when a pinned ThroughlinePiece's content is unavailable", %{
+      conn: conn,
+      story: story,
+      raw_token: raw_token
+    } do
+      # A ThroughlinePiece pointing at a non-existent storage object.
+      {:ok, bad_piece} =
+        Storybox.Stories.ThroughlinePiece
+        |> Ash.Changeset.for_create(:create, %{
+          story_id: story.id,
+          character_id: nil,
+          content_uri:
+            "storybox://stories/#{story.id}/throughlines/controlling_idea/v999_missing",
+          version_number: 999
+        })
+        |> Ash.create(authorize?: false)
+
+      cut_throughline(story, [segment_for(bad_piece)])
+
+      conn =
+        conn
+        |> authed(raw_token)
+        |> get("/api/stories/#{story.id}/views/throughline")
+
+      assert json_response(conn, 503)["error"] == "content unavailable"
+    end
+
+    test "controlling_idea is nil and through_lines empty when only a character line is pinned",
+         %{conn: conn, story: story, raw_token: raw_token} do
+      char_a = create_character(story, "Alice")
+      line_a = create_throughline_piece(story, char_a.id, "Alice learns to forgive.")
+
+      cut_throughline(story, [segment_for(line_a)])
+
+      conn =
+        conn
+        |> authed(raw_token)
+        |> get("/api/stories/#{story.id}/views/throughline")
+
+      body = json_response(conn, 200)
+
+      assert body["resolved"] == true
+      assert body["controlling_idea"] == nil
+
+      assert body["through_lines"] == [
+               %{"character_id" => char_a.id, "content" => "Alice learns to forgive."}
+             ]
+    end
+
+    test "through_lines is empty when only the controlling idea is pinned", %{
+      conn: conn,
+      story: story,
+      raw_token: raw_token
+    } do
+      idea = create_throughline_piece(story, nil, "The cost of revenge.")
+
+      cut_throughline(story, [segment_for(idea)])
+
+      conn =
+        conn
+        |> authed(raw_token)
+        |> get("/api/stories/#{story.id}/views/throughline")
+
+      body = json_response(conn, 200)
+
+      assert body["resolved"] == true
+      assert body["controlling_idea"] == "The cost of revenge."
+      assert body["through_lines"] == []
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds `GET /api/stories/:story_id/views/throughline` — a read endpoint that resolves the Story Through-line View harness to its Piece content.

- Resolves the latest `ThroughlineViewVersion`'s segments (in `:position` order; the harness has no spine) to `ThroughlinePiece` content.
- Splits each resolved piece on its `character_id`: nil → the Story's `controlling_idea`; set → an entry in the `through_lines` list (`character_id` + `content`).
- Mirrors the existing synopsis/treatment resolved-read pattern: 404 when no view or no version, 503 when content is unavailable, null-pin segments recorded in `unresolvable` (by `position`) and omitted from content.
- New `fetch_throughline_piece_content/1` returns the piece alongside its content (3-tuple) so the caller can read `character_id`.

Read-only: one route + `throughline_view/2` + `assemble_throughline_view/3` + `fetch_throughline_piece_content/1` + a controller test. No schema changes.

## Test plan

New `throughline_view_test.exs` covers: 404 (no view / no version), 403 (cross-story token), 200 resolved controlling idea + per-character through-lines, `resolved: false` + unresolvable for a null-pin segment, 503 on missing storage object, and the `controlling_idea: nil` / `through_lines: []` edge cases.

`mix precommit` green — 419 tests, 0 failures.

Closes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)