### PR TITLE
Add per-version Piece content fetch endpoint (#192)

### DIFF
--- a/lib/storybox_web/controllers/api_controller.ex
+++ b/lib/storybox_web/controllers/api_controller.ex
@@ -1595,6 +1595,104 @@ defmodule StoryboxWeb.ApiController do
     end)
   end
 
+  # Returns the raw content of one specific Piece version, addressed by its
+  # piece type + id. Read-only and per-version: each PieceVersion is its own row,
+  # so any version (not just the latest) is fetchable, letting a client diff a
+  # working draft against the committed state before writing. Ownership is
+  # enforced per type — direct `story_id` pieces (synopsis/sequence/throughline)
+  # vs. parent-chain pieces (script→Scene, character→Character, world→World) —
+  # so a piece belonging to another story reads as 404, never leaking content.
+  def piece_version(conn, %{"piece_type" => raw_type, "piece_id" => piece_id}) do
+    story = conn.assigns.current_story
+
+    case parse_piece_type(raw_type) do
+      {:error, _} ->
+        conn |> put_status(400) |> json(%{error: "unknown piece_type"})
+
+      {:ok, type} ->
+        case load_piece_for_story(type, piece_id, story) do
+          nil ->
+            conn |> put_status(404) |> json(%{error: "not found"})
+
+          piece ->
+            case Storybox.Storage.get_content(piece.content_uri) do
+              {:ok, content} ->
+                json(conn, %{
+                  piece_id: piece.id,
+                  piece_type: raw_type,
+                  version_number: piece.version_number,
+                  content: content
+                })
+
+              {:error, _} ->
+                conn |> put_status(503) |> json(%{error: "content unavailable"})
+            end
+        end
+    end
+  end
+
+  defp parse_piece_type("script"), do: {:ok, :script}
+  defp parse_piece_type("synopsis"), do: {:ok, :synopsis}
+  defp parse_piece_type("sequence"), do: {:ok, :sequence}
+  defp parse_piece_type("character"), do: {:ok, :character}
+  defp parse_piece_type("world"), do: {:ok, :world}
+  defp parse_piece_type("throughline"), do: {:ok, :throughline}
+  defp parse_piece_type(_), do: {:error, :unknown_piece_type}
+
+  # Direct-story types: the piece carries `story_id`, so ownership is a single
+  # filtered read. A piece in another story (or a missing id) yields nil → 404.
+  defp load_piece_for_story(:synopsis, piece_id, story),
+    do: read_piece_in_story(Storybox.Stories.SynopsisPiece, piece_id, story.id)
+
+  defp load_piece_for_story(:sequence, piece_id, story),
+    do: read_piece_in_story(Storybox.Stories.SequencePiece, piece_id, story.id)
+
+  defp load_piece_for_story(:throughline, piece_id, story),
+    do: read_piece_in_story(Storybox.Stories.ThroughlinePiece, piece_id, story.id)
+
+  # Parent-chain types: the piece has no `story_id`, so ownership is verified via
+  # its parent entity (Scene / Character / World) belonging to this story. Either
+  # the piece or the ownership check failing yields nil → 404.
+  defp load_piece_for_story(:script, piece_id, story) do
+    piece =
+      Storybox.Stories.ScriptPiece
+      |> Ash.Query.filter(id == ^piece_id)
+      |> Ash.read_one!(authorize?: false)
+
+    scene =
+      piece &&
+        Storybox.Stories.Scene
+        |> Ash.Query.filter(id == ^piece.scene_id and story_id == ^story.id)
+        |> Ash.read_one!(authorize?: false)
+
+    if scene, do: piece
+  end
+
+  defp load_piece_for_story(:character, piece_id, story) do
+    piece =
+      Storybox.Stories.CharacterPiece
+      |> Ash.Query.filter(id == ^piece_id)
+      |> Ash.read_one!(authorize?: false)
+
+    if piece && load_character_for_story(piece.character_id, story.id), do: piece
+  end
+
+  defp load_piece_for_story(:world, piece_id, story) do
+    piece =
+      Storybox.Stories.WorldPiece
+      |> Ash.Query.filter(id == ^piece_id)
+      |> Ash.read_one!(authorize?: false)
+
+    world = load_world_for_story(story.id)
+    if piece && world && piece.world_id == world.id, do: piece
+  end
+
+  defp read_piece_in_story(resource, piece_id, story_id) do
+    resource
+    |> Ash.Query.filter(id == ^piece_id and story_id == ^story_id)
+    |> Ash.read_one!(authorize?: false)
+  end
+
   defp load_task_for_story(task_id, story_id) do
     Storybox.Stories.Task
     |> Ash.Query.filter(id == ^task_id and story_id == ^story_id)

--- a/lib/storybox_web/router.ex
+++ b/lib/storybox_web/router.ex
@@ -49,6 +49,7 @@ defmodule StoryboxWeb.Router do
     get "/stories/:story_id/views/treatment", ApiController, :treatment_view
     get "/stories/:story_id/views/throughline", ApiController, :throughline_view
     get "/stories/:story_id/views/script", ApiController, :script_view
+    get "/stories/:story_id/pieces/:piece_type/:piece_id", ApiController, :piece_version
     post "/stories/:story_id/scenes/:id/versions", ApiController, :create_scene_version
     get "/stories/:story_id/tasks", ApiController, :list_tasks
     post "/stories/:story_id/tasks/:id/in_progress", ApiController, :mark_task_in_progress

--- a/test/storybox_web/controllers/piece_content_fetch_test.exs
+++ b/test/storybox_web/controllers/piece_content_fetch_test.exs
@@ -1,0 +1,312 @@
+defmodule StoryboxWeb.PieceContentFetchTest do
+  use StoryboxWeb.ConnCase
+
+  alias Storybox.Accounts.ApiToken
+
+  require Ash.Query
+
+  # Per-version Piece content fetch (issue #192).
+  #
+  # Setup builds, under one story, a version-1 piece of every type (and a
+  # version-2 SynopsisPiece, to prove non-latest versions stay addressable),
+  # plus an other_story SynopsisPiece for the cross-story ownership boundary.
+  #
+  #   story ── sequence ── SynopsisPiece v1 + v2, SequencePiece v1
+  #         ├─ scene     ── ScriptPiece v1
+  #         ├─ character ── CharacterPiece v1
+  #         ├─ world     ── WorldPiece v1
+  #         └─ (story)   ── ThroughlinePiece v1 (controlling idea)
+  #
+  #   other_story ── other_sequence ── SynopsisPiece v1
+  #
+  # raw_token is scoped to story; raw_token_other to other_story.
+
+  setup do
+    {:ok, user} =
+      Storybox.Accounts.User
+      |> Ash.Changeset.for_create(:register_with_password, %{
+        email: "piece_content_fetch_test@example.com",
+        password: "password123!",
+        password_confirmation: "password123!"
+      })
+      |> Ash.create()
+
+    {:ok, story} =
+      Storybox.Stories.Story
+      |> Ash.Changeset.for_create(:create, %{title: "Fetch Story", user_id: user.id})
+      |> Ash.create()
+
+    {:ok, other_story} =
+      Storybox.Stories.Story
+      |> Ash.Changeset.for_create(:create, %{title: "Other Story", user_id: user.id})
+      |> Ash.create()
+
+    {:ok, raw_token, _} = ApiToken.generate(%{story_id: story.id, user_id: user.id})
+    {:ok, raw_token_other, _} = ApiToken.generate(%{story_id: other_story.id, user_id: user.id})
+
+    {:ok, sequence} =
+      Storybox.Stories.Sequence
+      |> Ash.Changeset.for_create(:create, %{story_id: story.id, name: "Seq", slug: "seq"})
+      |> Ash.create(authorize?: false)
+
+    {:ok, synopsis_v1} =
+      Storybox.Stories.SynopsisPiece
+      |> Ash.ActionInput.for_action(:create_version, %{
+        story_id: story.id,
+        sequence_id: sequence.id,
+        content: "Synopsis v1."
+      })
+      |> Ash.run_action(authorize?: false)
+
+    {:ok, synopsis_v2} =
+      Storybox.Stories.SynopsisPiece
+      |> Ash.ActionInput.for_action(:create_version, %{
+        story_id: story.id,
+        sequence_id: sequence.id,
+        content: "Synopsis v2."
+      })
+      |> Ash.run_action(authorize?: false)
+
+    {:ok, sequence_piece} =
+      Storybox.Stories.SequencePiece
+      |> Ash.ActionInput.for_action(:create_version, %{
+        story_id: story.id,
+        sequence_id: sequence.id,
+        content: "Sequence prose."
+      })
+      |> Ash.run_action(authorize?: false)
+
+    {:ok, scene} =
+      Storybox.Stories.Scene
+      |> Ash.Changeset.for_create(:create, %{slug: "scene", story_id: story.id})
+      |> Ash.create(authorize?: false)
+
+    {:ok, script_piece} =
+      Storybox.Stories.ScriptPiece
+      |> Ash.ActionInput.for_action(:create_version, %{
+        scene_id: scene.id,
+        content: "INT. OFFICE - DAY\nScript body."
+      })
+      |> Ash.run_action(authorize?: false)
+
+    {:ok, character} =
+      Storybox.Stories.Character
+      |> Ash.Changeset.for_create(:create, %{name: "Akko", story_id: story.id})
+      |> Ash.create(authorize?: false)
+
+    {:ok, character_piece} =
+      Storybox.Stories.CharacterPiece
+      |> Ash.ActionInput.for_action(:create_version, %{
+        character_id: character.id,
+        content: "Character notes."
+      })
+      |> Ash.run_action(authorize?: false)
+
+    {:ok, world} =
+      Storybox.Stories.World
+      |> Ash.Changeset.for_create(:create, %{name: "World", story_id: story.id})
+      |> Ash.create(authorize?: false)
+
+    {:ok, world_piece} =
+      Storybox.Stories.WorldPiece
+      |> Ash.ActionInput.for_action(:create_version, %{
+        world_id: world.id,
+        content: "World bible."
+      })
+      |> Ash.run_action(authorize?: false)
+
+    {:ok, throughline_piece} =
+      Storybox.Stories.ThroughlinePiece
+      |> Ash.ActionInput.for_action(:create_version, %{
+        story_id: story.id,
+        character_id: nil,
+        content: "The controlling idea."
+      })
+      |> Ash.run_action(authorize?: false)
+
+    # A piece in another story, used for the cross-story ownership boundary.
+    {:ok, other_sequence} =
+      Storybox.Stories.Sequence
+      |> Ash.Changeset.for_create(:create, %{
+        story_id: other_story.id,
+        name: "Other Seq",
+        slug: "other-seq"
+      })
+      |> Ash.create(authorize?: false)
+
+    {:ok, other_synopsis} =
+      Storybox.Stories.SynopsisPiece
+      |> Ash.ActionInput.for_action(:create_version, %{
+        story_id: other_story.id,
+        sequence_id: other_sequence.id,
+        content: "Other story synopsis."
+      })
+      |> Ash.run_action(authorize?: false)
+
+    %{
+      story: story,
+      other_story: other_story,
+      raw_token: raw_token,
+      raw_token_other: raw_token_other,
+      synopsis_v1: synopsis_v1,
+      synopsis_v2: synopsis_v2,
+      sequence_piece: sequence_piece,
+      script_piece: script_piece,
+      character_piece: character_piece,
+      world_piece: world_piece,
+      throughline_piece: throughline_piece,
+      other_synopsis: other_synopsis
+    }
+  end
+
+  describe "GET /api/stories/:story_id/pieces/:piece_type/:piece_id — 200 per type" do
+    test "synopsis", %{conn: conn, story: story, raw_token: token, synopsis_v2: piece} do
+      body = fetch(conn, token, story, "synopsis", piece.id, 200)
+      assert body["piece_id"] == piece.id
+      assert body["piece_type"] == "synopsis"
+      assert body["version_number"] == 2
+      assert body["content"] == "Synopsis v2."
+    end
+
+    test "sequence", %{conn: conn, story: story, raw_token: token, sequence_piece: piece} do
+      body = fetch(conn, token, story, "sequence", piece.id, 200)
+      assert body["piece_type"] == "sequence"
+      assert body["content"] == "Sequence prose."
+    end
+
+    test "script", %{conn: conn, story: story, raw_token: token, script_piece: piece} do
+      body = fetch(conn, token, story, "script", piece.id, 200)
+      assert body["piece_type"] == "script"
+      assert body["content"] == "INT. OFFICE - DAY\nScript body."
+    end
+
+    test "character", %{conn: conn, story: story, raw_token: token, character_piece: piece} do
+      body = fetch(conn, token, story, "character", piece.id, 200)
+      assert body["piece_type"] == "character"
+      assert body["content"] == "Character notes."
+    end
+
+    test "world", %{conn: conn, story: story, raw_token: token, world_piece: piece} do
+      body = fetch(conn, token, story, "world", piece.id, 200)
+      assert body["piece_type"] == "world"
+      assert body["content"] == "World bible."
+    end
+
+    test "throughline", %{conn: conn, story: story, raw_token: token, throughline_piece: piece} do
+      body = fetch(conn, token, story, "throughline", piece.id, 200)
+      assert body["piece_type"] == "throughline"
+      assert body["content"] == "The controlling idea."
+    end
+  end
+
+  describe "per-version addressing" do
+    test "a non-latest version is still fetchable by its id", %{
+      conn: conn,
+      story: story,
+      raw_token: token,
+      synopsis_v1: v1
+    } do
+      body = fetch(conn, token, story, "synopsis", v1.id, 200)
+      assert body["version_number"] == 1
+      assert body["content"] == "Synopsis v1."
+    end
+  end
+
+  describe "ownership boundary" do
+    test "404 when the piece belongs to a different story", %{
+      conn: conn,
+      story: story,
+      raw_token: token,
+      other_synopsis: other
+    } do
+      body = fetch(conn, token, story, "synopsis", other.id, 404)
+      assert body["error"] == "not found"
+    end
+
+    test "404 for a parent-chain piece (script) owned by another story", %{
+      conn: conn,
+      story: story,
+      other_story: other_story,
+      raw_token: token
+    } do
+      {:ok, other_scene} =
+        Storybox.Stories.Scene
+        |> Ash.Changeset.for_create(:create, %{slug: "x", story_id: other_story.id})
+        |> Ash.create(authorize?: false)
+
+      {:ok, other_script} =
+        Storybox.Stories.ScriptPiece
+        |> Ash.ActionInput.for_action(:create_version, %{
+          scene_id: other_scene.id,
+          content: "Other script."
+        })
+        |> Ash.run_action(authorize?: false)
+
+      body = fetch(conn, token, story, "script", other_script.id, 404)
+      assert body["error"] == "not found"
+    end
+  end
+
+  describe "error handling" do
+    test "400 for an unknown piece_type", %{conn: conn, story: story, raw_token: token} do
+      body =
+        fetch(conn, token, story, "bogus", "00000000-0000-0000-0000-000000000000", 400)
+
+      assert body["error"] == "unknown piece_type"
+    end
+
+    test "404 for a valid-but-absent piece_id", %{conn: conn, story: story, raw_token: token} do
+      body =
+        fetch(conn, token, story, "synopsis", "00000000-0000-0000-0000-000000000000", 404)
+
+      assert body["error"] == "not found"
+    end
+
+    test "503 when stored content is unavailable", %{
+      conn: conn,
+      story: story,
+      raw_token: token,
+      synopsis_v1: existing
+    } do
+      # A piece row whose content_uri was never written to storage.
+      {:ok, orphan} =
+        Storybox.Stories.SynopsisPiece
+        |> Ash.Changeset.for_create(:create, %{
+          story_id: story.id,
+          sequence_id: existing.sequence_id,
+          content_uri: "storybox://stories/#{story.id}/synopsis/orphan/v999",
+          version_number: 999
+        })
+        |> Ash.create(authorize?: false)
+
+      body = fetch(conn, token, story, "synopsis", orphan.id, 503)
+      assert body["error"] == "content unavailable"
+    end
+
+    test "401 without a token", %{conn: conn, story: story, synopsis_v1: piece} do
+      conn = get(conn, "/api/stories/#{story.id}/pieces/synopsis/#{piece.id}")
+      assert json_response(conn, 401)
+    end
+
+    test "403 when the token story does not match the path story_id", %{
+      conn: conn,
+      story: story,
+      raw_token_other: token_other,
+      synopsis_v1: piece
+    } do
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{token_other}")
+        |> get("/api/stories/#{story.id}/pieces/synopsis/#{piece.id}")
+
+      assert json_response(conn, 403)
+    end
+  end
+
+  defp fetch(conn, token, story, type, id, status) do
+    conn
+    |> put_req_header("authorization", "Bearer #{token}")
+    |> get("/api/stories/#{story.id}/pieces/#{type}/#{id}")
+    |> json_response(status)
+  end
+end


### PR DESCRIPTION
## What

Adds `GET /api/stories/:story_id/pieces/:piece_type/:piece_id`, returning a specific PieceVersion's raw content so a client can diff a working draft against committed state before writing.

Response (200): `{piece_id, piece_type, version_number, content}`.

## Why

Per the issue, only the *latest* content was reachable through the view reads; there was no per-version addressing. Each PieceVersion is its own row, so this endpoint makes **any** version fetchable by id — meeting the issue's Failure guard ("only latest fetchable / no per-version addressing").

## How

- **Router** — one `get` route in the authenticated `/api` scope.
- **`ApiController.piece_version/2`** — parses the type, loads the piece with a cross-story ownership check, fetches content.
- **`parse_piece_type/1`** — maps the six allowed type strings to atoms; anything else → 400.
- **`load_piece_for_story/3`** — per-type ownership:
  - direct `story_id` (`synopsis`, `sequence`, `throughline`) — single filtered read;
  - parent-chain (`script`→Scene, `character`→Character, `world`→World) — verify the parent belongs to the story, reusing existing helpers.

Status codes: **400** unknown type, **404** not-found / wrong-story, **503** storage-unavailable. Read-only; no schema change.

## Tests

New `piece_content_fetch_test.exs`: 200 for all six types, a non-latest version still fetchable by id, cross-story 404 (direct + parent-chain), 400 unknown type, 404 absent id, 503 storage-unavailable, plus 401/403 auth. Full `mix precommit` green (475 tests, 0 failures).

Closes #192