### PR TITLE
Add ThroughlinePiece write endpoint with Through-line VV cut

### DIFF
--- a/lib/storybox_web/controllers/api_controller.ex
+++ b/lib/storybox_web/controllers/api_controller.ex
@@ -1356,6 +1356,73 @@ defmodule StoryboxWeb.ApiController do
     end
   end
 
+  # Writes a ThroughlinePiece version (the Story's controlling idea when
+  # `character_id` is nil, else that character's through-line) then cuts a new
+  # Through-line ViewVersion pinning the full harness — the cut is the approval
+  # act. Unlike the single-piece view cuts, the Through-line VV carries an
+  # explicit, full-snapshot segment list (latest piece per lineage), so the
+  # read path (#184) can assemble the whole harness from one VV.
+  def create_throughline_piece(conn, params) do
+    story = conn.assigns.current_story
+    content = params["content"]
+
+    if is_nil(content) or content == "" do
+      conn |> put_status(400) |> json(%{error: "content is required"})
+    else
+      character_id = params["character_id"]
+
+      if character_id && is_nil(load_character_for_story(character_id, story.id)) do
+        conn |> put_status(404) |> json(%{error: "not found"})
+      else
+        with {:ok, _piece} <-
+               Storybox.Stories.ThroughlinePiece
+               |> Ash.ActionInput.for_action(:create_version, %{
+                 story_id: story.id,
+                 character_id: character_id,
+                 content: content
+               })
+               |> Ash.run_action(authorize?: false),
+             {:ok, view} <-
+               Storybox.Stories.ThroughlineView
+               |> Ash.ActionInput.for_action(:ensure_for_story, %{story_id: story.id})
+               |> Ash.run_action(authorize?: false),
+             {:ok, vv} <-
+               Storybox.Stories.ThroughlineViewVersion
+               |> Ash.ActionInput.for_action(:cut, %{
+                 throughline_view_id: view.id,
+                 segments: throughline_segments_for_story(story.id)
+               })
+               |> Ash.run_action(authorize?: false) do
+          conn |> put_status(201) |> json(format_cut_vv(vv, :throughline_vv))
+        else
+          {:error, _} -> conn |> put_status(500) |> json(%{error: "internal error"})
+        end
+      end
+    end
+  end
+
+  # Builds the full-snapshot segment list for a Through-line cut: the latest
+  # ThroughlinePiece per lineage (one nil-character controlling idea + one per
+  # character). Runs after :create_version, so the new piece is already its
+  # lineage head. Ordered controlling-idea-first, then by character UUID for
+  # deterministic positions.
+  defp throughline_segments_for_story(story_id) do
+    Storybox.Stories.ThroughlinePiece
+    |> Ash.Query.filter(story_id == ^story_id)
+    |> Ash.Query.sort(version_number: :desc)
+    |> Ash.read!(authorize?: false)
+    |> Enum.group_by(& &1.character_id)
+    |> Enum.map(fn {_char_id, pieces} -> hd(pieces) end)
+    |> Enum.sort_by(fn p -> if is_nil(p.character_id), do: "", else: p.character_id end)
+    |> Enum.map(fn piece ->
+      %{
+        "pin_id" => piece.id,
+        "pin_type" => "throughline_piece",
+        "pin_version_at_creation" => piece.version_number
+      }
+    end)
+  end
+
   defp load_task_for_story(task_id, story_id) do
     Storybox.Stories.Task
     |> Ash.Query.filter(id == ^task_id and story_id == ^story_id)

--- a/lib/storybox_web/router.ex
+++ b/lib/storybox_web/router.ex
@@ -75,6 +75,7 @@ defmodule StoryboxWeb.Router do
     post "/stories/:story_id/characters/:char_id/pieces", ApiController, :create_character_piece
     get "/stories/:story_id/world", ApiController, :world_detail
     post "/stories/:story_id/world/pieces", ApiController, :create_world_piece
+    post "/stories/:story_id/throughline/pieces", ApiController, :create_throughline_piece
   end
 
   # Enable LiveDashboard and Swoosh mailbox preview in development

--- a/test/storybox_web/controllers/throughline_piece_write_test.exs
+++ b/test/storybox_web/controllers/throughline_piece_write_test.exs
@@ -1,0 +1,213 @@
+defmodule StoryboxWeb.ThroughlinePieceWriteTest do
+  use StoryboxWeb.ConnCase
+
+  alias Storybox.Accounts.ApiToken
+
+  require Ash.Query
+
+  setup do
+    {:ok, user} =
+      Storybox.Accounts.User
+      |> Ash.Changeset.for_create(:register_with_password, %{
+        email: "throughline_piece_write_test@example.com",
+        password: "password123!",
+        password_confirmation: "password123!"
+      })
+      |> Ash.create()
+
+    {:ok, story} =
+      Storybox.Stories.Story
+      |> Ash.Changeset.for_create(:create, %{title: "Through-line Write Story", user_id: user.id})
+      |> Ash.create()
+
+    {:ok, other_story} =
+      Storybox.Stories.Story
+      |> Ash.Changeset.for_create(:create, %{title: "Other Story", user_id: user.id})
+      |> Ash.create()
+
+    {:ok, char} =
+      Storybox.Stories.Character
+      |> Ash.Changeset.for_create(:create, %{story_id: story.id, name: "Alice"})
+      |> Ash.create(authorize?: false)
+
+    # A character on a different story — used for the cross-story 404 case.
+    {:ok, other_char} =
+      Storybox.Stories.Character
+      |> Ash.Changeset.for_create(:create, %{story_id: other_story.id, name: "Other"})
+      |> Ash.create(authorize?: false)
+
+    {:ok, raw_token, _} = ApiToken.generate(%{story_id: story.id, user_id: user.id})
+
+    %{
+      user: user,
+      story: story,
+      other_story: other_story,
+      char: char,
+      other_char: other_char,
+      raw_token: raw_token
+    }
+  end
+
+  defp authed(conn, raw_token) do
+    put_req_header(conn, "authorization", "Bearer #{raw_token}")
+  end
+
+  describe "POST /api/stories/:story_id/throughline/pieces" do
+    test "201 — content, no character_id (controlling idea); cuts a Through-line VV", %{
+      conn: conn,
+      story: story,
+      raw_token: token
+    } do
+      conn =
+        conn
+        |> authed(token)
+        |> post("/api/stories/#{story.id}/throughline/pieces", %{
+          "content" => "The cost of revenge."
+        })
+
+      body = json_response(conn, 201)
+      assert body["id"]
+      assert body["version_number"] == 1
+      assert body["unresolvable_segments"] == []
+    end
+
+    test "201 — content with a character_id belonging to the story", %{
+      conn: conn,
+      story: story,
+      char: char,
+      raw_token: token
+    } do
+      conn =
+        conn
+        |> authed(token)
+        |> post("/api/stories/#{story.id}/throughline/pieces", %{
+          "content" => "Alice learns to forgive.",
+          "character_id" => char.id
+        })
+
+      body = json_response(conn, 201)
+      assert body["id"]
+      assert body["version_number"] == 1
+      assert body["unresolvable_segments"] == []
+    end
+
+    test "404 — character_id does not belong to the story", %{
+      conn: conn,
+      story: story,
+      other_char: other_char,
+      raw_token: token
+    } do
+      conn =
+        conn
+        |> authed(token)
+        |> post("/api/stories/#{story.id}/throughline/pieces", %{
+          "content" => "Should not be written.",
+          "character_id" => other_char.id
+        })
+
+      assert json_response(conn, 404)["error"]
+    end
+
+    test "400 — missing content", %{conn: conn, story: story, raw_token: token} do
+      conn =
+        conn
+        |> authed(token)
+        |> post("/api/stories/#{story.id}/throughline/pieces", %{})
+
+      assert json_response(conn, 400)["error"] =~ "content"
+    end
+
+    test "400 — empty content", %{conn: conn, story: story, raw_token: token} do
+      conn =
+        conn
+        |> authed(token)
+        |> post("/api/stories/#{story.id}/throughline/pieces", %{"content" => ""})
+
+      assert json_response(conn, 400)["error"] =~ "content"
+    end
+
+    test "read-back: controlling idea then a character line populate the Through-line view", %{
+      conn: conn,
+      story: story,
+      char: char,
+      raw_token: token
+    } do
+      conn
+      |> authed(token)
+      |> post("/api/stories/#{story.id}/throughline/pieces", %{
+        "content" => "The cost of revenge."
+      })
+      |> json_response(201)
+
+      conn
+      |> authed(token)
+      |> post("/api/stories/#{story.id}/throughline/pieces", %{
+        "content" => "Alice learns to forgive.",
+        "character_id" => char.id
+      })
+      |> json_response(201)
+
+      get_conn =
+        conn
+        |> authed(token)
+        |> get("/api/stories/#{story.id}/views/throughline")
+
+      body = json_response(get_conn, 200)
+      assert body["controlling_idea"] == "The cost of revenge."
+
+      assert body["through_lines"] == [
+               %{"character_id" => char.id, "content" => "Alice learns to forgive."}
+             ]
+    end
+
+    test "the controlling-idea lineage and a character lineage version independently", %{
+      conn: conn,
+      story: story,
+      char: char,
+      raw_token: token
+    } do
+      # Two controlling-idea writes (nil lineage) and one character write.
+      conn
+      |> authed(token)
+      |> post("/api/stories/#{story.id}/throughline/pieces", %{"content" => "Idea v1."})
+      |> json_response(201)
+
+      conn
+      |> authed(token)
+      |> post("/api/stories/#{story.id}/throughline/pieces", %{"content" => "Idea v2."})
+      |> json_response(201)
+
+      conn
+      |> authed(token)
+      |> post("/api/stories/#{story.id}/throughline/pieces", %{
+        "content" => "Alice line v1.",
+        "character_id" => char.id
+      })
+      |> json_response(201)
+
+      latest_version = fn filter ->
+        Storybox.Stories.ThroughlinePiece
+        |> filter.()
+        |> Ash.read!(authorize?: false)
+        |> Enum.map(& &1.version_number)
+        |> Enum.max()
+      end
+
+      # The nil lineage reached v2; the character lineage is independently at v1.
+      assert latest_version.(fn q ->
+               Ash.Query.filter(q, story_id == ^story.id and is_nil(character_id))
+             end) == 2
+
+      assert latest_version.(fn q ->
+               Ash.Query.filter(q, story_id == ^story.id and character_id == ^char.id)
+             end) == 1
+    end
+
+    test "401 without token", %{conn: conn, story: story} do
+      conn =
+        post(conn, "/api/stories/#{story.id}/throughline/pieces", %{"content" => "x"})
+
+      assert json_response(conn, 401)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds `POST /stories/:story_id/throughline/pieces`, making the through-line harness above the synopsis writable. The endpoint:

- Creates a `ThroughlinePiece` version — the Story's **controlling idea** when `character_id` is nil, else that **character's through-line**.
- Validates a supplied `character_id` belongs to the story (404 otherwise) and requires non-empty `content` (400 otherwise).
- Cuts a new **Through-line ViewVersion** pinning the full harness snapshot (latest piece per lineage) — the cut is the approval act.

Mirrors the existing piece-write + cut flows (`create_character_piece` / `create_world_piece`). No schema changes.

## Implementation

- `router.ex`: one route in the authenticated `/api` scope.
- `api_controller.ex`: `create_throughline_piece/2` action + `throughline_segments_for_story/1` helper (latest piece per lineage, controlling-idea-first then by character UUID for deterministic positions).

## Testing

- `mix precommit` green (420 tests, 0 failures) via `podman compose -f podman-compose.yml run --rm -e MIX_ENV=test app mix precommit`.

Closes #185