### PR TITLE
Add SynopsisPiece create endpoint (#193)

### DIFF
--- a/lib/storybox_web/controllers/api_controller.ex
+++ b/lib/storybox_web/controllers/api_controller.ex
@@ -1047,6 +1047,49 @@ defmodule StoryboxWeb.ApiController do
     end
   end
 
+  # Writes a synopsis-prose SynopsisPiece version, the top of the rough-to-fine
+  # chain. Addressed by slug like create_sequence_piece: a not-yet-existing
+  # target sequence is lazily materialized (Sequence + spine entry) via
+  # find_or_create_sequence/3. The response is inlined with the three fields the
+  # resource carries — SynopsisPiece has no `weights`, so format_version/1 would
+  # raise. `name` defaults to the slug.
+  def create_synopsis_piece(conn, %{"seq_slug" => seq_slug} = params) do
+    story = conn.assigns.current_story
+    content = params["content"]
+
+    if is_nil(content) or content == "" do
+      conn |> put_status(400) |> json(%{error: "content is required"})
+    else
+      name = Map.get(params, "name", seq_slug)
+
+      case find_or_create_sequence(story.id, seq_slug, name) do
+        {:error, _} ->
+          conn |> put_status(500) |> json(%{error: "internal error"})
+
+        {:ok, sequence} ->
+          case Storybox.Stories.SynopsisPiece
+               |> Ash.ActionInput.for_action(:create_version, %{
+                 story_id: story.id,
+                 sequence_id: sequence.id,
+                 content: content
+               })
+               |> Ash.run_action(authorize?: false) do
+            {:ok, piece} ->
+              conn
+              |> put_status(201)
+              |> json(%{
+                id: piece.id,
+                version_number: piece.version_number,
+                inserted_at: piece.inserted_at
+              })
+
+            {:error, _} ->
+              conn |> put_status(503) |> json(%{error: "storage error"})
+          end
+      end
+    end
+  end
+
   def list_tasks(conn, params) do
     story = conn.assigns.current_story
     status_str = Map.get(params, "status", "pending")

--- a/lib/storybox_web/router.ex
+++ b/lib/storybox_web/router.ex
@@ -69,6 +69,10 @@ defmodule StoryboxWeb.Router do
          ApiController,
          :create_sequence_piece
 
+    post "/stories/:story_id/sequences/:seq_slug/synopsis/pieces",
+         ApiController,
+         :create_synopsis_piece
+
     post "/stories/:story_id/scenes/:scene_id/weights", ApiController, :set_script_piece_weights
 
     get "/stories/:story_id/characters", ApiController, :list_characters

--- a/test/storybox_web/controllers/synopsis_piece_test.exs
+++ b/test/storybox_web/controllers/synopsis_piece_test.exs
@@ -1,0 +1,163 @@
+defmodule StoryboxWeb.SynopsisPieceTest do
+  use StoryboxWeb.ConnCase
+
+  require Ash.Query
+
+  alias Storybox.Accounts.ApiToken
+
+  # Shared setup creates:
+  #
+  #   user ──── story ──── existing_seq (slug "act-1", with synopsis_v1)
+  #
+  # raw_token is scoped to story.
+
+  setup do
+    {:ok, user} =
+      Storybox.Accounts.User
+      |> Ash.Changeset.for_create(:register_with_password, %{
+        email: "synopsis_piece_test@example.com",
+        password: "password123!",
+        password_confirmation: "password123!"
+      })
+      |> Ash.create()
+
+    {:ok, story} =
+      Storybox.Stories.Story
+      |> Ash.Changeset.for_create(:create, %{title: "Synopsis Piece Story", user_id: user.id})
+      |> Ash.create()
+
+    {:ok, raw_token, _} = ApiToken.generate(%{story_id: story.id, user_id: user.id})
+
+    {:ok, existing_seq} =
+      Storybox.Stories.Sequence
+      |> Ash.Changeset.for_create(:create, %{
+        story_id: story.id,
+        name: "Act One",
+        slug: "act-1"
+      })
+      |> Ash.create(authorize?: false)
+
+    {:ok, _synopsis_v1} =
+      Storybox.Stories.SynopsisPiece
+      |> Ash.ActionInput.for_action(:create_version, %{
+        story_id: story.id,
+        sequence_id: existing_seq.id,
+        content: "Opening synopsis prose."
+      })
+      |> Ash.run_action(authorize?: false)
+
+    %{story: story, existing_seq: existing_seq, raw_token: raw_token}
+  end
+
+  describe "POST /api/stories/:story_id/sequences/:seq_slug/synopsis/pieces" do
+    test "creates a new version on an existing sequence and returns 201", %{
+      conn: conn,
+      story: story,
+      raw_token: raw_token
+    } do
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{raw_token}")
+        |> post("/api/stories/#{story.id}/sequences/act-1/synopsis/pieces", %{
+          "content" => "Revised synopsis prose."
+        })
+
+      body = json_response(conn, 201)
+      assert body["version_number"] == 2
+      assert body["id"]
+      assert body["inserted_at"]
+      refute Map.has_key?(body, "weights")
+      refute Map.has_key?(body, "sequence_id")
+    end
+
+    test "lazily materializes the sequence and spine entry for an unknown slug", %{
+      conn: conn,
+      story: story,
+      raw_token: raw_token
+    } do
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{raw_token}")
+        |> post("/api/stories/#{story.id}/sequences/act-2/synopsis/pieces", %{
+          "content" => "Brand new sequence synopsis."
+        })
+
+      body = json_response(conn, 201)
+      assert body["version_number"] == 1
+      assert body["id"]
+
+      sequence =
+        Storybox.Stories.Sequence
+        |> Ash.Query.filter(story_id == ^story.id and slug == "act-2")
+        |> Ash.read_one!(authorize?: false)
+
+      assert sequence
+      assert sequence.name == "act-2"
+
+      spine =
+        Storybox.Stories.StorySpine
+        |> Ash.Query.filter(story_id == ^story.id)
+        |> Ash.read_one!(authorize?: false)
+
+      assert spine
+
+      entry =
+        Storybox.Stories.StorySpineEntry
+        |> Ash.Query.filter(story_spine_id == ^spine.id and sequence_id == ^sequence.id)
+        |> Ash.read_one!(authorize?: false)
+
+      assert entry
+    end
+
+    test "uses an explicit name when supplied for a lazily-created sequence", %{
+      conn: conn,
+      story: story,
+      raw_token: raw_token
+    } do
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{raw_token}")
+        |> post("/api/stories/#{story.id}/sequences/act-3/synopsis/pieces", %{
+          "content" => "Named sequence synopsis.",
+          "name" => "Act Three"
+        })
+
+      assert json_response(conn, 201)
+
+      sequence =
+        Storybox.Stories.Sequence
+        |> Ash.Query.filter(story_id == ^story.id and slug == "act-3")
+        |> Ash.read_one!(authorize?: false)
+
+      assert sequence.name == "Act Three"
+    end
+
+    test "returns 400 when content is missing", %{
+      conn: conn,
+      story: story,
+      raw_token: raw_token
+    } do
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{raw_token}")
+        |> post("/api/stories/#{story.id}/sequences/act-1/synopsis/pieces", %{})
+
+      assert json_response(conn, 400)["error"] == "content is required"
+    end
+
+    test "returns 400 when content is empty", %{
+      conn: conn,
+      story: story,
+      raw_token: raw_token
+    } do
+      conn =
+        conn
+        |> put_req_header("authorization", "Bearer #{raw_token}")
+        |> post("/api/stories/#{story.id}/sequences/act-1/synopsis/pieces", %{
+          "content" => ""
+        })
+
+      assert json_response(conn, 400)["error"] == "content is required"
+    end
+  end
+end


### PR DESCRIPTION
## What

Adds `POST /stories/:story_id/sequences/:seq_slug/synopsis/pieces` — the writable top of the rough-to-fine chain — mirroring `create_sequence_piece`.

- The target sequence is addressed by slug. When it does not yet exist, it is **lazily materialized** (Sequence + spine entry) via the existing `find_or_create_sequence/3` helper, then `SynopsisPiece.:create_version` writes the versioned piece.
- `201` on success; `400` on empty/missing content; `503` on storage error; `500` on sequence-materialization failure.
- The response is inlined as `{id, version_number, inserted_at}` rather than `format_version/1`, because `SynopsisPiece` has no `weights` attribute (which `format_version/1` reads).

No schema changes, no new modules.

## Changes

- `lib/storybox_web/router.ex` — new route beside `create_sequence_piece`.
- `lib/storybox_web/controllers/api_controller.ex` — `create_synopsis_piece/2`.
- `test/storybox_web/controllers/synopsis_piece_test.exs` — mirrors the sequence-piece test suite (existing-seq version increment, lazy materialization of Sequence + spine entry, explicit name, 400 on missing/empty content).

## Verification

`mix precommit` green (480 tests, 0 failures), run via `podman compose run --rm -e MIX_ENV=test app mix precommit`.

Closes #193